### PR TITLE
Nullability discoverers + manifest-backed nullability_property (step 2)

### DIFF
--- a/src/dblect/lineage/properties/__init__.py
+++ b/src/dblect/lineage/properties/__init__.py
@@ -5,9 +5,9 @@ how values combine at operators and aggregates. The propagator in
 ``dblect.lineage.property`` consumes them generically: one walker, many
 properties.
 
-``where_provenance`` is production. ``nullability`` and
-``aggregation_depth`` are demo properties — their module docstrings list
-the operator-coverage gaps that keep them out of audit consumption.
+``where_provenance`` is production. ``nullability_property`` reads a manifest for
+its grounding; ``aggregation_depth`` is a demo property whose module docstring
+lists the operator-coverage gaps that keep it out of audit consumption.
 """
 
 from dblect.lineage.properties.aggregation_depth import aggregation_depth
@@ -15,7 +15,6 @@ from dblect.lineage.properties.nullability import (
     Nullability,
     native_not_null_discoverer,
     not_null_test_discoverer,
-    nullability,
     nullability_property,
 )
 from dblect.lineage.properties.where_provenance import where_provenance
@@ -25,7 +24,6 @@ __all__ = [
     "aggregation_depth",
     "native_not_null_discoverer",
     "not_null_test_discoverer",
-    "nullability",
     "nullability_property",
     "where_provenance",
 ]

--- a/src/dblect/lineage/properties/__init__.py
+++ b/src/dblect/lineage/properties/__init__.py
@@ -11,12 +11,21 @@ the operator-coverage gaps that keep them out of audit consumption.
 """
 
 from dblect.lineage.properties.aggregation_depth import aggregation_depth
-from dblect.lineage.properties.nullability import Nullability, nullability
+from dblect.lineage.properties.nullability import (
+    Nullability,
+    native_not_null_discoverer,
+    not_null_test_discoverer,
+    nullability,
+    nullability_property,
+)
 from dblect.lineage.properties.where_provenance import where_provenance
 
 __all__ = [
     "Nullability",
     "aggregation_depth",
+    "native_not_null_discoverer",
+    "not_null_test_discoverer",
     "nullability",
+    "nullability_property",
     "where_provenance",
 ]

--- a/src/dblect/lineage/properties/nullability.py
+++ b/src/dblect/lineage/properties/nullability.py
@@ -1,10 +1,4 @@
-"""Demo nullability property: per-column tri-state {NON_NULL, NULLABLE, UNKNOWN}.
-
-**Demo, not a production property.** It pins that a CTE-wrapped ``COALESCE``
-propagates NON_NULL to the outer projection, and that a ``UNION ALL`` with one
-nullable arm taints the combined output. Grounding is trivial here (every node
-IMPLICIT) until the nullability discoverers land and consult ``not_null`` tests,
-the declared ``nullable`` flag, and native ``NOT NULL`` constraints.
+"""Nullability property: per-column tri-state {NON_NULL, NULLABLE, UNKNOWN}.
 
 The lattice orders by precision (NON_NULL refines NULLABLE refines UNKNOWN, the
 "no information" top); ``meet`` keeps the stronger guarantee. A structural
@@ -14,20 +8,45 @@ exists only to make the lattice bounded.
 Confluence uses a semiring rather than the lattice join, so a proven NULLABLE
 arm can beat an UNKNOWN one (a join with the top cannot); see
 :class:`NullabilitySemiring` and ``propagation-soundness.md``.
+
+Grounding comes from two discoverers that read a dbt manifest: a ``not_null``
+generic test and a native ``NOT NULL`` constraint each ground a column to
+NON_NULL. Both are sound-by-omission: a disabled test, a ``where``-conditional
+test, or an axis they do not own grounds nothing rather than over-claiming. Build
+the manifest-backed property with :func:`nullability_property`; the bare
+:data:`nullability` value keeps a trivial grounding for graph-only tests and the
+COALESCE / IS / COUNT transfer demos.
 """
 
 from __future__ import annotations
 
+from collections.abc import Collection, Mapping
 from dataclasses import dataclass
 from enum import StrEnum
 
 from sqlglot import Expr
 from sqlglot import expressions as exp
 
+from dblect.lineage.facts.grounding import collect, grounding
 from dblect.lineage.facts.lattice import Lattice
-from dblect.lineage.facts.model import Annotation, Opacity
-from dblect.lineage.facts.property import AggregateRule, DepContext, Property, column_property
-from dblect.lineage.graph import ColumnRef
+from dblect.lineage.facts.model import (
+    Annotation,
+    Declared,
+    DeclaredSource,
+    Fact,
+    NativeConstraint,
+    Opacity,
+)
+from dblect.lineage.facts.property import (
+    AggregateRule,
+    DepContext,
+    FactDiscoverer,
+    OperatorTransfer,
+    Property,
+    column_property,
+)
+from dblect.lineage.graph import ColumnRef, SourceKind, SourceRef
+from dblect.manifest import ConstraintType, Manifest, Node, ResourceType
 
 
 class Nullability(StrEnum):
@@ -85,11 +104,6 @@ class NullabilitySemiring:
         return self.plus(a, b)
 
 
-def _ground_unknown(_: ColumnRef) -> Annotation[Nullability]:
-    """Trivial grounding: nothing is declared yet, so every node is IMPLICIT top."""
-    return Annotation(Nullability.UNKNOWN, Opacity.IMPLICIT)
-
-
 def _coalesce_rule(
     _expr: Expr, kids: tuple[Annotation[Nullability], ...], _ctx: DepContext
 ) -> Annotation[Nullability]:
@@ -118,16 +132,182 @@ def _count_core(_expr: exp.AggFunc, child: Annotation[Nullability]) -> Annotatio
     return Annotation(Nullability.NON_NULL, provisional=child.provisional)
 
 
+_NULLABILITY_OPERATORS: Mapping[type[Expr], OperatorTransfer[Nullability]] = {
+    exp.Coalesce: _coalesce_rule,
+    exp.Is: _is_not_null_rule,
+}
+_NULLABILITY_AGGREGATES: Mapping[type[exp.AggFunc], AggregateRule[Nullability]] = {
+    exp.Count: AggregateRule(core=_count_core),
+}
+
+
+def _ground_unknown(_: ColumnRef) -> Annotation[Nullability]:
+    """Trivial grounding for the bare demo value: every node is IMPLICIT top."""
+    return Annotation(Nullability.UNKNOWN, Opacity.IMPLICIT)
+
+
 nullability: Property[Nullability, ColumnRef] = column_property(
     name="nullability",
     lattice=NULLABILITY_LATTICE,
-    operators={
-        exp.Coalesce: _coalesce_rule,
-        exp.Is: _is_not_null_rule,
-    },
-    aggregates={
-        exp.Count: AggregateRule(core=_count_core),
-    },
+    operators=_NULLABILITY_OPERATORS,
+    aggregates=_NULLABILITY_AGGREGATES,
     ground=_ground_unknown,
     semiring=NullabilitySemiring(),
 )
+
+
+# --- discoverers -------------------------------------------------------------
+
+_SOURCE_KIND: Mapping[ResourceType, SourceKind] = {
+    ResourceType.MODEL: SourceKind.MODEL,
+    ResourceType.SOURCE: SourceKind.SOURCE,
+    ResourceType.SEED: SourceKind.SEED,
+    ResourceType.SNAPSHOT: SourceKind.SNAPSHOT,
+}
+_TARGET_PREFIXES: tuple[str, ...] = ("model.", "source.", "seed.", "snapshot.")
+
+
+def _test_target_node(node: Node) -> str | None:
+    """The unique_id a generic test is attached to. Prefer ``attached_node`` (the
+    modern shape), fall back to the first eligible ``depends_on`` for older
+    manifests."""
+    if node.attached_node and node.attached_node.startswith(_TARGET_PREFIXES):
+        return node.attached_node
+    for dep in sorted(node.depends_on):
+        if dep.startswith(_TARGET_PREFIXES):
+            return dep
+    return None
+
+
+def _column_ref(manifest: Manifest, target_uid: str, column: str) -> ColumnRef | None:
+    """The graph-keyed ColumnRef for ``column`` on the target node, or None if the
+    node is absent or not a data-flow relation. Column names are case-folded to
+    match how the builder keys the graph."""
+    node = manifest.nodes.get(target_uid)
+    if node is None:
+        return None
+    kind = _SOURCE_KIND.get(node.resource_type)
+    if kind is None:
+        return None
+    return ColumnRef(SourceRef(kind, target_uid), column.lower())
+
+
+class _NotNullTestDiscoverer:
+    """Grounds NON_NULL from enabled, unconditional ``not_null`` generic tests."""
+
+    def discover(
+        self, manifest: Manifest, *, name_to_source: Mapping[str, SourceRef]
+    ) -> Collection[Fact[Nullability, ColumnRef]]:
+        out: list[Fact[Nullability, ColumnRef]] = []
+        for node in manifest.nodes.values():
+            tm = node.test_metadata
+            if tm is None or not tm.enabled or tm.name != "not_null":
+                continue
+            # A `where` filter makes the assertion conditional ("not null within
+            # rows matching X"). Grounding it as an unconditional NON_NULL would
+            # over-claim, so it is captured-but-not-activated until conditional
+            # facts land (see conditional-uniqueness-facts.md).
+            if tm.where is not None:
+                continue
+            col = tm.kwargs.get("column_name")
+            if not isinstance(col, str) or not col:
+                continue
+            target = _test_target_node(node)
+            if target is None:
+                continue
+            scope = _column_ref(manifest, target, col)
+            if scope is None:
+                continue
+            out.append(
+                Fact(
+                    scope=scope,
+                    value=Nullability.NON_NULL,
+                    provenance=Declared(DeclaredSource.DBT_GENERIC_TEST),
+                    detail=node.name,
+                )
+            )
+        return out
+
+
+# NOT NULL is enforced on write by essentially every warehouse, unlike the
+# advisory PRIMARY KEY / UNIQUE that several leave unchecked, so the default is
+# enforced. The set names adapters known to treat it otherwise (none yet); the
+# flag is descriptive provenance, read only by the unenforced-constraint finding.
+_NOT_NULL_ADVISORY_ADAPTERS: frozenset[str] = frozenset()
+
+
+def _not_null_enforced(adapter_type: str) -> bool:
+    return adapter_type.lower() not in _NOT_NULL_ADVISORY_ADAPTERS
+
+
+class _NativeNotNullDiscoverer:
+    """Grounds NON_NULL from native ``NOT NULL`` constraints (dbt 1.5+)."""
+
+    def __init__(self, adapter_type: str) -> None:
+        self._enforced = _not_null_enforced(adapter_type)
+
+    def discover(
+        self, manifest: Manifest, *, name_to_source: Mapping[str, SourceRef]
+    ) -> Collection[Fact[Nullability, ColumnRef]]:
+        out: list[Fact[Nullability, ColumnRef]] = []
+        for node in manifest.nodes.values():
+            if node.resource_type is not ResourceType.MODEL:
+                continue
+            source = SourceRef(SourceKind.MODEL, node.unique_id)
+            # Model-level constraints name their columns explicitly.
+            out.extend(
+                self._fact(source, col, "model-level NOT NULL")
+                for c in node.constraints
+                if c.type is ConstraintType.NOT_NULL
+                for col in c.columns
+            )
+            # Column-level constraints attach to the column implicitly.
+            out.extend(
+                self._fact(source, col_name, f"column-level NOT NULL on {col_name}")
+                for col_name, col in node.columns.items()
+                for c in col.constraints
+                if c.type is ConstraintType.NOT_NULL
+            )
+        return out
+
+    def _fact(self, source: SourceRef, column: str, detail: str) -> Fact[Nullability, ColumnRef]:
+        return Fact(
+            scope=ColumnRef(source, column.lower()),
+            value=Nullability.NON_NULL,
+            provenance=NativeConstraint(enforced_on_write=self._enforced),
+            detail=detail,
+        )
+
+
+def not_null_test_discoverer() -> FactDiscoverer[Nullability, ColumnRef]:
+    return _NotNullTestDiscoverer()
+
+
+def native_not_null_discoverer(adapter_type: str) -> FactDiscoverer[Nullability, ColumnRef]:
+    return _NativeNotNullDiscoverer(adapter_type)
+
+
+def nullability_property(
+    manifest: Manifest,
+    *,
+    name_to_source: Mapping[str, SourceRef],
+    extra: tuple[FactDiscoverer[Nullability, ColumnRef], ...] = (),
+) -> Property[Nullability, ColumnRef]:
+    """The manifest-backed nullability property: grounding folds the discoverers'
+    NON_NULL claims (plus any ``extra``) through the lattice, leaving every
+    undeclared column UNKNOWN. No opaque opt-out reader is wired yet, so the
+    opaque set is empty."""
+    discoverers = (
+        not_null_test_discoverer(),
+        native_not_null_discoverer(manifest.adapter_type),
+        *extra,
+    )
+    facts = collect(manifest, discoverers, name_to_source=name_to_source)
+    return column_property(
+        name="nullability",
+        lattice=NULLABILITY_LATTICE,
+        operators=_NULLABILITY_OPERATORS,
+        aggregates=_NULLABILITY_AGGREGATES,
+        ground=grounding(facts, opaque=set(), lat=NULLABILITY_LATTICE),
+        semiring=NullabilitySemiring(),
+    )

--- a/src/dblect/lineage/properties/nullability.py
+++ b/src/dblect/lineage/properties/nullability.py
@@ -13,9 +13,10 @@ Grounding comes from two discoverers that read a dbt manifest: a ``not_null``
 generic test and a native ``NOT NULL`` constraint each ground a column to
 NON_NULL. Both are sound-by-omission: a disabled test, a ``where``-conditional
 test, or an axis they do not own grounds nothing rather than over-claiming. Build
-the manifest-backed property with :func:`nullability_property`; the bare
-:data:`nullability` value keeps a trivial grounding for graph-only tests and the
-COALESCE / IS / COUNT transfer demos.
+the manifest-backed property with :func:`nullability_property`. The axis pieces a
+custom grounding reuses (the lattice, the transfer catalogs, the semiring) are
+public, so a graph-only test or a transfer demo can assemble its own property
+without a manifest.
 """
 
 from __future__ import annotations
@@ -46,7 +47,7 @@ from dblect.lineage.facts.property import (
     column_property,
 )
 from dblect.lineage.graph import ColumnRef, SourceKind, SourceRef
-from dblect.manifest import ConstraintType, Manifest, Node, ResourceType
+from dblect.manifest import ConstraintType, Manifest, ResourceType, generic_test_target_uid
 
 
 class Nullability(StrEnum):
@@ -132,28 +133,16 @@ def _count_core(_expr: exp.AggFunc, child: Annotation[Nullability]) -> Annotatio
     return Annotation(Nullability.NON_NULL, provisional=child.provisional)
 
 
-_NULLABILITY_OPERATORS: Mapping[type[Expr], OperatorTransfer[Nullability]] = {
+# The transfer catalogs are the reusable axis surface: :func:`nullability_property`
+# and any custom-grounding caller (graph-only tests, transfer demos) build their
+# property from these plus a ``ground`` function of their own.
+NULLABILITY_OPERATORS: Mapping[type[Expr], OperatorTransfer[Nullability]] = {
     exp.Coalesce: _coalesce_rule,
     exp.Is: _is_not_null_rule,
 }
-_NULLABILITY_AGGREGATES: Mapping[type[exp.AggFunc], AggregateRule[Nullability]] = {
+NULLABILITY_AGGREGATES: Mapping[type[exp.AggFunc], AggregateRule[Nullability]] = {
     exp.Count: AggregateRule(core=_count_core),
 }
-
-
-def _ground_unknown(_: ColumnRef) -> Annotation[Nullability]:
-    """Trivial grounding for the bare demo value: every node is IMPLICIT top."""
-    return Annotation(Nullability.UNKNOWN, Opacity.IMPLICIT)
-
-
-nullability: Property[Nullability, ColumnRef] = column_property(
-    name="nullability",
-    lattice=NULLABILITY_LATTICE,
-    operators=_NULLABILITY_OPERATORS,
-    aggregates=_NULLABILITY_AGGREGATES,
-    ground=_ground_unknown,
-    semiring=NullabilitySemiring(),
-)
 
 
 # --- discoverers -------------------------------------------------------------
@@ -164,19 +153,6 @@ _SOURCE_KIND: Mapping[ResourceType, SourceKind] = {
     ResourceType.SEED: SourceKind.SEED,
     ResourceType.SNAPSHOT: SourceKind.SNAPSHOT,
 }
-_TARGET_PREFIXES: tuple[str, ...] = ("model.", "source.", "seed.", "snapshot.")
-
-
-def _test_target_node(node: Node) -> str | None:
-    """The unique_id a generic test is attached to. Prefer ``attached_node`` (the
-    modern shape), fall back to the first eligible ``depends_on`` for older
-    manifests."""
-    if node.attached_node and node.attached_node.startswith(_TARGET_PREFIXES):
-        return node.attached_node
-    for dep in sorted(node.depends_on):
-        if dep.startswith(_TARGET_PREFIXES):
-            return dep
-    return None
 
 
 def _column_ref(manifest: Manifest, target_uid: str, column: str) -> ColumnRef | None:
@@ -205,14 +181,14 @@ class _NotNullTestDiscoverer:
                 continue
             # A `where` filter makes the assertion conditional ("not null within
             # rows matching X"). Grounding it as an unconditional NON_NULL would
-            # over-claim, so it is captured-but-not-activated until conditional
-            # facts land (see conditional-uniqueness-facts.md).
+            # over-claim, so it grounds nothing until conditional facts land (see
+            # conditional-uniqueness-facts.md).
             if tm.where is not None:
                 continue
             col = tm.kwargs.get("column_name")
             if not isinstance(col, str) or not col:
                 continue
-            target = _test_target_node(node)
+            target = generic_test_target_uid(node)
             if target is None:
                 continue
             scope = _column_ref(manifest, target, col)
@@ -306,8 +282,8 @@ def nullability_property(
     return column_property(
         name="nullability",
         lattice=NULLABILITY_LATTICE,
-        operators=_NULLABILITY_OPERATORS,
-        aggregates=_NULLABILITY_AGGREGATES,
+        operators=NULLABILITY_OPERATORS,
+        aggregates=NULLABILITY_AGGREGATES,
         ground=grounding(facts, opaque=set(), lat=NULLABILITY_LATTICE),
         semiring=NullabilitySemiring(),
     )

--- a/src/dblect/manifest/__init__.py
+++ b/src/dblect/manifest/__init__.py
@@ -2,6 +2,7 @@
 
 from dblect.manifest.dag import CycleError, Dag
 from dblect.manifest.parse import (
+    DATA_FLOW_UID_PREFIXES,
     Column,
     ConstraintSpec,
     ConstraintType,
@@ -9,9 +10,11 @@ from dblect.manifest.parse import (
     Manifest,
     Node,
     ResourceType,
+    generic_test_target_uid,
 )
 
 __all__ = [
+    "DATA_FLOW_UID_PREFIXES",
     "Column",
     "ConstraintSpec",
     "ConstraintType",
@@ -21,4 +24,5 @@ __all__ = [
     "Manifest",
     "Node",
     "ResourceType",
+    "generic_test_target_uid",
 ]

--- a/src/dblect/manifest/parse.py
+++ b/src/dblect/manifest/parse.py
@@ -174,6 +174,33 @@ class Node:
         return self.compiled_code
 
 
+# The unique_id prefixes dbt gives the data-flow node kinds, derived from the
+# resource types so the two stay in lockstep ("model.", "source.", "seed.",
+# "snapshot."). ``OTHER`` (tests, analyses) never anchors a generic test.
+DATA_FLOW_UID_PREFIXES: tuple[str, ...] = tuple(
+    f"{rt.value}." for rt in ResourceType if rt is not ResourceType.OTHER
+)
+
+
+def generic_test_target_uid(
+    node: Node, *, eligible_prefixes: tuple[str, ...] = DATA_FLOW_UID_PREFIXES
+) -> str | None:
+    """The unique_id a generic test is attached to, or None if undeterminable.
+
+    Prefer ``attached_node`` (the modern manifest shape); fall back to the first
+    eligible entry in ``depends_on`` for older manifests where ``attached_node``
+    isn't populated. ``eligible_prefixes`` narrows which target kinds count, so a
+    caller that grounds only models and sources can pass a subset of the
+    data-flow default.
+    """
+    if node.attached_node and node.attached_node.startswith(eligible_prefixes):
+        return node.attached_node
+    for dep in sorted(node.depends_on):
+        if dep.startswith(eligible_prefixes):
+            return dep
+    return None
+
+
 @dataclass(frozen=True, slots=True)
 class Manifest:
     """A dblect-shaped view of a parsed dbt ``manifest.json``."""

--- a/src/dblect/uniqueness/facts.py
+++ b/src/dblect/uniqueness/facts.py
@@ -34,7 +34,14 @@ from typing import Any, cast
 
 from sqlglot import Expr
 
-from dblect.manifest import ConstraintSpec, ConstraintType, Manifest, Node, ResourceType
+from dblect.manifest import (
+    ConstraintSpec,
+    ConstraintType,
+    Manifest,
+    Node,
+    ResourceType,
+    generic_test_target_uid,
+)
 from dblect.sql import SQLParseError, parse_sql
 
 
@@ -260,21 +267,12 @@ def _uniqueness_columns(c: ConstraintSpec) -> frozenset[str] | None:
     return frozenset(c.columns)
 
 
+# Models and sources both accept generic tests and both feed downstream model
+# SQL, so both ground facts. Seeds and snapshots are eligible in the shared
+# default but kept out here until the downstream consumers are tested against
+# them; see issue #52.
 _TARGET_PREFIXES: tuple[str, ...] = ("model.", "source.")
 
 
 def _test_target_node(node: Node) -> str | None:
-    """The unique_id a generic test is attached to, or None if undeterminable.
-
-    Prefer ``attached_node`` (the modern shape); fall back to the first
-    eligible entry in ``depends_on`` for older manifest versions where
-    ``attached_node`` isn't populated. Models and sources both accept generic
-    tests and both feed downstream model SQL, so both ground facts; seeds and
-    snapshots are out of scope for now.
-    """
-    if node.attached_node and node.attached_node.startswith(_TARGET_PREFIXES):
-        return node.attached_node
-    for dep in sorted(node.depends_on):
-        if dep.startswith(_TARGET_PREFIXES):
-            return dep
-    return None
+    return generic_test_target_uid(node, eligible_prefixes=_TARGET_PREFIXES)

--- a/tests/lineage/test_demo_nullability.py
+++ b/tests/lineage/test_demo_nullability.py
@@ -12,8 +12,13 @@ from dblect.lineage.builder import build_model_graph
 from dblect.lineage.facts.model import Annotation, Opacity
 from dblect.lineage.facts.property import Property, column_property
 from dblect.lineage.graph import ColumnRef, SourceKind, SourceRef
-from dblect.lineage.properties import Nullability, nullability
-from dblect.lineage.properties.nullability import NULLABILITY_LATTICE
+from dblect.lineage.properties import Nullability
+from dblect.lineage.properties.nullability import (
+    NULLABILITY_AGGREGATES,
+    NULLABILITY_LATTICE,
+    NULLABILITY_OPERATORS,
+    NullabilitySemiring,
+)
 from tests.lineage._lattice_laws import assert_consistency_laws, assert_lattice_laws
 
 _nullabilities = st.sampled_from(list(Nullability))
@@ -40,12 +45,12 @@ def _with_source_rule(
         return Annotation(value, Opacity.CONCRETE)
 
     return column_property(
-        name=nullability.name,
+        name="nullability",
         lattice=NULLABILITY_LATTICE,
-        operators=nullability.operators,
-        aggregates=nullability.aggregates,
+        operators=NULLABILITY_OPERATORS,
+        aggregates=NULLABILITY_AGGREGATES,
         ground=ground,
-        semiring=nullability.semiring,
+        semiring=NullabilitySemiring(),
     )
 
 

--- a/tests/lineage/test_nullability_facts.py
+++ b/tests/lineage/test_nullability_facts.py
@@ -1,0 +1,279 @@
+"""Nullability discoverers and the manifest-backed nullability_property.
+
+The discoverers read declarations off a dbt manifest: a ``not_null`` generic
+test and a native ``NOT NULL`` constraint each ground a column to NON_NULL. The
+tests build dblect-shaped manifests directly (no JSON round-trip) so each
+discoverer's contract is pinned against the typed `Manifest`, and one end-to-end
+case threads a discovered fact through the propagator.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from dblect.lineage import propagate
+from dblect.lineage.builder import build_model_graph
+from dblect.lineage.facts.model import Declared, DeclaredSource, NativeConstraint
+from dblect.lineage.graph import ColumnRef, SourceKind, SourceRef
+from dblect.lineage.properties.nullability import (
+    Nullability,
+    native_not_null_discoverer,
+    not_null_test_discoverer,
+    nullability_property,
+)
+from dblect.manifest import (
+    Column,
+    ConstraintSpec,
+    ConstraintType,
+    DbtTestMetadata,
+    Manifest,
+    Node,
+    ResourceType,
+)
+
+
+def _manifest(*nodes: Node, adapter_type: str = "duckdb") -> Manifest:
+    return Manifest(
+        schema_version="v12",
+        adapter_type=adapter_type,
+        nodes={n.unique_id: n for n in nodes},
+    )
+
+
+def _model(uid: str, *, columns: Mapping[str, Column] = {}, constraints: tuple[ConstraintSpec, ...] = ()) -> Node:
+    return Node(
+        unique_id=uid,
+        name=uid.split(".")[-1],
+        resource_type=ResourceType.MODEL,
+        fqn=(uid,),
+        package_name="shop",
+        schema="analytics",
+        raw_code=None,
+        compiled_code="select 1",
+        original_file_path=None,
+        columns=columns,
+        constraints=constraints,
+    )
+
+
+def _source(uid: str) -> Node:
+    return Node(
+        unique_id=uid,
+        name=uid.split(".")[-1],
+        resource_type=ResourceType.SOURCE,
+        fqn=(uid,),
+        package_name="shop",
+        schema="raw",
+        raw_code=None,
+        compiled_code=None,
+        original_file_path=None,
+        columns={},
+    )
+
+
+def _not_null_test(uid: str, *, column: str, target: str, where: str | None = None, enabled: bool = True) -> Node:
+    return Node(
+        unique_id=uid,
+        name=uid.split(".")[-1],
+        resource_type=ResourceType.OTHER,
+        fqn=(uid,),
+        package_name="shop",
+        schema=None,
+        raw_code=None,
+        compiled_code=None,
+        original_file_path=None,
+        columns={},
+        depends_on=frozenset({target}),
+        test_metadata=DbtTestMetadata(
+            name="not_null",
+            kwargs={"column_name": column},
+            enabled=enabled,
+            where=where,
+        ),
+        attached_node=target,
+    )
+
+
+# --- not_null test discoverer ------------------------------------------------
+
+
+def test_not_null_test_on_source_column_grounds_non_null() -> None:
+    src = _source("source.shop.raw.orders")
+    test = _not_null_test("test.shop.nn", column="id", target=src.unique_id)
+    facts = list(not_null_test_discoverer().discover(_manifest(src, test), name_to_source={}))
+    assert len(facts) == 1
+    fact = facts[0]
+    assert fact.scope == ColumnRef(SourceRef(SourceKind.SOURCE, src.unique_id), "id")
+    assert fact.value is Nullability.NON_NULL
+    assert fact.provenance == Declared(DeclaredSource.DBT_GENERIC_TEST)
+
+
+def test_not_null_test_on_model_column_grounds_non_null() -> None:
+    model = _model("model.shop.fct_orders")
+    test = _not_null_test("test.shop.nn", column="order_id", target=model.unique_id)
+    facts = list(not_null_test_discoverer().discover(_manifest(model, test), name_to_source={}))
+    assert facts[0].scope == ColumnRef(SourceRef(SourceKind.MODEL, model.unique_id), "order_id")
+
+
+def test_not_null_test_column_name_is_case_folded() -> None:
+    src = _source("source.shop.raw.orders")
+    test = _not_null_test("test.shop.nn", column="OrderId", target=src.unique_id)
+    facts = list(not_null_test_discoverer().discover(_manifest(src, test), name_to_source={}))
+    assert facts[0].scope.column == "orderid"
+
+
+def test_conditional_not_null_test_is_not_activated() -> None:
+    """A ``where`` filter makes the assertion conditional; capturing it as an
+    unconditional NON_NULL would over-claim, so it grounds nothing for now."""
+    src = _source("source.shop.raw.orders")
+    test = _not_null_test("test.shop.nn", column="id", target=src.unique_id, where="amount > 0")
+    facts = list(not_null_test_discoverer().discover(_manifest(src, test), name_to_source={}))
+    assert facts == []
+
+
+def test_disabled_not_null_test_grounds_nothing() -> None:
+    src = _source("source.shop.raw.orders")
+    test = _not_null_test("test.shop.nn", column="id", target=src.unique_id, enabled=False)
+    facts = list(not_null_test_discoverer().discover(_manifest(src, test), name_to_source={}))
+    assert facts == []
+
+
+def test_non_nullability_test_is_ignored() -> None:
+    """A discoverer is total within its axis: a ``unique`` test is not its concern."""
+    src = _source("source.shop.raw.orders")
+    other = _not_null_test("test.shop.u", column="id", target=src.unique_id)
+    other = Node(  # rebuild with a unique test rather than not_null
+        unique_id=other.unique_id,
+        name=other.name,
+        resource_type=ResourceType.OTHER,
+        fqn=other.fqn,
+        package_name=other.package_name,
+        schema=None,
+        raw_code=None,
+        compiled_code=None,
+        original_file_path=None,
+        columns={},
+        depends_on=other.depends_on,
+        test_metadata=DbtTestMetadata(name="unique", kwargs={"column_name": "id"}),
+        attached_node=src.unique_id,
+    )
+    facts = list(not_null_test_discoverer().discover(_manifest(src, other), name_to_source={}))
+    assert facts == []
+
+
+# --- native NOT NULL constraint discoverer -----------------------------------
+
+
+def test_column_level_not_null_constraint_grounds_non_null() -> None:
+    model = _model(
+        "model.shop.fct_orders",
+        columns={
+            "order_id": Column(
+                name="order_id",
+                data_type="bigint",
+                description=None,
+                constraints=(ConstraintSpec(type=ConstraintType.NOT_NULL),),
+            )
+        },
+    )
+    facts = list(native_not_null_discoverer("duckdb").discover(_manifest(model), name_to_source={}))
+    assert len(facts) == 1
+    fact = facts[0]
+    assert fact.scope == ColumnRef(SourceRef(SourceKind.MODEL, model.unique_id), "order_id")
+    assert fact.value is Nullability.NON_NULL
+    assert isinstance(fact.provenance, NativeConstraint)
+
+
+def test_model_level_not_null_constraint_grounds_each_named_column() -> None:
+    model = _model(
+        "model.shop.fct_orders",
+        constraints=(ConstraintSpec(type=ConstraintType.NOT_NULL, columns=("order_id", "customer_id")),),
+    )
+    facts = list(native_not_null_discoverer("duckdb").discover(_manifest(model), name_to_source={}))
+    cols = {f.scope.column for f in facts}
+    assert cols == {"order_id", "customer_id"}
+
+
+def test_native_constraint_other_than_not_null_is_ignored() -> None:
+    model = _model(
+        "model.shop.fct_orders",
+        columns={
+            "order_id": Column(
+                name="order_id",
+                data_type="bigint",
+                description=None,
+                constraints=(ConstraintSpec(type=ConstraintType.PRIMARY_KEY),),
+            )
+        },
+    )
+    facts = list(native_not_null_discoverer("duckdb").discover(_manifest(model), name_to_source={}))
+    assert facts == []
+
+
+# --- nullability_property end-to-end -----------------------------------------
+
+
+def test_nullability_property_flows_discovered_non_null_through_a_model() -> None:
+    src = _source("source.shop.raw.orders")
+    test = _not_null_test("test.shop.nn", column="id", target=src.unique_id)
+    manifest = _manifest(src, test)
+    src_ref = SourceRef(SourceKind.SOURCE, src.unique_id)
+    graph = build_model_graph(
+        model_uid="model.shop.fct",
+        sql="SELECT u.id FROM orders u",
+        name_to_source={"orders": src_ref},
+        schema={"orders": {"id": "INT"}},
+    )
+    prop = nullability_property(manifest, name_to_source={"orders": src_ref})
+    anns = propagate(graph, prop)
+    leaf = ColumnRef(src_ref, "id")
+    out = ColumnRef(SourceRef(SourceKind.MODEL, "model.shop.fct"), "id")
+    assert anns[leaf].value is Nullability.NON_NULL
+    assert anns[out].value is Nullability.NON_NULL
+
+
+def test_nullability_property_leaves_undeclared_columns_unknown() -> None:
+    src = _source("source.shop.raw.orders")
+    manifest = _manifest(src)  # no not_null test
+    src_ref = SourceRef(SourceKind.SOURCE, src.unique_id)
+    graph = build_model_graph(
+        model_uid="model.shop.fct",
+        sql="SELECT u.id FROM orders u",
+        name_to_source={"orders": src_ref},
+        schema={"orders": {"id": "INT"}},
+    )
+    prop = nullability_property(manifest, name_to_source={"orders": src_ref})
+    anns = propagate(graph, prop)
+    out = ColumnRef(SourceRef(SourceKind.MODEL, "model.shop.fct"), "id")
+    assert anns[out].value is Nullability.UNKNOWN
+
+
+def test_nullability_property_accepts_extra_discoverers() -> None:
+    """A caller can contribute its own discoverer; its facts ground alongside
+    the built-ins."""
+    src = _source("source.shop.raw.orders")
+    src_ref = SourceRef(SourceKind.SOURCE, src.unique_id)
+
+    class _AlwaysNonNull:
+        def discover(self, manifest: Manifest, *, name_to_source: Mapping[str, SourceRef]):  # type: ignore[no-untyped-def]
+            from dblect.lineage.facts.model import Fact
+
+            return (
+                Fact(
+                    scope=ColumnRef(src_ref, "id"),
+                    value=Nullability.NON_NULL,
+                    provenance=Declared(DeclaredSource.USER_ASSERTED),
+                ),
+            )
+
+    graph = build_model_graph(
+        model_uid="model.shop.fct",
+        sql="SELECT u.id FROM orders u",
+        name_to_source={"orders": src_ref},
+        schema={"orders": {"id": "INT"}},
+    )
+    prop = nullability_property(
+        _manifest(src), name_to_source={"orders": src_ref}, extra=(_AlwaysNonNull(),)
+    )
+    anns = propagate(graph, prop)
+    assert anns[ColumnRef(src_ref, "id")].value is Nullability.NON_NULL

--- a/tests/lineage/test_nullability_facts.py
+++ b/tests/lineage/test_nullability_facts.py
@@ -40,7 +40,9 @@ def _manifest(*nodes: Node, adapter_type: str = "duckdb") -> Manifest:
     )
 
 
-def _model(uid: str, *, columns: Mapping[str, Column] = {}, constraints: tuple[ConstraintSpec, ...] = ()) -> Node:
+def _model(
+    uid: str, *, columns: Mapping[str, Column] = {}, constraints: tuple[ConstraintSpec, ...] = ()
+) -> Node:
     return Node(
         unique_id=uid,
         name=uid.split(".")[-1],
@@ -71,7 +73,9 @@ def _source(uid: str) -> Node:
     )
 
 
-def _not_null_test(uid: str, *, column: str, target: str, where: str | None = None, enabled: bool = True) -> Node:
+def _not_null_test(
+    uid: str, *, column: str, target: str, where: str | None = None, enabled: bool = True
+) -> Node:
     return Node(
         unique_id=uid,
         name=uid.split(".")[-1],
@@ -187,7 +191,9 @@ def test_column_level_not_null_constraint_grounds_non_null() -> None:
 def test_model_level_not_null_constraint_grounds_each_named_column() -> None:
     model = _model(
         "model.shop.fct_orders",
-        constraints=(ConstraintSpec(type=ConstraintType.NOT_NULL, columns=("order_id", "customer_id")),),
+        constraints=(
+            ConstraintSpec(type=ConstraintType.NOT_NULL, columns=("order_id", "customer_id")),
+        ),
     )
     facts = list(native_not_null_discoverer("duckdb").discover(_manifest(model), name_to_source={}))
     cols = {f.scope.column for f in facts}

--- a/tests/lineage/test_pbt_nullability_monotone.py
+++ b/tests/lineage/test_pbt_nullability_monotone.py
@@ -20,8 +20,13 @@ from dblect.lineage.builder import build_manifest_graph, build_model_graph
 from dblect.lineage.facts.model import Annotation, Opacity
 from dblect.lineage.facts.property import Property, column_property
 from dblect.lineage.graph import ColumnRef, SourceKind, SourceRef
-from dblect.lineage.properties import Nullability, nullability
-from dblect.lineage.properties.nullability import NULLABILITY_LATTICE
+from dblect.lineage.properties import Nullability
+from dblect.lineage.properties.nullability import (
+    NULLABILITY_AGGREGATES,
+    NULLABILITY_LATTICE,
+    NULLABILITY_OPERATORS,
+    NullabilitySemiring,
+)
 from tests.lineage.test_pbt_lineage import (
     CTEScenario,
     Scenario,
@@ -58,12 +63,12 @@ def _rule_property(
         return Annotation(value, Opacity.CONCRETE)
 
     return column_property(
-        name=nullability.name,
+        name="nullability",
         lattice=NULLABILITY_LATTICE,
-        operators=nullability.operators,
-        aggregates=nullability.aggregates,
+        operators=NULLABILITY_OPERATORS,
+        aggregates=NULLABILITY_AGGREGATES,
         ground=ground,
-        semiring=nullability.semiring,
+        semiring=NullabilitySemiring(),
     )
 
 


### PR DESCRIPTION
## Summary

Step 2, stacked on #32. Promotes nullability from the trivial-grounding demo to a manifest-backed property: grounding now reads real declarations instead of defaulting every node to UNKNOWN. This is the source-rule piece of #26 for nullability.

**Stacked on `lineage/facts-impl` (#32)** — review that one first; this PR's diff is just the step-2 delta. 318 tests pass; pyright strict and ruff clean.

## What's here

- **`not_null_test_discoverer()`** — an enabled, unconditional `not_null` generic test grounds its column to NON_NULL (`Declared`/`DBT_GENERIC_TEST`). Target resolves via `attached_node` then `depends_on` (matching the uniqueness facts module); column names are case-folded to match the graph. A disabled or `where`-conditional test grounds nothing — capturing a conditional `not_null` as an unconditional NON_NULL would over-claim, so it's deferred (captured-but-not-activated, per the soundness contract).
- **`native_not_null_discoverer(adapter_type)`** — column- and model-level native `NOT NULL` constraints ground NON_NULL (`NativeConstraint`). `enforced_on_write` defaults true (NOT NULL is enforced on write nearly everywhere, unlike advisory `PRIMARY KEY`/`UNIQUE`); it's descriptive provenance, read only by the future unenforced-constraint finding.
- **`nullability_property(manifest, *, name_to_source, extra=())`** — the worked constructor from `lineage-facts-types.md`: `collect` + `grounding` over the discoverers, folding NON_NULL claims through the lattice and leaving undeclared columns UNKNOWN. Transfer catalogs are shared constants with the bare demo value. No opaque opt-out reader is wired yet, so the opaque set is empty.

## Tests

Manifests are built directly from the dblect-shaped `Manifest`/`Node` types (no JSON round-trip), pinning each discoverer's contract: source vs model column, case folding, conditional/disabled/other-axis skips, and both native-constraint levels. End-to-end cases thread a discovered NON_NULL through a model passthrough and exercise the `extra=` discoverer seam.

## Related

- Stacked on #32 (facts substrate, step 1).
- Closes the source-rule piece of #26 for nullability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)