### PR TITLE
lineage: activate conditional uniqueness facts (#43, stage 3b)

### DIFF
--- a/src/dblect/lineage/predicate.py
+++ b/src/dblect/lineage/predicate.py
@@ -177,6 +177,33 @@ def implies(strong: Expr, weak: Expr) -> bool:
     return _entails(cmp_atoms, in_sets, weak)
 
 
+def entails(strong_atoms: frozenset[Canon], weak: Expr) -> bool:
+    """Whether the conjunction of ``strong_atoms`` implies ``weak``.
+
+    The atom-set form of :func:`implies`, for a caller (the predicate-flow activation
+    step) that already holds a relation's accumulated filter as atoms. ``strong`` is a
+    conjunction, so there is no disjunctive-strong case to distribute; ``weak`` is
+    still decomposed by its boolean structure.
+    """
+    weak = _unparen(weak)
+    if isinstance(weak, exp.And):
+        return entails(strong_atoms, weak.left) and entails(strong_atoms, weak.right)
+    if isinstance(weak, exp.Or):
+        return entails(strong_atoms, weak.left) or entails(strong_atoms, weak.right)
+    return entails_atoms(strong_atoms, frozenset({_canon(weak)}))
+
+
+def entails_atoms(strong_atoms: frozenset[Canon], weak_atoms: frozenset[Canon]) -> bool:
+    """Whether the conjunction of ``strong_atoms`` implies every atom of ``weak_atoms``.
+
+    Each weak atom is entailed when ``strong`` carries it verbatim (the syntactic case,
+    the only route for an :class:`OpaqueAtom`) or when the collected interval / ``IN``
+    constraints on its term entail it.
+    """
+    cmp_atoms, in_sets = _collect_canon(strong_atoms)
+    return all(w in strong_atoms or _entails_atom(cmp_atoms, in_sets, w) for w in weak_atoms)
+
+
 # --- atom extraction and column renaming -----------------------------------------
 #
 # The predicate-flow property carries a relation's accumulated row filter as a set
@@ -351,25 +378,55 @@ def _collect(
     return cmp_atoms, in_sets
 
 
+def _collect_canon(
+    atoms: frozenset[Canon],
+) -> tuple[dict[Term, list[tuple[Op, Lit]]], dict[Term, frozenset[Lit]]]:
+    """The same fold as :func:`_collect`, over already-canonicalised atoms. An
+    :class:`OpaqueAtom` contributes nothing to interval reasoning; it is matched only
+    syntactically by the caller."""
+    cmp_atoms: dict[Term, list[tuple[Op, Lit]]] = {}
+    in_sets: dict[Term, frozenset[Lit]] = {}
+    for atom in atoms:
+        if isinstance(atom, CmpAtom):
+            cmp_atoms.setdefault(atom.term, []).append((atom.op, atom.lit))
+        elif isinstance(atom, InAtom):
+            prior = in_sets.get(atom.term)
+            in_sets[atom.term] = atom.values if prior is None else (prior & atom.values)
+    return cmp_atoms, in_sets
+
+
 def _entails(
     cmp_atoms: dict[Term, list[tuple[Op, Lit]]],
     in_sets: dict[Term, frozenset[Lit]],
     weak: Expr,
 ) -> bool:
-    atom = _as_atom(weak)
-    if atom is not None:
-        if _interval_entails(cmp_atoms.get(atom.term, []), atom.op, atom.lit):
+    atom = _as_atom(weak) or _as_in(weak)
+    return atom is not None and _entails_atom(cmp_atoms, in_sets, atom)
+
+
+def _entails_atom(
+    cmp_atoms: dict[Term, list[tuple[Op, Lit]]],
+    in_sets: dict[Term, frozenset[Lit]],
+    weak: Canon,
+) -> bool:
+    """Whether the collected constraints entail one canonical ``weak`` atom. An
+    :class:`OpaqueAtom` is never entailed here; it only matches by membership."""
+    if isinstance(weak, CmpAtom):
+        if _interval_entails(cmp_atoms.get(weak.term, []), weak.op, weak.lit):
             return True
-        in_set = in_sets.get(atom.term)
-        return in_set is not None and _set_entails(in_set, atom.op, atom.lit)
-    in_atom = _as_in(weak)
-    if in_atom is not None:
-        have = in_sets.get(in_atom.term)
-        if have is not None and have <= in_atom.values:
+        in_set = in_sets.get(weak.term)
+        return in_set is not None and _set_entails(in_set, weak.op, weak.lit)
+    if isinstance(weak, InAtom):
+        have = in_sets.get(weak.term)
+        if have is not None and have <= weak.values:
             return True
-        iv = _interval(cmp_atoms.get(in_atom.term, []))
-        if iv is not None and _is_point(iv) and iv.lo is not None:
-            return Lit(iv.kind, iv.lo) in in_atom.values
+        iv = _interval(cmp_atoms.get(weak.term, []))
+        return (
+            iv is not None
+            and _is_point(iv)
+            and iv.lo is not None
+            and Lit(iv.kind, iv.lo) in weak.values
+        )
     return False
 
 

--- a/src/dblect/lineage/predicate.py
+++ b/src/dblect/lineage/predicate.py
@@ -23,6 +23,7 @@ pins it directly with PBTs that sample concrete worlds across the fragment
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from decimal import Decimal, InvalidOperation
 from enum import StrEnum
@@ -177,31 +178,32 @@ def implies(strong: Expr, weak: Expr) -> bool:
     return _entails(cmp_atoms, in_sets, weak)
 
 
-def entails(strong_atoms: frozenset[Canon], weak: Expr) -> bool:
-    """Whether the conjunction of ``strong_atoms`` implies ``weak``.
+def entailment_checker(strong_atoms: frozenset[Canon]) -> Callable[[frozenset[Canon]], bool]:
+    """A tester for "does ``strong_atoms`` entail this weak atom-set", with the strong
+    side's interval / ``IN`` constraints folded once.
 
-    The atom-set form of :func:`implies`, for a caller (the predicate-flow activation
-    step) that already holds a relation's accumulated filter as atoms. ``strong`` is a
-    conjunction, so there is no disjunctive-strong case to distribute; ``weak`` is
-    still decomposed by its boolean structure.
+    The activation step entails many conditional predicates against one relation's
+    accumulated filter, so collecting that filter's constraints per predicate is wasted
+    work. This folds the strong side once and returns a closure over many weak sets.
+    Each weak atom is entailed when ``strong`` carries it verbatim (the syntactic case,
+    the only route for an :class:`OpaqueAtom`) or when the collected constraints on its
+    term entail it.
     """
-    weak = _unparen(weak)
-    if isinstance(weak, exp.And):
-        return entails(strong_atoms, weak.left) and entails(strong_atoms, weak.right)
-    if isinstance(weak, exp.Or):
-        return entails(strong_atoms, weak.left) or entails(strong_atoms, weak.right)
-    return entails_atoms(strong_atoms, frozenset({_canon(weak)}))
+    cmp_atoms, in_sets = _collect_canon(strong_atoms)
+
+    def check(weak_atoms: frozenset[Canon]) -> bool:
+        return all(w in strong_atoms or _entails_atom(cmp_atoms, in_sets, w) for w in weak_atoms)
+
+    return check
 
 
 def entails_atoms(strong_atoms: frozenset[Canon], weak_atoms: frozenset[Canon]) -> bool:
     """Whether the conjunction of ``strong_atoms`` implies every atom of ``weak_atoms``.
 
-    Each weak atom is entailed when ``strong`` carries it verbatim (the syntactic case,
-    the only route for an :class:`OpaqueAtom`) or when the collected interval / ``IN``
-    constraints on its term entail it.
+    The one-shot form of :func:`entailment_checker`, for a caller entailing a single
+    weak set.
     """
-    cmp_atoms, in_sets = _collect_canon(strong_atoms)
-    return all(w in strong_atoms or _entails_atom(cmp_atoms, in_sets, w) for w in weak_atoms)
+    return entailment_checker(strong_atoms)(weak_atoms)
 
 
 # --- atom extraction and column renaming -----------------------------------------

--- a/src/dblect/lineage/properties/activation.py
+++ b/src/dblect/lineage/properties/activation.py
@@ -1,0 +1,41 @@
+"""Generic activation of conditional facts against a relation's accumulated filter.
+
+A captured conditional fact holds only over the rows matching its predicate. It
+activates at a scope whose flowed row filter (the predicate-flow property) *implies*
+that predicate: the scope's rows are then a subset of the fact's rows, so a claim
+that survives row removal (a candidate key, a ``NOT_NULL``) carries unconditionally.
+
+This step owns no property. A property supplies its value-lattice ``meet`` so an
+activated value folds into the scope's annotation the same way a declared one would:
+uniqueness meets a promoted candidate key into its key set, nullability would meet a
+promoted ``NOT_NULL``, and a future axis likewise.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from typing import TypeVar
+
+from dblect.lineage.predicate import Canon, entails_atoms
+
+K = TypeVar("K")
+
+
+def activate(
+    base: K,
+    conditionals: Iterable[tuple[K, frozenset[Canon]]],
+    flow_atoms: frozenset[Canon],
+    meet: Callable[[K, K], K],
+) -> K:
+    """Fold every conditional value whose predicate ``flow_atoms`` implies into ``base``.
+
+    Each conditional is a ``(value, predicate)`` pair; where the accumulated filter
+    implies the predicate, the value joins ``base`` by ``meet``. A conditional whose
+    predicate is not implied leaves ``base`` untouched, so activation only ever adds
+    information and never over-claims.
+    """
+    result = base
+    for value, predicate in conditionals:
+        if entails_atoms(flow_atoms, predicate):
+            result = meet(result, value)
+    return result

--- a/src/dblect/lineage/properties/activation.py
+++ b/src/dblect/lineage/properties/activation.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from collections.abc import Callable, Iterable
 from typing import TypeVar
 
-from dblect.lineage.predicate import Canon, entails_atoms
+from dblect.lineage.predicate import Canon, entailment_checker
 
 K = TypeVar("K")
 
@@ -32,10 +32,12 @@ def activate(
     Each conditional is a ``(value, predicate)`` pair; where the accumulated filter
     implies the predicate, the value joins ``base`` by ``meet``. A conditional whose
     predicate is not implied leaves ``base`` untouched, so activation only ever adds
-    information and never over-claims.
+    information and never over-claims. The filter's constraints are folded once for the
+    whole batch, since one relation entails its many conditionals against one flow.
     """
+    entails = entailment_checker(flow_atoms)
     result = base
     for value, predicate in conditionals:
-        if entails_atoms(flow_atoms, predicate):
+        if entails(predicate):
             result = meet(result, value)
     return result

--- a/src/dblect/lineage/properties/uniqueness.py
+++ b/src/dblect/lineage/properties/uniqueness.py
@@ -46,6 +46,9 @@ from dblect.lineage.facts.model import (
 )
 from dblect.lineage.facts.property import DepContext, FactDiscoverer, Property, relation_property
 from dblect.lineage.graph import SourceKind, SourceRef, source_ref_meta
+from dblect.lineage.predicate import Canon, atoms_of, parse_predicate
+from dblect.lineage.properties.activation import activate
+from dblect.lineage.properties.predicate_flow import RowFilter
 from dblect.manifest import (
     ConstraintSpec,
     ConstraintType,
@@ -62,18 +65,36 @@ Key = frozenset[str]
 
 
 @dataclass(frozen=True, slots=True)
+class ConditionalKey:
+    """A candidate key that holds only over the rows matching ``predicate``.
+
+    A ``where``-filtered ``unique`` test grounds one of these rather than an
+    unconditional key. It is carried (never folded into ``keys``) until a scope's
+    flowed row filter implies ``predicate``, at which point activation promotes it.
+    ``predicate`` is the test's ``where`` parsed to the engine's atoms, so it feeds
+    :func:`~dblect.lineage.predicate.entails_atoms` directly.
+    """
+
+    key: Key
+    predicate: frozenset[Canon]
+
+
+@dataclass(frozen=True, slots=True)
 class CandidateKeySet:
     """The set of candidate keys a relation is known to be unique on.
 
-    ``keys`` holds the known keys; the empty set is the lattice ``top`` ("no key
-    known"). ``is_bottom`` marks the formal universal element (the lattice
-    ``bottom``): it absorbs under ``meet`` and is the identity under ``join``, and
-    no resolution of real declarations reaches it, since uniqueness claims only
-    ever union. Equality is structural, so ``CandidateKeySet(frozenset())`` (top)
-    and the bottom sentinel are distinct values.
+    ``keys`` holds the unconditionally known keys; the empty set is the lattice
+    ``top`` ("no key known"). ``conditional`` carries keys that hold only over a row
+    filter, captured for activation and never counted among ``keys`` until promoted.
+    ``is_bottom`` marks the formal universal element (the lattice ``bottom``): it
+    absorbs under ``meet`` and is the identity under ``join``, and no resolution of
+    real declarations reaches it, since uniqueness claims only ever union. Equality
+    is structural, so ``CandidateKeySet(frozenset())`` (top) and the bottom sentinel
+    are distinct values.
     """
 
     keys: frozenset[Key]
+    conditional: frozenset[ConditionalKey] = frozenset()
     is_bottom: bool = False
 
     @staticmethod
@@ -92,18 +113,20 @@ ALL_KEYS: CandidateKeySet = CandidateKeySet(frozenset(), is_bottom=True)
 
 
 def _meet(a: CandidateKeySet, b: CandidateKeySet) -> CandidateKeySet:
-    """Most precise value consistent with both: union of the known keys.
+    """Most precise value consistent with both: union of the known keys (and of the
+    carried conditional keys, which also only ever accumulate).
 
     Bottom annihilates (it already "knows" every key), so a meet touching bottom
     stays bottom.
     """
     if a.is_bottom or b.is_bottom:
         return ALL_KEYS
-    return CandidateKeySet(a.keys | b.keys)
+    return CandidateKeySet(a.keys | b.keys, a.conditional | b.conditional)
 
 
 def _join(a: CandidateKeySet, b: CandidateKeySet) -> CandidateKeySet:
-    """Least precise value both refine: the keys both sides carry (intersection).
+    """Least precise value both refine: the keys both sides carry (intersection),
+    conditional keys likewise.
 
     Bottom is the identity (it refines nothing finer than the other side), so a
     join with bottom returns the other operand.
@@ -112,7 +135,7 @@ def _join(a: CandidateKeySet, b: CandidateKeySet) -> CandidateKeySet:
         return b
     if b.is_bottom:
         return a
-    return CandidateKeySet(a.keys & b.keys)
+    return CandidateKeySet(a.keys & b.keys, a.conditional & b.conditional)
 
 
 UNIQUENESS_LATTICE: Lattice[CandidateKeySet] = Lattice(
@@ -650,7 +673,79 @@ def uniqueness_property(
         lattice=UNIQUENESS_LATTICE,
         operators={},
         aggregates={},
-        ground=grounding(facts, opaque=set(), lat=UNIQUENESS_LATTICE),
+        ground=_grounding_with_conditional(facts),
         reconcile_by_meet=True,
         reducer=_relation_reduce,
     )
+
+
+def _grounding_with_conditional(
+    facts: Mapping[SourceRef, tuple[Fact[CandidateKeySet, SourceRef], ...]],
+) -> Callable[[SourceRef], Annotation[CandidateKeySet]]:
+    """The shared grounding, extended to carry each scope's conditional keys.
+
+    The shared ``grounding`` folds only unconditional facts, so a ``where``-filtered
+    ``unique`` would ground nothing. Here those conditional facts become the value's
+    ``conditional`` payload, marked CONCRETE so reconcile keeps it (an IMPLICIT
+    grounded value is discarded in favour of the inferred one). The payload rides
+    along until activation promotes it; it never counts as an unconditional key.
+    """
+    base = grounding(facts, opaque=set(), lat=UNIQUENESS_LATTICE)
+    conditional = _conditional_by_scope(facts)
+
+    def ground(scope: SourceRef) -> Annotation[CandidateKeySet]:
+        ann = base(scope)
+        cond = conditional.get(scope)
+        if cond is None or ann.opacity is Opacity.EXPLICIT:
+            return ann
+        return Annotation(CandidateKeySet(ann.value.keys, cond), Opacity.CONCRETE, ann.provisional)
+
+    return ground
+
+
+def _conditional_by_scope(
+    facts: Mapping[SourceRef, tuple[Fact[CandidateKeySet, SourceRef], ...]],
+) -> dict[SourceRef, frozenset[ConditionalKey]]:
+    """The conditional candidate keys captured per scope, with each test's ``where``
+    parsed to atoms. A predicate that does not parse carries no information, so its
+    key is dropped rather than activated on a guess."""
+    out: dict[SourceRef, frozenset[ConditionalKey]] = {}
+    for scope, bucket in facts.items():
+        cks: set[ConditionalKey] = set()
+        for fact in bucket:
+            if fact.condition is None:
+                continue
+            parsed = parse_predicate(fact.condition.sql)
+            if parsed is None:
+                continue
+            predicate = atoms_of(parsed)
+            cks.update(ConditionalKey(key, predicate) for key in fact.value.keys)
+        if cks:
+            out[scope] = frozenset(cks)
+    return out
+
+
+def activate_conditional(
+    keys: Mapping[SourceRef, Annotation[CandidateKeySet]],
+    flow: Mapping[SourceRef, Annotation[RowFilter]],
+) -> dict[SourceRef, CandidateKeySet]:
+    """Promote each relation's conditional keys whose predicate its flowed filter
+    implies, leaving the carried conditional payload in place for scopes downstream.
+
+    The promoted key folds in by the uniqueness ``meet`` (a union), exactly as a
+    declared key would, so a relation that defines its own filter and carries a
+    matching ``where``-filtered ``unique`` gains that key unconditionally.
+    """
+    out: dict[SourceRef, CandidateKeySet] = {}
+    for ref, ann in keys.items():
+        value = ann.value
+        flow_ann = flow.get(ref)
+        flow_atoms = flow_ann.value.atoms if flow_ann is not None else frozenset[Canon]()
+        promoted = activate(
+            value,
+            ((CandidateKeySet.of(ck.key), ck.predicate) for ck in value.conditional),
+            flow_atoms,
+            _meet,
+        )
+        out[ref] = promoted
+    return out

--- a/src/dblect/lineage/property.py
+++ b/src/dblect/lineage/property.py
@@ -88,6 +88,7 @@ def propagate(
     prop: Property[K, S],
     *,
     dep_context: DepContext = _NULL_DEP_CONTEXT,
+    subjects: Iterable[S] | None = None,
 ) -> Mapping[S, Annotation[K]]:
     """Compute ``prop``'s flow annotation for every subject in ``graph``.
 
@@ -99,6 +100,13 @@ def propagate(
     triggered. A property carries its own reducer (relation scope) or falls back
     to the generic column reducer. Everything else here is shared by column- and
     relation-scoped properties alike.
+
+    ``subjects`` restricts the annotated set to a seed set; memoised recursion still
+    pulls in each seed's upstreams, so the returned map covers the seeds and
+    everything they transitively read, and nothing else. A caller that needs the
+    property only at a few scopes (activation reads predicate-flow only where
+    conditional facts live) passes those to skip the rest of the graph. The default
+    annotates every subject.
 
     Memoised per subject, so each is annotated once regardless of how many
     downstream paths touch it. A defensive cycle guard returns the property's
@@ -139,7 +147,7 @@ def propagate(
         finally:
             in_progress.discard(subject)
 
-    for subject in graph.subjects():
+    for subject in graph.subjects() if subjects is None else subjects:
         annotate(subject)
     return annotations
 

--- a/src/dblect/uniqueness/detector.py
+++ b/src/dblect/uniqueness/detector.py
@@ -24,11 +24,12 @@ import sqlglot.expressions as exp
 from sqlglot import Expr
 
 from dblect.lineage.builder import build_relation_graph
-from dblect.lineage.facts.model import Annotation
 from dblect.lineage.graph import SourceKind, SourceRef
+from dblect.lineage.properties.predicate_flow import predicate_flow_property
 from dblect.lineage.properties.uniqueness import (
     CandidateKeySet,
     Key,
+    activate_conditional,
     relation_scope_keys,
     uniqueness_property,
 )
@@ -175,8 +176,10 @@ def make_fact_grounded_detectors(
     most once per tree no matter how many detectors consume it.
     """
     graph = build_relation_graph(manifest, dialect=dialect, parsed=parsed).graph
-    anns = propagate(graph, uniqueness_property(manifest))
-    model_keys = _model_keys_by_name(manifest, anns)
+    keys = propagate(graph, uniqueness_property(manifest))
+    flow = propagate(graph, predicate_flow_property())
+    activated = activate_conditional(keys, flow)
+    model_keys = _model_keys_by_name(manifest, activated)
     cache: dict[int, ScopeIndex] = {}
 
     def scope_index(tree: Expr) -> ScopeIndex:
@@ -198,7 +201,7 @@ def make_fact_grounded_detectors(
 
 
 def _model_keys_by_name(
-    manifest: Manifest, anns: Mapping[SourceRef, Annotation[CandidateKeySet]]
+    manifest: Manifest, anns: Mapping[SourceRef, CandidateKeySet]
 ) -> dict[str, frozenset[Key]]:
     """Index propagated keys by the relation name as it appears in compiled SQL.
 
@@ -211,12 +214,12 @@ def _model_keys_by_name(
     """
     by_name: dict[str, frozenset[Key]] = {}
     models: dict[str, frozenset[Key]] = {}
-    for ref, ann in anns.items():
+    for ref, cks in anns.items():
         node = manifest.nodes.get(ref.unique_id)
         if node is None:
             continue
         target = models if ref.kind is SourceKind.MODEL else by_name
-        target[node.identifier or node.name] = ann.value.keys
+        target[node.identifier or node.name] = cks.keys
     by_name.update(models)
     return by_name
 

--- a/src/dblect/uniqueness/detector.py
+++ b/src/dblect/uniqueness/detector.py
@@ -177,7 +177,11 @@ def make_fact_grounded_detectors(
     """
     graph = build_relation_graph(manifest, dialect=dialect, parsed=parsed).graph
     keys = propagate(graph, uniqueness_property(manifest))
-    flow = propagate(graph, predicate_flow_property())
+    # Predicate-flow is consulted only where a conditional key waits to activate, so
+    # seed the flow pass with those scopes and let it pull in their upstreams rather
+    # than walking every relation in the graph.
+    conditional_scopes = [ref for ref, ann in keys.items() if ann.value.conditional]
+    flow = propagate(graph, predicate_flow_property(), subjects=conditional_scopes)
     activated = activate_conditional(keys, flow)
     model_keys = _model_keys_by_name(manifest, activated)
     cache: dict[int, ScopeIndex] = {}

--- a/tests/lineage/test_conditional_activation.py
+++ b/tests/lineage/test_conditional_activation.py
@@ -115,6 +115,32 @@ def test_conditional_key_activates_under_a_narrower_filter() -> None:
     assert _key("id") in res["model.shop.dim"].keys
 
 
+def test_conditional_key_activates_when_a_cte_carries_the_filter() -> None:
+    # The filter sits in a CTE, not the outer WHERE. Flow accumulates through CTEs
+    # for free, so the model's flow still implies the predicate.
+    res = _activated(
+        _source("source.shop.raw.orders"),
+        _model(
+            "model.shop.dim",
+            "WITH a AS (SELECT * FROM orders WHERE active) SELECT * FROM a",
+        ),
+        _unique("test.shop.u", column="id", target="model.shop.dim", where="active"),
+    )
+    assert _key("id") in res["model.shop.dim"].keys
+
+
+def test_conditional_key_activates_when_an_inline_subquery_carries_the_filter() -> None:
+    res = _activated(
+        _source("source.shop.raw.orders"),
+        _model(
+            "model.shop.dim",
+            "SELECT * FROM (SELECT * FROM orders WHERE active) s",
+        ),
+        _unique("test.shop.u", column="id", target="model.shop.dim", where="active"),
+    )
+    assert _key("id") in res["model.shop.dim"].keys
+
+
 def test_conditional_key_stays_conditional_without_a_matching_filter() -> None:
     res = _activated(
         _source("source.shop.raw.orders"),

--- a/tests/lineage/test_conditional_activation.py
+++ b/tests/lineage/test_conditional_activation.py
@@ -1,0 +1,189 @@
+"""Activation of conditional uniqueness facts against the predicate flow.
+
+A ``where``-filtered ``unique`` test grounds a *conditional* key: captured, carried,
+but never counted as an unconditional key until a scope's accumulated row filter
+implies the test's predicate. These pin that promotion at the propagation boundary:
+build a manifest, propagate uniqueness and predicate-flow, run activation, and read
+each relation's keys. A relation that defines its own filter and carries a matching
+conditional ``unique`` gains the key; one whose filter does not imply the predicate
+keeps the key conditional (carried, not promoted).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from dblect.lineage.builder import build_relation_graph
+from dblect.lineage.graph import SourceKind
+from dblect.lineage.properties.predicate_flow import predicate_flow_property
+from dblect.lineage.properties.uniqueness import (
+    CandidateKeySet,
+    Key,
+    activate_conditional,
+    uniqueness_property,
+)
+from dblect.lineage.property import propagate
+from dblect.manifest import DbtTestMetadata, Manifest, Node, ResourceType
+from dblect.sql import FindingKind, parse_sql
+from dblect.uniqueness.detector import make_fact_grounded_detectors
+
+
+def _model(uid: str, sql: str) -> Node:
+    return Node(
+        unique_id=uid,
+        name=uid.split(".")[-1],
+        resource_type=ResourceType.MODEL,
+        fqn=(uid,),
+        package_name="shop",
+        schema="analytics",
+        raw_code=None,
+        compiled_code=sql,
+        original_file_path=None,
+        columns={},
+        constraints=(),
+    )
+
+
+def _source(uid: str) -> Node:
+    return Node(
+        unique_id=uid,
+        name=uid.split(".")[-1],
+        resource_type=ResourceType.SOURCE,
+        fqn=(uid,),
+        package_name="shop",
+        schema="raw",
+        raw_code=None,
+        compiled_code=None,
+        original_file_path=None,
+        columns={},
+    )
+
+
+def _unique(uid: str, *, column: str, target: str, where: str | None = None) -> Node:
+    return Node(
+        unique_id=uid,
+        name=uid.split(".")[-1],
+        resource_type=ResourceType.OTHER,
+        fqn=(uid,),
+        package_name="shop",
+        schema=None,
+        raw_code=None,
+        compiled_code=None,
+        original_file_path=None,
+        columns={},
+        depends_on=frozenset({target}),
+        test_metadata=DbtTestMetadata(name="unique", kwargs={"column_name": column}, where=where),
+        attached_node=target,
+    )
+
+
+def _key(*cols: str) -> Key:
+    return frozenset(cols)
+
+
+def _activated(*nodes: Node) -> Mapping[str, CandidateKeySet]:
+    """Propagate uniqueness and predicate-flow, activate, and return each model's
+    candidate-key set by unique_id."""
+    manifest = Manifest(
+        schema_version="v12",
+        adapter_type="duckdb",
+        nodes={n.unique_id: n for n in nodes},
+    )
+    graph = build_relation_graph(manifest).graph
+    keys = propagate(graph, uniqueness_property(manifest))
+    flow = propagate(graph, predicate_flow_property())
+    activated = activate_conditional(keys, flow)
+    return {ref.unique_id: cks for ref, cks in activated.items() if ref.kind is SourceKind.MODEL}
+
+
+def test_conditional_key_activates_when_the_model_carries_the_filter() -> None:
+    res = _activated(
+        _source("source.shop.raw.orders"),
+        _model("model.shop.dim", "SELECT * FROM orders WHERE active"),
+        _unique("test.shop.u", column="id", target="model.shop.dim", where="active"),
+    )
+    assert _key("id") in res["model.shop.dim"].keys
+
+
+def test_conditional_key_activates_under_a_narrower_filter() -> None:
+    # The model filters ``amount > 5``, which implies the test's ``amount > 0``.
+    res = _activated(
+        _source("source.shop.raw.orders"),
+        _model("model.shop.dim", "SELECT * FROM orders WHERE amount > 5"),
+        _unique("test.shop.u", column="id", target="model.shop.dim", where="amount > 0"),
+    )
+    assert _key("id") in res["model.shop.dim"].keys
+
+
+def test_conditional_key_stays_conditional_without_a_matching_filter() -> None:
+    res = _activated(
+        _source("source.shop.raw.orders"),
+        _model("model.shop.dim", "SELECT * FROM orders"),
+        _unique("test.shop.u", column="id", target="model.shop.dim", where="active"),
+    )
+    dim = res["model.shop.dim"]
+    assert _key("id") not in dim.keys
+    assert any(ck.key == _key("id") for ck in dim.conditional)
+
+
+def test_filter_that_does_not_imply_the_predicate_does_not_activate() -> None:
+    # ``amount > 0`` does not imply ``amount > 5``: a wider filter is not enough.
+    res = _activated(
+        _source("source.shop.raw.orders"),
+        _model("model.shop.dim", "SELECT * FROM orders WHERE amount > 0"),
+        _unique("test.shop.u", column="id", target="model.shop.dim", where="amount > 5"),
+    )
+    assert _key("id") not in res["model.shop.dim"].keys
+
+
+def test_unconditional_unique_still_grounds_a_key() -> None:
+    # The conditional-carrying grounding must not disturb the ordinary path.
+    res = _activated(
+        _source("source.shop.raw.orders"),
+        _model("model.shop.dim", "SELECT * FROM orders"),
+        _unique("test.shop.u", column="id", target="model.shop.dim"),
+    )
+    assert res["model.shop.dim"].keys == frozenset({_key("id")})
+
+
+# --- end to end: activation changes what the detectors see -----------------------
+
+# A consumer joins ``dim`` on ``id``. ``dim`` declares an unconditional key on
+# ``region`` and a conditional key on ``id`` (where active). The join is covered only
+# when the ``id`` key is in force, so the join-fanout finding stands or falls on
+# whether activation promoted it.
+_CONSUMER = "SELECT f.x FROM events f JOIN dim d ON f.did = d.id"
+
+
+def _fanout_kinds(*nodes: Node) -> list[FindingKind]:
+    manifest = Manifest(
+        schema_version="v12",
+        adapter_type="duckdb",
+        nodes={n.unique_id: n for n in nodes},
+    )
+    _window, fanout = make_fact_grounded_detectors(manifest)
+    return [f.kind for f in fanout(parse_sql(_CONSUMER, dialect="duckdb"))]
+
+
+def test_activation_covers_a_join_and_suppresses_the_fanout_finding() -> None:
+    # ``dim`` filters to ``active``, so its conditional ``id`` key activates and the
+    # join on ``id`` is covered: no fanout.
+    kinds = _fanout_kinds(
+        _source("source.shop.raw.events"),
+        _model("model.shop.dim", "SELECT * FROM events WHERE active"),
+        _unique("test.shop.region", column="region", target="model.shop.dim"),
+        _unique("test.shop.id", column="id", target="model.shop.dim", where="active"),
+    )
+    assert FindingKind.JOIN_FANOUT not in kinds
+
+
+def test_without_the_filter_the_join_fanout_finding_stands() -> None:
+    # Same shape, but ``dim`` carries no filter, so the ``id`` key stays conditional;
+    # the only key is ``region``, which does not cover the join, and the fanout fires.
+    kinds = _fanout_kinds(
+        _source("source.shop.raw.events"),
+        _model("model.shop.dim", "SELECT * FROM events"),
+        _unique("test.shop.region", column="region", target="model.shop.dim"),
+        _unique("test.shop.id", column="id", target="model.shop.dim", where="active"),
+    )
+    assert FindingKind.JOIN_FANOUT in kinds

--- a/tests/lineage/test_predicate_implication.py
+++ b/tests/lineage/test_predicate_implication.py
@@ -19,7 +19,14 @@ from hypothesis import given
 from hypothesis import strategies as st
 from sqlglot import Expr
 
-from dblect.lineage.predicate import implies, parse_predicate
+from dblect.lineage.predicate import (
+    Canon,
+    atoms_of,
+    entails,
+    entails_atoms,
+    implies,
+    parse_predicate,
+)
 
 _DIALECT = "duckdb"
 
@@ -155,6 +162,38 @@ def test_disjunction_in_strong_needs_every_arm() -> None:
 
 def test_unparseable_or_empty_predicate_is_no_information() -> None:
     assert parse_predicate("???", dialect=_DIALECT) is None
+
+
+# --- entails: the atom-set form, for activation ----------------------------------
+
+
+def _strong(sql: str) -> frozenset[Canon]:
+    parsed = parse_predicate(sql, dialect=_DIALECT)
+    assert parsed is not None
+    return atoms_of(parsed)
+
+
+def test_entails_proves_a_weaker_bound_from_collected_atoms() -> None:
+    assert entails(_strong("a >= 10 AND b = 3"), _p("a >= 5"))
+    assert entails(_strong("a >= 10 AND b = 3"), _p("a >= 5 AND b = 3"))
+    assert not entails(_strong("a >= 5"), _p("a >= 10"))
+
+
+def test_entails_matches_a_conjunct_syntactically() -> None:
+    assert entails(_strong("country = 'US' AND active"), _p("country = 'US'"))
+    # A bare boolean is opaque; only an exact-atom match proves it.
+    assert entails(_strong("active"), _p("active"))
+    assert not entails(_strong("active"), _p("inactive"))
+
+
+def test_entails_decomposes_weak_boolean_structure() -> None:
+    assert entails(_strong("a >= 10"), _p("a >= 5 OR z >= 100"))
+    assert not entails(_strong("a >= 10"), _p("a >= 5 AND b = 3"))
+
+
+def test_entails_atoms_is_in_subset_aware() -> None:
+    assert entails_atoms(_strong("a IN (1, 2)"), _strong("a IN (1, 2, 3)"))
+    assert not entails_atoms(_strong("a IN (1, 2, 3)"), _strong("a IN (1, 2)"))
 
 
 # --- soundness PBT: a True verdict is never wrong --------------------------------

--- a/tests/lineage/test_predicate_implication.py
+++ b/tests/lineage/test_predicate_implication.py
@@ -22,7 +22,7 @@ from sqlglot import Expr
 from dblect.lineage.predicate import (
     Canon,
     atoms_of,
-    entails,
+    entailment_checker,
     entails_atoms,
     implies,
     parse_predicate,
@@ -164,7 +164,7 @@ def test_unparseable_or_empty_predicate_is_no_information() -> None:
     assert parse_predicate("???", dialect=_DIALECT) is None
 
 
-# --- entails: the atom-set form, for activation ----------------------------------
+# --- entails_atoms: the atom-set form, for activation ----------------------------
 
 
 def _strong(sql: str) -> frozenset[Canon]:
@@ -173,27 +173,31 @@ def _strong(sql: str) -> frozenset[Canon]:
     return atoms_of(parsed)
 
 
-def test_entails_proves_a_weaker_bound_from_collected_atoms() -> None:
-    assert entails(_strong("a >= 10 AND b = 3"), _p("a >= 5"))
-    assert entails(_strong("a >= 10 AND b = 3"), _p("a >= 5 AND b = 3"))
-    assert not entails(_strong("a >= 5"), _p("a >= 10"))
+def test_entails_atoms_proves_a_weaker_bound_from_collected_atoms() -> None:
+    assert entails_atoms(_strong("a >= 10 AND b = 3"), _strong("a >= 5"))
+    assert entails_atoms(_strong("a >= 10 AND b = 3"), _strong("a >= 5 AND b = 3"))
+    assert not entails_atoms(_strong("a >= 5"), _strong("a >= 10"))
 
 
-def test_entails_matches_a_conjunct_syntactically() -> None:
-    assert entails(_strong("country = 'US' AND active"), _p("country = 'US'"))
+def test_entails_atoms_matches_a_conjunct_syntactically() -> None:
+    assert entails_atoms(_strong("country = 'US' AND active"), _strong("country = 'US'"))
     # A bare boolean is opaque; only an exact-atom match proves it.
-    assert entails(_strong("active"), _p("active"))
-    assert not entails(_strong("active"), _p("inactive"))
-
-
-def test_entails_decomposes_weak_boolean_structure() -> None:
-    assert entails(_strong("a >= 10"), _p("a >= 5 OR z >= 100"))
-    assert not entails(_strong("a >= 10"), _p("a >= 5 AND b = 3"))
+    assert entails_atoms(_strong("active"), _strong("active"))
+    assert not entails_atoms(_strong("active"), _strong("inactive"))
 
 
 def test_entails_atoms_is_in_subset_aware() -> None:
     assert entails_atoms(_strong("a IN (1, 2)"), _strong("a IN (1, 2, 3)"))
     assert not entails_atoms(_strong("a IN (1, 2, 3)"), _strong("a IN (1, 2)"))
+
+
+def test_entailment_checker_reuses_one_fold_across_weak_sets() -> None:
+    # A disjunctive WHERE flattens to a single opaque atom (no AND to split), so it
+    # entails only an identical atom, not its weaker arms. This is the conservative
+    # boundary the disjunction follow-up (#61) lifts; pin it so the gap is intentional.
+    check = entailment_checker(_strong("a >= 10"))
+    assert check(_strong("a >= 5"))
+    assert not check(_strong("a >= 5 OR z >= 100"))
 
 
 # --- soundness PBT: a True verdict is never wrong --------------------------------


### PR DESCRIPTION
Works toward #43. **Stacked on #56** (base is `predicate-flow-43`, itself stacked on #55) — the diff is only this branch's work; retarget down the stack as each lands.

This closes the loop on conditional facts: a captured `where`-filtered `unique` (#55) becomes a real candidate key wherever a relation's accumulated row filter (#56) implies the test's predicate.

## What activates

A soft-delete / partition shape, the common case from the original design note:

```sql
-- model dim_users:  SELECT * FROM stg WHERE not deleted
-- test on dim_users:  unique(id) where not deleted
```

`dim_users`' flow is `not deleted`, which implies the test's predicate, so `id` promotes to a candidate key. Every scope that reads `dim_users` as a source then sees that key — a downstream window's `PARTITION BY id` is covered, a join on `id` is covered, and the corresponding findings fall silent.

The filter can sit in the outer `WHERE`, **a CTE, or an inline subquery** of the owning model — the flow walk accumulates all of them for free, so each activates. Interval reasoning carries too: a model filtering `amount > 5` activates a `unique(id) where amount > 0`.

## Mechanism (property-agnostic)

- **predicate engine** gains `entails(atoms, expr)` and `entails_atoms(atoms, atoms)` — the atom-set form of `implies`, sharing the entailment core (a refactor split `_entails` into `_entails`/`_entails_atom`). A flow filter held as atoms feeds it directly.
- **`activate(base, conditionals, flow_atoms, meet)`** folds every conditional value whose predicate the flow implies into the base by the property's own lattice `meet`. No property owns the step; nullability and future axes reuse it.
- **uniqueness** carries conditional keys: `CandidateKeySet` gains a `conditional` payload, grounding routes a `where`-filtered `unique` into it (marked CONCRETE so reconcile keeps it rather than discarding an IMPLICIT grounded value), and `activate_conditional` promotes per relation against the predicate-flow annotation. The audit wiring now propagates predicate-flow alongside uniqueness and activates before indexing keys for the detectors.

## Testing

Propagation-boundary tests: activates with a matching or narrower filter (including when the filter is in a CTE or inline subquery), stays conditional without one, a strictly wider filter does not activate, and the ordinary unconditional path is undisturbed. End-to-end contrast through `make_fact_grounded_detectors`: the join-fanout finding **stands** when the model carries no filter and is **suppressed** once the filter activates the covering key, so the test is non-vacuous. Full suite green, strict ruff + ruff format + pyright clean.

## Deferred (named non-goals, each stays silent / never wrong)

- **Cross-relation (consumer-side) activation.** A conditional fact activates at the relation that *owns* it, using that relation's own accumulated filter — and that filter is accumulated for free through the owning relation's CTEs and inline subqueries. What is not yet covered is activating a conditional fact at a *different* scope that consumes the relation and applies the implying filter there: a downstream model, or an intra-model CTE doing `SELECT * FROM upstream WHERE ...`, where the conditional test lives on `upstream`. Both are the same gap — conditional facts do not yet travel the relation walk with their predicates renamed, so a consuming scope cannot activate them against its own flow. This is the follow-up that makes the original design note's window-detector-on-a-filtering-consumer example fire.
- **Nullability activation** — the same `activate` step with a `NOT_NULL` meet; a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)