### PR TITLE
lineage: predicate-flow property (#43, stage 3a)

### DIFF
--- a/src/dblect/lineage/predicate.py
+++ b/src/dblect/lineage/predicate.py
@@ -177,6 +177,49 @@ def implies(strong: Expr, weak: Expr) -> bool:
     return _entails(cmp_atoms, in_sets, weak)
 
 
+# --- atom extraction and column renaming -----------------------------------------
+#
+# The predicate-flow property carries a relation's accumulated row filter as a set
+# of these atoms, so it needs to lift a ``WHERE`` expression into atoms and rename
+# an atom's column through a projection. Both operate on the same typed atom forms
+# the entailment core reasons about, so they live here rather than re-deriving the
+# recognition logic elsewhere.
+
+
+def atoms_of(e: Expr) -> frozenset[Canon]:
+    """The conjuncts of ``e``, each canonicalised to an atom. A conjunct outside the
+    fragment (an ``OR``, an unmodelled shape) becomes an :class:`OpaqueAtom`, carried
+    but inert to interval reasoning."""
+    return frozenset(_canon(c) for c in _conjuncts(e))
+
+
+def atom_column(atom: Canon) -> str | None:
+    """The single base column an atom constrains, or ``None`` for an
+    :class:`OpaqueAtom` (whose columns the engine does not model)."""
+    if isinstance(atom, CmpAtom | InAtom):
+        return _term_column(atom.term)
+    return None
+
+
+def rename_atom(atom: CmpAtom | InAtom, new_column: str) -> CmpAtom | InAtom:
+    """``atom`` with its base column replaced by ``new_column`` (renaming the inner
+    column of a truncation term), so a filter follows a projection's ``col AS x``."""
+    term = _rename_term_column(atom.term, new_column)
+    if isinstance(atom, CmpAtom):
+        return CmpAtom(term, atom.op, atom.lit)
+    return InAtom(term, atom.values)
+
+
+def _term_column(t: Term) -> str:
+    return t.name if isinstance(t, Column) else _term_column(t.inner)
+
+
+def _rename_term_column(t: Term, new_column: str) -> Term:
+    if isinstance(t, Column):
+        return Column(new_column)
+    return Trunc(t.unit, _rename_term_column(t.inner, new_column))
+
+
 # --- decomposition ---------------------------------------------------------------
 
 

--- a/src/dblect/lineage/properties/predicate_flow.py
+++ b/src/dblect/lineage/properties/predicate_flow.py
@@ -1,0 +1,289 @@
+"""Predicate-flow property: the row filter every row of a relation satisfies.
+
+A relation's value is the conjunction of atoms (in the relation's *output* column
+names) that every one of its rows is known to satisfy. A ``WHERE`` conjoins its
+atoms, a passthrough carries the upstream filter, a consumer's own ``WHERE`` adds
+to it, and a projection renames the filter's columns (``country = 'US'`` becomes
+``region = 'US'`` after ``country AS region``). CTEs and inline subqueries
+accumulate for free, since the relation walk recurses through them.
+
+The property is the shared substrate a later activation step reads to decide when a
+captured conditional fact applies: a conditional ``unique`` / ``not_null`` holds at
+any scope whose accumulated filter *implies* the test's predicate. Type refinement
+and contract validation are further consumers of the same flow.
+
+The value reuses the predicate engine's typed atoms (:data:`Canon`), so the filter
+is rigorously shaped and feeds the engine directly. Posture is silent-when-unproven:
+a shape the walk cannot carry soundly (a ``JOIN`` whose columns could blur across
+sources, a ``UNION`` whose arms differ, a ``GROUP BY`` that changes row identity, a
+filtered column the projection drops) yields "no filter known" rather than a guess.
+The lattice orders by precision, where knowing *more* atoms is more precise: ``meet``
+unions the atom sets, ``join`` (confluence) keeps the atoms both branches carry, and
+``top`` is the empty set. Filters are never declared, only derived, so ``ground``
+returns ``top`` everywhere and the reducer does all the work.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+
+import sqlglot.expressions as exp
+from sqlglot import Expr
+
+from dblect.lineage.facts.lattice import Lattice
+from dblect.lineage.facts.model import Annotation, Opacity
+from dblect.lineage.facts.property import DepContext, Property, relation_property
+from dblect.lineage.graph import SourceRef, source_ref_meta
+from dblect.lineage.predicate import Canon, CmpAtom, InAtom, atom_column, atoms_of, rename_atom
+from dblect.sql import _sqlglot as sg
+
+
+@dataclass(frozen=True, slots=True)
+class RowFilter:
+    """The conjunction of atoms every row of a relation is known to satisfy.
+
+    ``atoms`` holds the known conjuncts in the relation's output column names; the
+    empty set is the lattice ``top`` ("no filter known"). ``is_bottom`` marks the
+    formal universal element (the lattice ``bottom``): it absorbs under ``meet`` and
+    is the identity under ``join``. Filters only ever accumulate, so no resolution of
+    real derivations reaches bottom; it exists only so the lattice is bounded.
+    """
+
+    atoms: frozenset[Canon]
+    is_bottom: bool = False
+
+    @staticmethod
+    def of(*atoms: Canon) -> RowFilter:
+        return RowFilter(frozenset(atoms))
+
+
+# The empty filter: "no filter known", the value every relation grounds to and the
+# meet identity.
+NO_FILTER: RowFilter = RowFilter(frozenset())
+
+# The formal universal element, present so the lattice is bounded; unreachable when
+# reducing real derivations, which only ever union atoms.
+ALL_FILTERS: RowFilter = RowFilter(frozenset(), is_bottom=True)
+
+
+def _meet(a: RowFilter, b: RowFilter) -> RowFilter:
+    """Most precise filter consistent with both: the union of their atoms."""
+    if a.is_bottom or b.is_bottom:
+        return ALL_FILTERS
+    return RowFilter(a.atoms | b.atoms)
+
+
+def _join(a: RowFilter, b: RowFilter) -> RowFilter:
+    """Least precise filter both refine: the atoms both sides carry (intersection)."""
+    if a.is_bottom:
+        return b
+    if b.is_bottom:
+        return a
+    return RowFilter(a.atoms & b.atoms)
+
+
+PREDICATE_FLOW_LATTICE: Lattice[RowFilter] = Lattice(
+    meet=_meet,
+    join=_join,
+    top=NO_FILTER,
+    bottom=ALL_FILTERS,
+)
+
+
+# --- the relation reducer ----------------------------------------------------
+#
+# The relation-algebra walk for row filters. It mirrors the uniqueness walk's job
+# (turn a derivation into an inferred annotation, recursing into referenced nodes)
+# but accumulates a filter rather than keys: a FROM carries the source's filter, a
+# WHERE conjoins, a projection renames the filter onto output names, and the shapes
+# that change row identity or blur columns (JOIN, UNION, GROUP BY) drop to top.
+
+# Resolves the accumulated filter of a base (non-CTE) table reference, by reading the
+# table's stamped SourceRef and recursing through the shared propagator.
+_BaseFilter = Callable[["exp.Table"], frozenset[Canon]]
+
+
+def _flow_reduce(
+    deriv: Expr,
+    _prop: Property[RowFilter, SourceRef],
+    recurse: Callable[[SourceRef], Annotation[RowFilter]],
+    _ctx: DepContext,
+    _default: Annotation[RowFilter],
+) -> Annotation[RowFilter]:
+    """Reduce a model's relational tree to its inferred row filter.
+
+    A base table resolves through ``recurse`` on its stamped ``SourceRef``, so the
+    upstream filter and its provisional taint flow in. CTEs and inline subqueries are
+    resolved structurally within the walk.
+    """
+    provisional = False
+
+    def base_filter(table: exp.Table) -> frozenset[Canon]:
+        nonlocal provisional
+        ref = source_ref_meta(table)
+        if ref is None:
+            return frozenset()
+        ann = recurse(ref)
+        provisional = provisional or ann.provisional
+        return ann.value.atoms
+
+    atoms = _FlowWalk(base_filter).scope_filter(deriv, cte_scope={})
+    opacity = Opacity.CONCRETE if atoms else Opacity.IMPLICIT
+    return Annotation(RowFilter(atoms), opacity, provisional=provisional)
+
+
+class _FlowWalk:
+    """Bottom-up row-filter inference over one relational tree.
+
+    ``base_filter`` resolves a base table's filter; CTEs and inline subqueries are
+    resolved structurally within the walk. A scope is carried only when it is a
+    single source with no join; everything else drops to the empty filter.
+    """
+
+    def __init__(self, base_filter: _BaseFilter) -> None:
+        self._base_filter = base_filter
+
+    def scope_filter(
+        self, node: Expr, *, cte_scope: Mapping[str, frozenset[Canon]]
+    ) -> frozenset[Canon]:
+        if isinstance(node, exp.Select):
+            return self._select(node, cte_scope=cte_scope)
+        return frozenset()  # UNION and anything else: row identity differs, drop to top
+
+    def _select(
+        self, sel: exp.Select, *, cte_scope: Mapping[str, frozenset[Canon]]
+    ) -> frozenset[Canon]:
+        local = dict(cte_scope)
+        with_ = sel.args.get("with_")
+        if isinstance(with_, exp.With):
+            for cte in with_.expressions:
+                if isinstance(cte, exp.CTE) and isinstance(cte.this, Expr):
+                    local[cte.alias_or_name] = self.scope_filter(cte.this, cte_scope=local)
+
+        from_ = sg.from_of(sel)
+        if from_ is None or not isinstance(from_.this, Expr):
+            return frozenset()
+        if sg.joins_of(sel):
+            return frozenset()  # multi-source: a bare-name atom could blur across sources
+        source = self._resolve_source(from_.this, cte_scope=local)
+        if source is None:
+            return frozenset()
+
+        group = sg.group_of(sel)
+        if group is not None and group.expressions:
+            return frozenset()  # GROUP BY changes row identity; the input filter no longer applies
+
+        where = sg.where_of(sel)
+        where_atoms: frozenset[Canon] = (
+            atoms_of(where.this)
+            if where is not None and isinstance(where.this, Expr)
+            else frozenset()
+        )
+        return _project_filter(sel, source | where_atoms)
+
+    def _resolve_source(
+        self, node: Expr, *, cte_scope: Mapping[str, frozenset[Canon]]
+    ) -> frozenset[Canon] | None:
+        if isinstance(node, exp.Table):
+            if node.name in cte_scope:
+                return cte_scope[node.name]
+            return self._base_filter(node)
+        if isinstance(node, exp.Subquery):
+            inner = node.this
+            if not isinstance(inner, Expr):
+                return None
+            return self.scope_filter(inner, cte_scope=cte_scope)
+        return None
+
+
+def _project_filter(sel: exp.Select, atoms: frozenset[Canon]) -> frozenset[Canon]:
+    """Map the scope's input-column atoms onto its output-column names.
+
+    Under a ``*`` every column passes through unchanged, so every atom carries
+    verbatim (a bare-boolean opaque atom included). Under an explicit projection a
+    comparison/``IN`` atom renames to the output name(s) its column appears under and
+    drops if its column has no image; an opaque atom drops, since its column is
+    unknown and cannot be tracked through the rename.
+    """
+    if _has_star(sel):
+        return atoms
+    rename = _explicit_rename(sel)
+    out: set[Canon] = set()
+    for atom in atoms:
+        if not isinstance(atom, CmpAtom | InAtom):
+            continue  # opaque atom: column unknown, cannot survive an explicit projection
+        col = atom_column(atom)
+        if col is None:
+            continue
+        for name in rename.get(col, ()):
+            out.add(rename_atom(atom, name))
+    return frozenset(out)
+
+
+def _has_star(sel: exp.Select) -> bool:
+    for proj in sel.expressions:
+        if isinstance(proj, exp.Star):
+            return True
+        if isinstance(proj, exp.Column) and isinstance(proj.this, exp.Star):
+            return True
+    return False
+
+
+def _explicit_rename(sel: exp.Select) -> Mapping[str, tuple[str, ...]]:
+    """Each input column's output name(s) under an explicit (star-free) projection.
+
+    An output name that more than one input column resolves to is ambiguous and is
+    dropped, since an atom renamed onto it could no longer be traced to one column.
+    """
+    raw: dict[str, list[str]] = {}
+    out_to_in: dict[str, set[str]] = {}
+    for proj in sel.expressions:
+        pair = _projection_pair(proj)
+        if pair is None:
+            continue
+        input_col, output_name = pair
+        raw.setdefault(input_col, []).append(output_name)
+        out_to_in.setdefault(output_name, set()).add(input_col)
+    ambiguous = {name for name, inputs in out_to_in.items() if len(inputs) > 1}
+    return {col: tuple(n for n in names if n not in ambiguous) for col, names in raw.items()}
+
+
+def _projection_pair(proj: Expr) -> tuple[str, str] | None:
+    """The ``(input column, output name)`` a projection induces, or ``None`` for a
+    shape with no single tractable input column (a computed expression, a star)."""
+    if isinstance(proj, exp.Alias) and isinstance(proj.this, exp.Column):
+        inner = proj.this
+        if isinstance(inner.this, exp.Star):
+            return None
+        return (sg.column_name(inner).lower(), proj.alias_or_name.lower())
+    if isinstance(proj, exp.Column) and not isinstance(proj.this, exp.Star):
+        name = sg.column_name(proj).lower()
+        return (name, name)
+    return None
+
+
+# --- the property ------------------------------------------------------------
+
+
+def _ground(_scope: SourceRef) -> Annotation[RowFilter]:
+    """A relation's filter is never declared, only derived, so every scope grounds to
+    the empty filter and the reducer supplies all information."""
+    return Annotation(NO_FILTER, Opacity.IMPLICIT)
+
+
+def predicate_flow_property() -> Property[RowFilter, SourceRef]:
+    """The predicate-flow property: each relation's accumulated row filter, inferred
+    by the relation reducer. Nothing grounds it (filters are derived), and atoms only
+    accumulate, so declared and inferred compose by meet (``reconcile_by_meet``). The
+    property carries its relation-algebra walk as ``reducer`` so the propagator
+    dispatches it without a global registry."""
+    return relation_property(
+        name="predicate_flow",
+        lattice=PREDICATE_FLOW_LATTICE,
+        operators={},
+        aggregates={},
+        ground=_ground,
+        reconcile_by_meet=True,
+        reducer=_flow_reduce,
+    )

--- a/src/dblect/lineage/properties/predicate_flow.py
+++ b/src/dblect/lineage/properties/predicate_flow.py
@@ -58,8 +58,7 @@ class RowFilter:
         return RowFilter(frozenset(atoms))
 
 
-# The empty filter: "no filter known", the value every relation grounds to and the
-# meet identity.
+# The value every relation grounds to ("no filter known"), and the meet identity.
 NO_FILTER: RowFilter = RowFilter(frozenset())
 
 # The formal universal element, present so the lattice is bounded; unreachable when
@@ -93,14 +92,12 @@ PREDICATE_FLOW_LATTICE: Lattice[RowFilter] = Lattice(
 
 # --- the relation reducer ----------------------------------------------------
 #
-# The relation-algebra walk for row filters. It mirrors the uniqueness walk's job
-# (turn a derivation into an inferred annotation, recursing into referenced nodes)
-# but accumulates a filter rather than keys: a FROM carries the source's filter, a
-# WHERE conjoins, a projection renames the filter onto output names, and the shapes
-# that change row identity or blur columns (JOIN, UNION, GROUP BY) drop to top.
+# The relation-algebra walk for row filters: the same shape as the uniqueness walk
+# (reduce a derivation to an inferred annotation, recursing into referenced nodes),
+# accumulating a filter rather than keys. The per-case rules are in the module
+# docstring; each case below carries the reason it carries or drops.
 
-# Resolves the accumulated filter of a base (non-CTE) table reference, by reading the
-# table's stamped SourceRef and recursing through the shared propagator.
+# Resolves a base (non-CTE) table's accumulated filter via its stamped SourceRef.
 _BaseFilter = Callable[["exp.Table"], frozenset[Canon]]
 
 
@@ -149,7 +146,7 @@ class _FlowWalk:
     ) -> frozenset[Canon]:
         if isinstance(node, exp.Select):
             return self._select(node, cte_scope=cte_scope)
-        return frozenset()  # UNION and anything else: row identity differs, drop to top
+        return frozenset()  # UNION (arms may differ) and other non-SELECT shapes carry nothing
 
     def _select(
         self, sel: exp.Select, *, cte_scope: Mapping[str, frozenset[Canon]]
@@ -212,7 +209,7 @@ def _project_filter(sel: exp.Select, atoms: frozenset[Canon]) -> frozenset[Canon
     out: set[Canon] = set()
     for atom in atoms:
         if not isinstance(atom, CmpAtom | InAtom):
-            continue  # opaque atom: column unknown, cannot survive an explicit projection
+            continue
         col = atom_column(atom)
         if col is None:
             continue

--- a/src/dblect/sql/_sqlglot.py
+++ b/src/dblect/sql/_sqlglot.py
@@ -37,6 +37,10 @@ def from_of(sel: exp.Select) -> exp.From | None:
     return cast("exp.From | None", sel.args.get("from_") or sel.args.get("from"))
 
 
+def where_of(sel: exp.Select) -> exp.Where | None:
+    return cast("exp.Where | None", sel.args.get("where"))
+
+
 def joins_of(sel: exp.Select) -> list[exp.Join]:
     return cast("list[exp.Join]", sel.args.get("joins") or [])
 

--- a/tests/lineage/test_predicate_flow.py
+++ b/tests/lineage/test_predicate_flow.py
@@ -1,0 +1,253 @@
+"""Predicate-flow propagation: the row filter every row of a relation satisfies.
+
+These pin the relation algebra at the contract boundary: build a manifest of
+sources and models, run the one propagator with the predicate-flow property, and
+read each relation's accumulated row filter. The rules under test are the sound
+ones: a ``WHERE`` conjoins, a passthrough carries the upstream filter, a consumer
+adds its own filter, a projection renames the filter's columns, and the shapes
+where row identity changes or the columns blur (``JOIN``, ``UNION``, ``GROUP BY``,
+a dropped column) drop conservatively to "no filter known".
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from dblect.lineage.builder import build_relation_graph
+from dblect.lineage.graph import SourceKind
+from dblect.lineage.predicate import Canon, atoms_of, parse_predicate
+from dblect.lineage.properties.predicate_flow import RowFilter, predicate_flow_property
+from dblect.lineage.property import propagate
+from dblect.manifest import Manifest, Node, ResourceType
+
+
+def _model(uid: str, sql: str) -> Node:
+    return Node(
+        unique_id=uid,
+        name=uid.split(".")[-1],
+        resource_type=ResourceType.MODEL,
+        fqn=(uid,),
+        package_name="shop",
+        schema="analytics",
+        raw_code=None,
+        compiled_code=sql,
+        original_file_path=None,
+        columns={},
+        constraints=(),
+    )
+
+
+def _source(uid: str) -> Node:
+    return Node(
+        unique_id=uid,
+        name=uid.split(".")[-1],
+        resource_type=ResourceType.SOURCE,
+        fqn=(uid,),
+        package_name="shop",
+        schema="raw",
+        raw_code=None,
+        compiled_code=None,
+        original_file_path=None,
+        columns={},
+    )
+
+
+def _flow(*nodes: Node) -> Mapping[str, RowFilter]:
+    """Build a manifest, propagate predicate-flow, and return each model's filter
+    keyed by unique_id."""
+    manifest = Manifest(
+        schema_version="v12",
+        adapter_type="duckdb",
+        nodes={n.unique_id: n for n in nodes},
+    )
+    result = build_relation_graph(manifest)
+    anns = propagate(result.graph, predicate_flow_property())
+    return {ref.unique_id: ann.value for ref, ann in anns.items() if ref.kind is SourceKind.MODEL}
+
+
+def _atoms(sql: str) -> frozenset[Canon]:
+    """The atom set a predicate string carries, the form the flow value holds."""
+    parsed = parse_predicate(sql, dialect="duckdb")
+    assert parsed is not None, f"could not parse predicate: {sql!r}"
+    return atoms_of(parsed)
+
+
+_ORDERS = "source.shop.raw.orders"
+
+
+# --- the filter forms ------------------------------------------------------------
+
+
+def test_passthrough_without_a_filter_knows_nothing() -> None:
+    flow = _flow(_source(_ORDERS), _model("model.shop.m", "SELECT * FROM orders"))
+    assert flow["model.shop.m"].atoms == frozenset()
+
+
+def test_where_becomes_the_filter() -> None:
+    flow = _flow(
+        _source(_ORDERS), _model("model.shop.m", "SELECT * FROM orders WHERE country = 'US'")
+    )
+    assert flow["model.shop.m"].atoms == _atoms("country = 'US'")
+
+
+def test_in_filter_carries() -> None:
+    flow = _flow(
+        _source(_ORDERS),
+        _model("model.shop.m", "SELECT * FROM orders WHERE region IN ('US', 'CA')"),
+    )
+    assert flow["model.shop.m"].atoms == _atoms("region IN ('US', 'CA')")
+
+
+def test_bare_boolean_carries_under_a_star() -> None:
+    # A bare boolean is opaque to interval reasoning, but under ``SELECT *`` every
+    # column passes through unchanged, so the atom is carried verbatim.
+    flow = _flow(_source(_ORDERS), _model("model.shop.m", "SELECT * FROM orders WHERE active"))
+    assert flow["model.shop.m"].atoms == _atoms("active")
+
+
+# --- flow across models ----------------------------------------------------------
+
+
+def test_filter_flows_downstream_through_a_passthrough() -> None:
+    flow = _flow(
+        _source(_ORDERS),
+        _model("model.shop.a", "SELECT * FROM orders WHERE country = 'US'"),
+        _model("model.shop.b", "SELECT * FROM a"),
+    )
+    assert flow["model.shop.b"].atoms == _atoms("country = 'US'")
+
+
+def test_consumer_conjoins_its_own_filter() -> None:
+    flow = _flow(
+        _source(_ORDERS),
+        _model("model.shop.a", "SELECT * FROM orders WHERE country = 'US'"),
+        _model("model.shop.b", "SELECT * FROM a WHERE amount > 0"),
+    )
+    assert flow["model.shop.b"].atoms == _atoms("country = 'US' AND amount > 0")
+
+
+# --- projection rename and drop --------------------------------------------------
+
+
+def test_projection_renames_the_filter_columns() -> None:
+    flow = _flow(
+        _source(_ORDERS),
+        _model("model.shop.m", "SELECT country AS region, amount FROM orders WHERE country = 'US'"),
+    )
+    assert flow["model.shop.m"].atoms == _atoms("region = 'US'")
+
+
+def test_filter_on_a_dropped_column_is_lost() -> None:
+    # ``country`` is filtered but not projected (no star), so the atom has no image
+    # in the output columns and drops.
+    flow = _flow(
+        _source(_ORDERS),
+        _model("model.shop.m", "SELECT amount FROM orders WHERE country = 'US'"),
+    )
+    assert flow["model.shop.m"].atoms == frozenset()
+
+
+# --- shapes that drop conservatively ---------------------------------------------
+
+
+def test_join_drops_the_filter() -> None:
+    flow = _flow(
+        _source(_ORDERS),
+        _source("source.shop.raw.customers"),
+        _model(
+            "model.shop.m",
+            "SELECT * FROM orders o JOIN customers c ON o.cid = c.id WHERE o.country = 'US'",
+        ),
+    )
+    assert flow["model.shop.m"].atoms == frozenset()
+
+
+def test_group_by_drops_the_filter() -> None:
+    flow = _flow(
+        _source(_ORDERS),
+        _model(
+            "model.shop.m",
+            "SELECT country, count(*) AS n FROM orders WHERE country = 'US' GROUP BY country",
+        ),
+    )
+    assert flow["model.shop.m"].atoms == frozenset()
+
+
+def test_union_drops_the_filter() -> None:
+    flow = _flow(
+        _source(_ORDERS),
+        _source("source.shop.raw.archive"),
+        _model(
+            "model.shop.m",
+            "SELECT * FROM orders WHERE country = 'US' "
+            "UNION ALL SELECT * FROM archive WHERE country = 'US'",
+        ),
+    )
+    assert flow["model.shop.m"].atoms == frozenset()
+
+
+# --- CTEs and inline subqueries accumulate for free ------------------------------
+
+
+def test_cte_accumulates_the_filter() -> None:
+    flow = _flow(
+        _source(_ORDERS),
+        _model(
+            "model.shop.m",
+            "WITH us AS (SELECT * FROM orders WHERE country = 'US') SELECT * FROM us",
+        ),
+    )
+    assert flow["model.shop.m"].atoms == _atoms("country = 'US'")
+
+
+def test_inline_subquery_accumulates_the_filter() -> None:
+    flow = _flow(
+        _source(_ORDERS),
+        _model(
+            "model.shop.m",
+            "SELECT * FROM (SELECT * FROM orders WHERE country = 'US') s",
+        ),
+    )
+    assert flow["model.shop.m"].atoms == _atoms("country = 'US'")
+
+
+def test_cte_filter_conjoins_with_the_outer_filter() -> None:
+    flow = _flow(
+        _source(_ORDERS),
+        _model(
+            "model.shop.m",
+            "WITH us AS (SELECT * FROM orders WHERE country = 'US') "
+            "SELECT * FROM us WHERE amount > 0",
+        ),
+    )
+    assert flow["model.shop.m"].atoms == _atoms("country = 'US' AND amount > 0")
+
+
+# --- accumulation invariant (PBT) ------------------------------------------------
+
+
+@given(
+    st.lists(
+        st.tuples(st.sampled_from((">", "<", ">=", "<=", "=")), st.integers(-3, 3)),
+        min_size=1,
+        max_size=5,
+    )
+)
+def test_filter_accumulates_down_a_passthrough_chain(specs: list[tuple[str, int]]) -> None:
+    """A chain of ``SELECT * FROM prev WHERE <atom>`` models accumulates the union
+    of every link's atom: a star passthrough neither renames nor drops, so the
+    bottom model's filter is exactly the conjunction of the whole chain."""
+    src = _source("source.shop.raw.s")
+    atom_sqls = [f"c{i} {op} {lit}" for i, (op, lit) in enumerate(specs)]
+    models: list[Node] = []
+    prev = "s"
+    for i, atom_sql in enumerate(atom_sqls):
+        uid = f"model.shop.m{i}"
+        models.append(_model(uid, f"SELECT * FROM {prev} WHERE {atom_sql}"))
+        prev = f"m{i}"
+    flow = _flow(src, *models)
+    expected: frozenset[Canon] = frozenset[Canon]().union(*(_atoms(s) for s in atom_sqls))
+    assert flow[f"model.shop.m{len(specs) - 1}"].atoms == expected


### PR DESCRIPTION
Works toward #43. **Stacked on #55** (base is `conditional-facts-43`, not `main`) — the diff is only this branch's work; retarget to `main` once #55 lands.

This is the first of two pieces for stage 3 (activation). It ships the **predicate-flow property**: the shared substrate that carries, per relation scope, the row filter every one of its rows is known to satisfy. The activation *wiring* (stage 3b) consumes it in a follow-up stacked PR.

## The property

A relation-scoped property (mirrors `uniqueness`) whose value is the conjunction of atoms, in the relation's **output** column names, that hold of every row. The relation reducer:

- a `WHERE` **conjoins** its atoms;
- a passthrough **carries** the upstream filter, and a consumer's own `WHERE` **adds** to it;
- a **projection renames** the filter's columns (`country = 'US'` becomes `region = 'US'` after `country AS region`), and drops an atom whose column has no image in the output;
- **CTEs and inline subqueries accumulate for free** — the relation walk already recurses through them.

Posture is silent-when-unproven: a `JOIN` (a bare-name atom could blur across sources), a `UNION` (arms may carry different filters), a `GROUP BY` (row identity changes), and a filtered-but-dropped column all yield the empty filter (`top`) rather than a guess.

The value **reuses the predicate engine's typed atoms** (from #55's `predicate.py`), so the filter is rigorously shaped and feeds `implies` directly when activation lands. The lattice orders by precision: `meet` unions atom sets, `join` (confluence) keeps the atoms both branches carry, `top` is the empty set. Nothing grounds the property (filters are derived, never declared), so `ground` returns `top` everywhere and the reducer does all the work.

This property is **not yet registered on the audit path** — there is no consumer until activation (stage 3b), so the audit's behavior is unchanged.

## Stage 3b (next PR) — activation

A captured conditional `Fact` (#55) promotes to a real annotation at any scope whose flowed filter `implies` its predicate. Per the design discussion, activation is consumed **inference-time, in the reducer**: uniqueness and nullability read this flow via `DepContext` (they `depends_on` predicate-flow) and call a generic `activate(conditional_facts, flow)` helper during their walk, so it fires at the realistic downstream consumer and establishes the same "read the flow at this scope" path that type-refinement and contract validation will reuse.

Named non-goals here (deferred to keep this cut sound and small): JOIN-side filter carrying, and UNION-arm intersection. Both stay conservative (silent) for now.

## Engine surface added

`atoms_of` (lift a `WHERE` into atoms), `atom_column` / `rename_atom` (rename an atom's column through a projection), and a `where_of` accessor. These operate on the same typed atom forms the entailment core already reasons about.

## Testing

Boundary tests for every reducer rule (conjoin, downstream flow, consumer-adds, projection rename, dropped column, JOIN/UNION/GROUP BY drop, CTE and inline-subquery accumulation, `IN` and bare-boolean carry) plus a PBT pinning the accumulation invariant down a passthrough chain. Full suite green (367), strict ruff + ruff format + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)