### PR TITLE
Add design: column-level lineage

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ Working design notes for the layers above the current static analyzer. These des
 - [**design/contract-directed-generation.md**](design/contract-directed-generation.md): the generator architecture: intent catalog, multi-table coordinated generation, shrinking.
 - [**design/flags_and_configs_as_types.md**](design/flags_and_configs_as_types.md): how dbt vars and env_vars become typed configuration, the `SemanticFlag` shape, world enumeration, PR-time flag-flip analysis.
 - [**design/var-inference-spec.md**](design/var-inference-spec.md): implementation spec for the var-discovery and inference pass that populates `SemanticFlag` scaffolding.
+- [**design/column-level-lineage.md**](design/column-level-lineage.md): per-column lineage substrate built on `sqlglot.lineage`. Closes the multi-source uniqueness gap, enables a handful of cross-model detectors, and prefigures tag tracking for the semantic-types layer.
 - [**design/demo_walkthrough.md**](design/demo_walkthrough.md): the canonical end-to-end demo against `jaffle_shop_duckdb`. Output and commands are illustrative; the demo presupposes the typed-contract layer.
 
 ## Other docs at the repo root

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ Working design notes for the layers above the current static analyzer. These des
 - [**design/contract-directed-generation.md**](design/contract-directed-generation.md): the generator architecture: intent catalog, multi-table coordinated generation, shrinking.
 - [**design/flags_and_configs_as_types.md**](design/flags_and_configs_as_types.md): how dbt vars and env_vars become typed configuration, the `SemanticFlag` shape, world enumeration, PR-time flag-flip analysis.
 - [**design/var-inference-spec.md**](design/var-inference-spec.md): implementation spec for the var-discovery and inference pass that populates `SemanticFlag` scaffolding.
-- [**design/column-level-lineage.md**](design/column-level-lineage.md): per-column lineage substrate built on `sqlglot.lineage`. Closes the multi-source uniqueness gap, enables a handful of cross-model detectors, and prefigures tag tracking for the semantic-types layer.
+- [**design/column-level-lineage.md**](design/column-level-lineage.md): column-level lineage and property propagation built on K-relations (Green-Karvounarakis-Tannen 2007) marrying with `sqlglot.lineage`. One propagation engine; properties (uniqueness, fanout, nullability, semantic tags) instantiate it by choosing a semiring and per-operator transfer functions. Closes the multi-source uniqueness gap and is the substrate the semantic-types layer will tag-propagate over.
 - [**design/demo_walkthrough.md**](design/demo_walkthrough.md): the canonical end-to-end demo against `jaffle_shop_duckdb`. Output and commands are illustrative; the demo presupposes the typed-contract layer.
 
 ## Other docs at the repo root

--- a/docs/design/column-level-lineage.md
+++ b/docs/design/column-level-lineage.md
@@ -1,146 +1,171 @@
-# Column-level lineage
+# Column-level lineage and property propagation
 
 ## Motivation
 
-Three downstream needs converge on a single missing substrate.
+Three downstream needs converge on a single substrate.
 
-1. **Multi-source uniqueness propagation.** The current uniqueness layer bails on join scopes (see `src/dblect/uniqueness/detector.py:51`). With per-column lineage we can attribute each output column to its source columns and propagate uniqueness through projections that preserve key-tuple structure.
-2. **Cross-model fanout impact.** Detecting fanout at the join site is already done. Tracing which downstream columns carry the multiplied counts forward, and which aggregates become contaminated by them, is the next layer.
-3. **Substrate for semantic types.** When the semantic-types layer ships, tag tracking ("this column is `RevenuePreTax`") follows the same lineage edges. Building the substrate now means tag tracking layers on cleanly rather than requiring a parallel walk.
+1. **Multi-source uniqueness propagation.** The current uniqueness layer bails on join scopes (`src/dblect/uniqueness/detector.py:51`). Per-column lineage closes the gap.
+2. **Cross-model fanout impact.** A `join_fanout` finding on model M needs to project forward to any downstream column whose values flowed through M's fan-out side.
+3. **Semantic-types tag propagation.** When the semantic-types layer lands, each declared type binds to `(model_uid, column)` and propagates forward through the same lineage edges.
 
-Building lineage as its own primitive, rather than re-deriving it inside each detector, also keeps the existing detector surface stable: detectors consume lineage facts the same way they consume uniqueness facts today.
+Each of these is a *property* we want to track on columns and propagate through SQL operators. The honest substrate is one that handles all of them under the same algebra, rather than three parallel passes with three ad-hoc rule tables.
 
-## What sqlglot gives us
+## Framework: K-relations at the column level
 
-`sqlglot.lineage.lineage(column, sql, schema, sources, dialect, on_node)` is the primitive:
+We build on the provenance-semiring framework (Green, Karvounarakis, Tannen 2007). A property is a commutative semiring `(K, +, ×, 0, 1)` together with operator-specific transfer functions that interpret SQL operators as semiring operations:
 
-- With `column=None` it returns a `dict[str, Node]` mapping every top-level output column to its lineage root, with a shared cache across columns.
-- Each `Node` carries the originating `sqlglot.expressions.Expression`, the source the column draws from, and pointers to downstream input nodes.
-- The `on_node` callback fires for every node as the walk populates its downstream; we can attach our own payload there.
-- `sources` lets us pass in other models' SQL strings, so cross-model lineage composes by threading dependencies through this argument.
-- `dialect` is propagated to the parse/qualify pass, so dialect-specific column resolution works the same way the rest of the analyser does.
+- `+` reconciles values at *confluence* points (`UNION ALL`, multiple branches feeding the same downstream column)
+- `×` combines values at *cross* points (the implicit cross product underlying every `JOIN`)
+- `0` is the absorbing element for `×` (annotation for "absent" or "bottom")
+- `1` is the identity for `×` (annotation for "neutral" or "fully present")
 
-What it does not give us:
+Choosing different K's encodes different properties under the same algorithm.
 
-- A first-class cross-model lineage object. The DAG walk is ours.
-- Operator classification (pass-through / transformed / aggregated / synthesized). We compute that from the lineage `Node`'s expression.
-- Stable identity for the lineage graph. We key on `(model_uid, column_name)`.
-- Robustness when sqlglot cannot fully resolve a column (dynamic SQL, dialect constructs sqlglot misparses, leftover Jinja that escaped dbt rendering). The lineage `Node` for those cases is shallow or absent.
+- **Bag cardinality (fanout).** `K = N` with arithmetic `+` and `×`. `JOIN` multiplies tuple multiplicity, `UNION ALL` adds. This is exactly the bag semantics that captures `join_fanout`'s downstream propagation.
+- **Where-provenance.** `K = P(ColumnRef)`, set union for both `+` and `×`. Records which source columns ultimately fed each output column.
+- **Uniqueness as candidate keys.** `K = P(P(ColumnRef))` (sets of candidate key sets). Sketch: `+` intersects branch key sets (`UNION ALL` retains a key only if both branches carry it), `×` concatenates keys across sides (`JOIN` combines keys subject to join-condition coverage). The detailed rules live in the `Property[K]` definition; this encoding is what lets the multi-source bail go away.
+- **Nullability.** `K = {non-null, nullable, unknown}`, a 3-element lattice (an idempotent semiring with lattice join as `+` and lattice meet as `×`). Sources seed from declared `not_null` tests.
+- **Semantic types (future).** `K` is the user-domain lattice from the types layer. Per-operator and per-aggregate transfers come from the type's declared transfer rules.
 
-## What we layer on top
+Aggregates need the semimodule extension (Amsterdamer, Deutch, Tannen 2011). Each aggregate function (`SUM`, `MIN`, `MAX`, `COUNT`, `ARRAY_AGG`, ...) is a `K → K` transfer that depends on the aggregate's algebra over `K`. We declare these per-property, keyed on the sqlglot aggregate expression subclass.
 
-### Per-model lineage
+The result: one propagation engine, one walk over the lineage graph. Adding a new property is adding a `Property[K]`, not a new pass.
 
-For each model we build a `ColumnLineage` from a single `sqlglot.lineage(None, compiled_sql, schema, sources, dialect)` call (one call per model, not per column, so the shared cache pays off). The result is stashed in the audit context keyed by `model_uid`.
+## Marrying with sqlglot
+
+sqlglot's parse tree gives us the relational-algebra structure; its `lineage` module gives us where-provenance per output column (which source columns and through which SQL expression each output column was built). We layer on:
+
+1. A `Semiring[K]` protocol that any property's K implements.
+2. A `Property[K]` bundle: name, semiring, per-operator transfer functions keyed on `exp.Expression` subclass, per-aggregate semimodule transfers keyed on `exp.AggFunc` subclass, and a source rule (how the property gets its initial value from dbt declarations or source-schema facts).
+3. A `Propagator` that consumes a `Property[K]` and a `ColumnLineageGraph`, walks the graph in topological DAG order, and produces a `Mapping[ColumnRef, K]`.
+
+Operator dispatch is on sqlglot's `Expression` subclass directly. The sqlglot type hierarchy already enumerates the operators we need, so there is no parallel enum to keep in sync; unrecognised subclasses fall through to a property-defined default (typically lattice top or semiring `0` per property's semantics).
+
+## Data model
 
 ```python
-@dataclass(frozen=True, slots=True)
-class ColumnLineage:
-    model_uid: str
-    columns: Mapping[str, ColumnOrigin]
+from typing import Protocol, runtime_checkable, TypeVar, Generic, Callable, Mapping
+from dataclasses import dataclass
+from sqlglot import expressions as exp
+
+K = TypeVar("K")
 
 
-@dataclass(frozen=True, slots=True)
-class ColumnOrigin:
-    output: str                          # column name on this model's output
-    op: ColumnOp                         # how the value was produced
-    inputs: tuple[ColumnRef, ...]        # source columns this output draws from
-    expression_sql: str                  # the SQL expression that produced this column
-    line_span: tuple[int, int] | None    # location in compiled SQL
+@runtime_checkable
+class Semiring(Protocol[K]):
+    zero: K
+    one:  K
+    def plus(self,  a: K, b: K) -> K: ...
+    def times(self, a: K, b: K) -> K: ...
 
 
 @dataclass(frozen=True, slots=True)
 class ColumnRef:
-    source: SourceRef                    # model_uid, source_uid, or CTE name in scope
+    source: SourceRef                  # model_uid, source_uid, seed_uid, or in-scope CTE name
     column: str
 
 
-class ColumnOp(StrEnum):
-    PASS_THROUGH = "pass_through"        # bare Column reference, no wrapping expression
-    TRANSFORMED  = "transformed"         # arithmetic, CASE, scalar function, cast
-    AGGREGATED   = "aggregated"          # SUM/COUNT/MIN/MAX/AVG/ARRAY_AGG/...
-    SYNTHESIZED  = "synthesized"         # literals, current_timestamp(), now(), random()
-    UNKNOWN      = "unknown"             # sqlglot resolved partially; lineage is incomplete
-```
-
-`ColumnOp` is derived by inspecting the lineage `Node`'s expression:
-
-- `PASS_THROUGH`: the projection is a bare `exp.Column` (optionally aliased).
-- `AGGREGATED`: the projection is wrapped in an `exp.AggFunc` subclass.
-- `SYNTHESIZED`: the projection has no `exp.Column` descendants.
-- `TRANSFORMED`: anything else with at least one `exp.Column` descendant.
-- `UNKNOWN`: sqlglot returned no usable `Node` for this output, or returned one whose source attribution we cannot resolve.
-
-### Cross-model lineage graph
-
-Across the DAG, lineage is a graph keyed by `ColumnRef`.
-
-```python
 @dataclass(frozen=True, slots=True)
-class LineageGraph:
-    edges: Mapping[ColumnRef, tuple[ColumnRef, ...]]   # downstream column -> upstream columns
-    origins: Mapping[ColumnRef, ColumnOrigin]
+class ColumnLineageGraph:
+    """Where-provenance and how-provenance, derived from sqlglot.lineage.
+
+    `edges` maps each output ColumnRef to its upstream ColumnRefs (where-provenance).
+    `expressions` maps each output ColumnRef to the sqlglot Expression that
+    produced it (how-provenance), letting per-property transfer functions
+    dispatch on operator type.
+    """
+    edges:       Mapping[ColumnRef, tuple[ColumnRef, ...]]
+    expressions: Mapping[ColumnRef, exp.Expression]
+
+
+@dataclass(frozen=True, slots=True)
+class Property(Generic[K]):
+    name:     str
+    semiring: Semiring[K]
+    # Per-operator transfer: how a sqlglot Expression combines its input
+    # column annotations into its output annotation.
+    operators:  Mapping[type[exp.Expression], Callable[[exp.Expression, tuple[K, ...]], K]]
+    # Per-aggregate transfer (the Amsterdamer-Deutch-Tannen semimodule extension).
+    aggregates: Mapping[type[exp.AggFunc], Callable[[exp.AggFunc, K], K]]
+    # Initial K from source-level facts (dbt tests, manifest schema).
+    source: Callable[[ColumnRef], K]
+
+
+def propagate(
+    graph: ColumnLineageGraph,
+    prop:  Property[K],
+) -> Mapping[ColumnRef, K]:
+    """Topologically propagate prop's K-annotation through graph."""
+    ...
 ```
 
-Construction is topological:
+## Operator-to-semiring mapping
 
-1. Walk the DAG in dependency order.
-2. For each model, populate `sources` with the SQL of every model it depends on (cached, not re-rendered each time).
-3. Call `sqlglot.lineage(None, ...)` once.
-4. Translate each output `Node` into a `ColumnOrigin`; emit edges per `inputs` entry. When an input refers to a source or seed, the edge terminates there (sources do not have outgoing lineage).
-5. Merge into the audit-wide `LineageGraph`.
+The propagator dispatches on the sqlglot expression type and consults `Property.operators` (or `Property.aggregates` for aggregates). The intended action per operator:
 
-The cache is per-audit: `LineageGraph` is rebuilt from scratch on each `dblect audit` run, same as the manifest is reparsed.
+| sqlglot operator              | Action on column annotations                                                 |
+|-------------------------------|------------------------------------------------------------------------------|
+| `exp.Column` (bare ref)       | Identity: output = input annotation                                          |
+| `exp.Alias` (no-op wrapper)   | Identity                                                                     |
+| Scalar function / cast        | Per-function rule; default folds inputs via the property's `×`               |
+| `exp.AggFunc` subclass        | `prop.aggregates[type]` applied to the partition's input annotation          |
+| `exp.Window`                  | Per-property; default is the aggregate transfer applied per-partition        |
+| `exp.Join`                    | `×` at the tuple level; column annotations pass through per side             |
+| `exp.Union` (UNION ALL)       | `+` of branch annotations                                                    |
+| `exp.Union` (set-semantics)   | `+` followed by property-specific dedup handling                             |
+| `exp.Where`                   | No-op on column annotations (filters tuples, leaves column-level facts)      |
+| `exp.Limit`                   | No-op on column annotations                                                  |
+| `exp.Subquery`                | Recursive `propagate` on the subquery; the result is treated as a source     |
 
-## Use sites
+The table is the shape of dispatch. Each `Property[K]` fills in the specific behaviour for the cases it cares about; missing entries fall through to the property-defined default.
 
-### Uniqueness propagation upgrade
+## Cross-model composition
 
-The multi-source bail in the current uniqueness propagation (`src/dblect/uniqueness/detector.py:51`) goes away. For a join with sources A and B, the output's uniqueness facts derive from per-column lineage tagged with the join condition. A key over `(a_id, b_id)` is unique iff each component traces back to a unique key on its respective source. The propagation pass consumes lineage the same way it consumes uniqueness facts today.
+The audit builds a single `ColumnLineageGraph` per run by walking the manifest DAG in topological order. For each model:
 
-### New detectors that need lineage
+1. Call `sqlglot.lineage(None, compiled_sql, schema, sources, dialect)` with `sources` populated from already-built upstream models. (sqlglot accepts SQL strings here; we cache per-model SQL once and reuse the string.)
+2. Translate the returned `Node` trees into `ColumnLineageGraph` entries: one edge per upstream column reference, with the sqlglot `Expression` recorded alongside.
+3. Merge into the audit-wide graph.
 
-- **Cross-model NOT IN with nullable upstream.** The NOT-IN-nullable-subquery detector (filed as its own issue) asks lineage whether the projected column came from an upstream that has a `not_null` fact.
-- **Aggregate over already-aggregated column.** A `SUM(x)` where `x` came from a `SUM(...)` upstream usually double-counts. Lineage answers the "did this column come from an aggregate" question cleanly.
-- **Cross-model fanout propagation.** A `join_fanout` finding on model M projects forward: any downstream column whose lineage flows through M's joined-in side inherits the fanout. The finding surfaces at the consumer, not just at M.
-
-### Semantic types
-
-When the semantic-types layer arrives, each declared type binds to `(model_uid, column)`. Tag propagation walks `LineageGraph.edges` forward: a type on an input column flows to its output under the same `op` classification. Pass-through preserves the type; aggregate transforms it via the aggregate's transfer rule (declared on the type); transformed needs either a per-operator rule or an explicit annotation; synthesized starts fresh.
+Property propagation is then a separate pass per property: `propagate(graph, prop)` returns a `Mapping[ColumnRef, K]`. Properties are independent. Running uniqueness propagation does not depend on running fanout propagation; they share the graph, never the annotations.
 
 ## Failure modes
 
-We will hit cases where lineage is incomplete. The contract is that detectors consume lineage as a partial map: where a column's origin is `UNKNOWN`, the lineage-dependent detector silently skips that column rather than producing a wrong answer.
+The contract is that annotations degrade gracefully when sqlglot cannot fully resolve a column.
 
-- **Macros sqlglot cannot render.** dbt expands macros before we see the SQL, but custom Jinja that emits non-standard SQL (runtime-resolved table names, dynamic column lists) may leave artefacts sqlglot does not fully resolve. Lineage for affected columns is `UNKNOWN`; we surface a per-model "lineage incomplete" note in the audit report so users know which findings might be silenced.
-- **Dialect-specific constructs.** Some dialects' lateral joins, `PIVOT`, `QUALIFY`, struct field access produce node trees with unclear source attribution. Same fallback: mark as `UNKNOWN`.
-- **Identical column names from joined sources.** sqlglot's `Scope` qualification disambiguates these. Where qualification fails, the column gets `UNKNOWN`. (sqlglot's `qualify` is fairly robust; this is a rare path.)
-- **Recursive CTEs and window functions referenced outside the projection.** Each gets a per-case decision: model conservatively (mark as `TRANSFORMED` with the full input set), or carve out and skip. We start conservative and tighten as concrete cases land.
+- **sqlglot resolution gap.** When sqlglot returns no usable `Node` for an output column, the column's entry in `expressions` is absent. The propagator emits the property's "unknown" value (typically lattice top for lattices, semiring `0` for cardinality). Detectors consuming the annotation interpret an unknown value as "we don't know" and skip the column. The audit reports a per-model "lineage incomplete" note so reviewers see what was silenced.
+- **Macros that escape dbt rendering.** Same handling: affected columns get the unknown annotation; we surface the gap rather than guess.
+- **Dialect-specific constructs sqlglot misparses.** Same handling.
+- **Column-name collisions across set-op branches.** sqlglot's qualification disambiguates these. Where qualification fails, the column gets the unknown annotation.
 
-The "incomplete" model means lineage is never load-bearing for correctness: detectors that need lineage and do not have it stay quiet rather than guess. False negatives are acceptable here; false positives from inferred-but-wrong lineage are not.
+Annotations are never load-bearing for correctness: false negatives on lineage-dependent detectors are acceptable; wrong annotations are not. This is the same contract the uniqueness layer holds today.
 
-## Testing strategy
+## Testing
 
-- **PBT on lineage invariants.** For any sqlglot-parseable generated SQL: every output column's lineage either traces to at least one input column or is `SYNTHESIZED`. No output ever has zero edges and a non-literal expression.
-- **Golden tests on jaffle.** Fixed lineage assertions on each jaffle model so refactors of the builder do not silently change shape. Snapshot-style tests, easy to read, fail loudly on real regressions.
-- **Differential check against dbt's column-level lineage.** Newer dbt versions ship column-level lineage; on fixtures where dbt's lineage is available we cross-check on a subset of models. Best-effort, not a contract.
+- **Semiring laws.** PBT on every `Semiring` instance for associativity, commutativity, identities, distributivity, and absorption. Catches structural bugs in property definitions immediately.
+- **Per-operator transfer rules.** PBT on each `Property.operators` entry: for any combination of input K-values, the output K-value satisfies the property's intended semantics (e.g., uniqueness propagation through `INNER JOIN` produces a key iff both sides contribute keys covering the join condition).
+- **Per-aggregate transfer rules.** PBT on `Property.aggregates`: for representative input shapes, the output annotation matches the aggregate's known behaviour over `K`.
+- **Jaffle goldens.** Per-column annotation snapshots on the jaffle fixture for each property, so refactors of the propagator do not silently change shape.
+- **dbt cross-check.** Newer dbt versions ship column-level lineage; where available, we cross-check our `ColumnLineageGraph` against dbt's on a subset of models. Best-effort, not a contract.
 
 ## What this design does not cover
 
-- Type inference (column SQL types from operations). The existing audit operates on a type-light AST and that is fine for the lineage substrate.
-- Tag-propagation transfer rules for transformed ops. Those belong to the semantic-types layer.
-- A lineage UI or export format. A separate ticket if and when it is needed.
+- Type inference of column SQL types from operations. The audit operates on type-light AST and that suffices for this substrate.
+- User-domain transfer-rule authoring for the semantic-types property. Belongs to the types layer that consumes this substrate.
+- A lineage UI or export format. Separate work if and when it is asked for.
 
 ## Sequencing
 
-1. `ColumnLineage` data model and per-model builder using `sqlglot.lineage()`.
-2. `LineageGraph` cross-model builder.
-3. Plumb into the uniqueness propagation pass to close the multi-source gap.
-4. Land the lineage-dependent detectors (NOT-IN-nullable-upstream, aggregate-over-aggregated, cross-model fanout propagation) as they unlock.
-5. Document the public lineage API in `docs/current_state/` once the surface settles.
+1. `Semiring[K]` and `Property[K]` API, plus the `Propagator`. No properties wired yet; only laws-testable scaffolding.
+2. Per-model `ColumnLineageGraph` builder on `sqlglot.lineage`. Cache and reuse per-model SQL.
+3. Cross-model composition across the manifest DAG.
+4. First instantiated property: bag cardinality (`N` semiring). Wires the cross-model fanout propagation detector.
+5. Uniqueness as candidate keys. Replaces the multi-source bail in the existing uniqueness layer.
+6. Where-provenance and nullability, together with the `NOT IN`-nullable-upstream detector.
+7. Publish the public API in `docs/current_state/` once the surface settles. Semantic tags land in this slot when the types layer arrives.
 
-## Prior art and influences
+## References
 
-- sqlglot's `lineage` module does the parse/qualify/walk heavy lifting; we are layering DAG composition and operator classification on top, not reinventing it.
-- dbt's own column-level lineage (newer versions) covers a similar surface; their work is an excellent reference and we cross-check against it where available.
-- Refinement-type and dependent-type literature on tag propagation through projection operators informs the eventual semantic-types layer that consumes this graph.
+- Green, T. J., Karvounarakis, G., Tannen, V. (2007). *Provenance Semirings*. PODS. The K-relations framework this design is built on.
+- Amsterdamer, Y., Deutch, D., Tannen, V. (2011). *Provenance for Aggregate Queries*. PODS. The semimodule extension used for aggregate transfer rules.
+- sqlglot's `lineage` module: the per-model where-provenance primitive we layer on.

--- a/docs/design/column-level-lineage.md
+++ b/docs/design/column-level-lineage.md
@@ -1,0 +1,146 @@
+# Column-level lineage
+
+## Motivation
+
+Three downstream needs converge on a single missing substrate.
+
+1. **Multi-source uniqueness propagation.** The current uniqueness layer bails on join scopes (see `src/dblect/uniqueness/detector.py:51`). With per-column lineage we can attribute each output column to its source columns and propagate uniqueness through projections that preserve key-tuple structure.
+2. **Cross-model fanout impact.** Detecting fanout at the join site is already done. Tracing which downstream columns carry the multiplied counts forward, and which aggregates become contaminated by them, is the next layer.
+3. **Substrate for semantic types.** When the semantic-types layer ships, tag tracking ("this column is `RevenuePreTax`") follows the same lineage edges. Building the substrate now means tag tracking layers on cleanly rather than requiring a parallel walk.
+
+Building lineage as its own primitive, rather than re-deriving it inside each detector, also keeps the existing detector surface stable: detectors consume lineage facts the same way they consume uniqueness facts today.
+
+## What sqlglot gives us
+
+`sqlglot.lineage.lineage(column, sql, schema, sources, dialect, on_node)` is the primitive:
+
+- With `column=None` it returns a `dict[str, Node]` mapping every top-level output column to its lineage root, with a shared cache across columns.
+- Each `Node` carries the originating `sqlglot.expressions.Expression`, the source the column draws from, and pointers to downstream input nodes.
+- The `on_node` callback fires for every node as the walk populates its downstream; we can attach our own payload there.
+- `sources` lets us pass in other models' SQL strings, so cross-model lineage composes by threading dependencies through this argument.
+- `dialect` is propagated to the parse/qualify pass, so dialect-specific column resolution works the same way the rest of the analyser does.
+
+What it does not give us:
+
+- A first-class cross-model lineage object. The DAG walk is ours.
+- Operator classification (pass-through / transformed / aggregated / synthesized). We compute that from the lineage `Node`'s expression.
+- Stable identity for the lineage graph. We key on `(model_uid, column_name)`.
+- Robustness when sqlglot cannot fully resolve a column (dynamic SQL, dialect constructs sqlglot misparses, leftover Jinja that escaped dbt rendering). The lineage `Node` for those cases is shallow or absent.
+
+## What we layer on top
+
+### Per-model lineage
+
+For each model we build a `ColumnLineage` from a single `sqlglot.lineage(None, compiled_sql, schema, sources, dialect)` call (one call per model, not per column, so the shared cache pays off). The result is stashed in the audit context keyed by `model_uid`.
+
+```python
+@dataclass(frozen=True, slots=True)
+class ColumnLineage:
+    model_uid: str
+    columns: Mapping[str, ColumnOrigin]
+
+
+@dataclass(frozen=True, slots=True)
+class ColumnOrigin:
+    output: str                          # column name on this model's output
+    op: ColumnOp                         # how the value was produced
+    inputs: tuple[ColumnRef, ...]        # source columns this output draws from
+    expression_sql: str                  # the SQL expression that produced this column
+    line_span: tuple[int, int] | None    # location in compiled SQL
+
+
+@dataclass(frozen=True, slots=True)
+class ColumnRef:
+    source: SourceRef                    # model_uid, source_uid, or CTE name in scope
+    column: str
+
+
+class ColumnOp(StrEnum):
+    PASS_THROUGH = "pass_through"        # bare Column reference, no wrapping expression
+    TRANSFORMED  = "transformed"         # arithmetic, CASE, scalar function, cast
+    AGGREGATED   = "aggregated"          # SUM/COUNT/MIN/MAX/AVG/ARRAY_AGG/...
+    SYNTHESIZED  = "synthesized"         # literals, current_timestamp(), now(), random()
+    UNKNOWN      = "unknown"             # sqlglot resolved partially; lineage is incomplete
+```
+
+`ColumnOp` is derived by inspecting the lineage `Node`'s expression:
+
+- `PASS_THROUGH`: the projection is a bare `exp.Column` (optionally aliased).
+- `AGGREGATED`: the projection is wrapped in an `exp.AggFunc` subclass.
+- `SYNTHESIZED`: the projection has no `exp.Column` descendants.
+- `TRANSFORMED`: anything else with at least one `exp.Column` descendant.
+- `UNKNOWN`: sqlglot returned no usable `Node` for this output, or returned one whose source attribution we cannot resolve.
+
+### Cross-model lineage graph
+
+Across the DAG, lineage is a graph keyed by `ColumnRef`.
+
+```python
+@dataclass(frozen=True, slots=True)
+class LineageGraph:
+    edges: Mapping[ColumnRef, tuple[ColumnRef, ...]]   # downstream column -> upstream columns
+    origins: Mapping[ColumnRef, ColumnOrigin]
+```
+
+Construction is topological:
+
+1. Walk the DAG in dependency order.
+2. For each model, populate `sources` with the SQL of every model it depends on (cached, not re-rendered each time).
+3. Call `sqlglot.lineage(None, ...)` once.
+4. Translate each output `Node` into a `ColumnOrigin`; emit edges per `inputs` entry. When an input refers to a source or seed, the edge terminates there (sources do not have outgoing lineage).
+5. Merge into the audit-wide `LineageGraph`.
+
+The cache is per-audit: `LineageGraph` is rebuilt from scratch on each `dblect audit` run, same as the manifest is reparsed.
+
+## Use sites
+
+### Uniqueness propagation upgrade
+
+The multi-source bail in the current uniqueness propagation (`src/dblect/uniqueness/detector.py:51`) goes away. For a join with sources A and B, the output's uniqueness facts derive from per-column lineage tagged with the join condition. A key over `(a_id, b_id)` is unique iff each component traces back to a unique key on its respective source. The propagation pass consumes lineage the same way it consumes uniqueness facts today.
+
+### New detectors that need lineage
+
+- **Cross-model NOT IN with nullable upstream.** The NOT-IN-nullable-subquery detector (filed as its own issue) asks lineage whether the projected column came from an upstream that has a `not_null` fact.
+- **Aggregate over already-aggregated column.** A `SUM(x)` where `x` came from a `SUM(...)` upstream usually double-counts. Lineage answers the "did this column come from an aggregate" question cleanly.
+- **Cross-model fanout propagation.** A `join_fanout` finding on model M projects forward: any downstream column whose lineage flows through M's joined-in side inherits the fanout. The finding surfaces at the consumer, not just at M.
+
+### Semantic types
+
+When the semantic-types layer arrives, each declared type binds to `(model_uid, column)`. Tag propagation walks `LineageGraph.edges` forward: a type on an input column flows to its output under the same `op` classification. Pass-through preserves the type; aggregate transforms it via the aggregate's transfer rule (declared on the type); transformed needs either a per-operator rule or an explicit annotation; synthesized starts fresh.
+
+## Failure modes
+
+We will hit cases where lineage is incomplete. The contract is that detectors consume lineage as a partial map: where a column's origin is `UNKNOWN`, the lineage-dependent detector silently skips that column rather than producing a wrong answer.
+
+- **Macros sqlglot cannot render.** dbt expands macros before we see the SQL, but custom Jinja that emits non-standard SQL (runtime-resolved table names, dynamic column lists) may leave artefacts sqlglot does not fully resolve. Lineage for affected columns is `UNKNOWN`; we surface a per-model "lineage incomplete" note in the audit report so users know which findings might be silenced.
+- **Dialect-specific constructs.** Some dialects' lateral joins, `PIVOT`, `QUALIFY`, struct field access produce node trees with unclear source attribution. Same fallback: mark as `UNKNOWN`.
+- **Identical column names from joined sources.** sqlglot's `Scope` qualification disambiguates these. Where qualification fails, the column gets `UNKNOWN`. (sqlglot's `qualify` is fairly robust; this is a rare path.)
+- **Recursive CTEs and window functions referenced outside the projection.** Each gets a per-case decision: model conservatively (mark as `TRANSFORMED` with the full input set), or carve out and skip. We start conservative and tighten as concrete cases land.
+
+The "incomplete" model means lineage is never load-bearing for correctness: detectors that need lineage and do not have it stay quiet rather than guess. False negatives are acceptable here; false positives from inferred-but-wrong lineage are not.
+
+## Testing strategy
+
+- **PBT on lineage invariants.** For any sqlglot-parseable generated SQL: every output column's lineage either traces to at least one input column or is `SYNTHESIZED`. No output ever has zero edges and a non-literal expression.
+- **Golden tests on jaffle.** Fixed lineage assertions on each jaffle model so refactors of the builder do not silently change shape. Snapshot-style tests, easy to read, fail loudly on real regressions.
+- **Differential check against dbt's column-level lineage.** Newer dbt versions ship column-level lineage; on fixtures where dbt's lineage is available we cross-check on a subset of models. Best-effort, not a contract.
+
+## What this design does not cover
+
+- Type inference (column SQL types from operations). The existing audit operates on a type-light AST and that is fine for the lineage substrate.
+- Tag-propagation transfer rules for transformed ops. Those belong to the semantic-types layer.
+- A lineage UI or export format. A separate ticket if and when it is needed.
+
+## Sequencing
+
+1. `ColumnLineage` data model and per-model builder using `sqlglot.lineage()`.
+2. `LineageGraph` cross-model builder.
+3. Plumb into the uniqueness propagation pass to close the multi-source gap.
+4. Land the lineage-dependent detectors (NOT-IN-nullable-upstream, aggregate-over-aggregated, cross-model fanout propagation) as they unlock.
+5. Document the public lineage API in `docs/current_state/` once the surface settles.
+
+## Prior art and influences
+
+- sqlglot's `lineage` module does the parse/qualify/walk heavy lifting; we are layering DAG composition and operator classification on top, not reinventing it.
+- dbt's own column-level lineage (newer versions) covers a similar surface; their work is an excellent reference and we cross-check against it where available.
+- Refinement-type and dependent-type literature on tag propagation through projection operators informs the eventual semantic-types layer that consumes this graph.


### PR DESCRIPTION
## Summary
- Adds [`docs/design/column-level-lineage.md`](https://github.com/dvryaboy/dblect/blob/design/column-lineage/docs/design/column-level-lineage.md) describing the per-column lineage substrate built on `sqlglot.lineage`.
- Closes the multi-source uniqueness gap called out at `src/dblect/uniqueness/detector.py:51`, unlocks a handful of cross-model detectors (cross-model NOT IN with nullable upstream, aggregate-over-aggregated, cross-model fanout propagation), and prefigures tag tracking for the eventual semantic-types layer.
- Adds an entry to `docs/README.md` so the new doc is discoverable.

## Sections
- Motivation (three converging needs)
- What sqlglot gives us, what we layer on top
- Data model: `ColumnLineage`, `ColumnOrigin`, `LineageGraph`, `ColumnOp`
- Use sites: uniqueness propagation upgrade, new lineage-dependent detectors, semantic-types substrate
- Failure modes: `UNKNOWN` never load-bearing; lineage is a partial map
- Testing: PBT invariants, jaffle goldens, optional dbt cross-check
- Sequencing and prior art

## Test plan
- [x] Docs-only change; nothing to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)