### PR TITLE
lineage: activate conditional keys at intra-model scopes (#43, stage 3d)

### DIFF
--- a/src/dblect/lineage/properties/predicate_flow.py
+++ b/src/dblect/lineage/properties/predicate_flow.py
@@ -135,18 +135,26 @@ class _FlowWalk:
 
     ``base_filter`` resolves a base table's filter; CTEs and inline subqueries are
     resolved structurally within the walk. A scope is carried only when it is a
-    single source with no join; everything else drops to the empty filter.
+    single source with no join; everything else drops to the empty filter. With
+    ``record`` set, every scope's filter is kept in ``scopes`` keyed by ``id(node)``,
+    so a detector can read the filter in force at an intermediate CTE / subquery.
     """
 
-    def __init__(self, base_filter: _BaseFilter) -> None:
+    def __init__(self, base_filter: _BaseFilter, *, record: bool = False) -> None:
         self._base_filter = base_filter
+        self._record = record
+        self.scopes: dict[int, frozenset[Canon]] = {}
 
     def scope_filter(
         self, node: Expr, *, cte_scope: Mapping[str, frozenset[Canon]]
     ) -> frozenset[Canon]:
         if isinstance(node, exp.Select):
-            return self._select(node, cte_scope=cte_scope)
-        return frozenset()  # UNION (arms may differ) and other non-SELECT shapes carry nothing
+            atoms = self._select(node, cte_scope=cte_scope)
+        else:
+            atoms = frozenset[Canon]()  # UNION (arms may differ) and non-SELECTs carry nothing
+        if self._record:
+            self.scopes[id(node)] = atoms
+        return atoms
 
     def _select(
         self, sel: exp.Select, *, cte_scope: Mapping[str, frozenset[Canon]]
@@ -258,6 +266,27 @@ def _projection_pair(proj: Expr) -> tuple[str, str] | None:
         name = sg.column_name(proj).lower()
         return (name, name)
     return None
+
+
+def relation_scope_filters(
+    tree: Expr, model_flow: Mapping[str, RowFilter]
+) -> Mapping[int, frozenset[Canon]]:
+    """Per-scope row filter for every SELECT/UNION node in ``tree``, keyed by
+    ``id(node)``.
+
+    The same flow algebra the reducer runs, but for one already-parsed tree with base
+    tables resolved by name against ``model_flow`` (the per-model filters propagation
+    produced). This is what a detector consults to learn the filter in force at an
+    intermediate CTE or inline subquery, so it can activate a conditional key there.
+    The returned map is valid only for the lifetime of ``tree``.
+    """
+
+    def base_filter(table: exp.Table) -> frozenset[Canon]:
+        return model_flow.get(table.name, NO_FILTER).atoms
+
+    walk = _FlowWalk(base_filter, record=True)
+    walk.scope_filter(tree, cte_scope={})
+    return walk.scopes
 
 
 # --- the property ------------------------------------------------------------

--- a/src/dblect/lineage/properties/uniqueness.py
+++ b/src/dblect/lineage/properties/uniqueness.py
@@ -457,6 +457,12 @@ def activated_scope_keys(
     walk.scope_keys(tree, cte_scope={})
     out: dict[int, frozenset[Key]] = {}
     for node_id, carried in walk.scopes.items():
+        # The flow walk does not record every scope this key walk does: it stops at a
+        # join rather than recursing into it, so a scope nested inside a joined
+        # subquery has no recorded flow. ``scope_flow.get`` defaults such a scope to
+        # the empty filter, which implies nothing and so activates nothing. That is
+        # the safe direction (a conditional key stays conditional), and it matches the
+        # flow's own posture of dropping at a join.
         promoted = activate(
             CandidateKeySet(carried.keys),
             ((CandidateKeySet.of(ck.key), ck.predicate) for ck in carried.conditional),

--- a/src/dblect/lineage/properties/uniqueness.py
+++ b/src/dblect/lineage/properties/uniqueness.py
@@ -430,6 +430,43 @@ def relation_scope_keys(
     return {node_id: carried.keys for node_id, carried in walk.scopes.items()}
 
 
+def activated_scope_keys(
+    tree: Expr,
+    model_keys: Mapping[str, frozenset[Key]],
+    conditional_by_name: Mapping[str, frozenset[ConditionalKey]],
+    scope_flow: Mapping[int, frozenset[Canon]],
+) -> Mapping[int, frozenset[Key]]:
+    """Per-scope candidate keys with conditional keys activated against each scope's
+    own row filter, keyed by ``id(node)``.
+
+    Like :func:`relation_scope_keys`, but base tables resolve to both their keys and
+    their conditional keys, so the walk carries conditional keys into each
+    intermediate scope, and each scope promotes the ones its flow (``scope_flow``,
+    from :func:`~dblect.lineage.properties.predicate_flow.relation_scope_filters`)
+    implies. This lets a window or join over a CTE that filters an upstream see the
+    key the filter activates.
+    """
+
+    def base_resolve(table: exp.Table) -> _Carried:
+        name = table.name
+        return _Carried(
+            model_keys.get(name, frozenset()), conditional_by_name.get(name, frozenset())
+        )
+
+    walk = _RelationWalk(base_resolve, record=True)
+    walk.scope_keys(tree, cte_scope={})
+    out: dict[int, frozenset[Key]] = {}
+    for node_id, carried in walk.scopes.items():
+        promoted = activate(
+            CandidateKeySet(carried.keys),
+            ((CandidateKeySet.of(ck.key), ck.predicate) for ck in carried.conditional),
+            scope_flow.get(node_id, frozenset()),
+            _meet,
+        )
+        out[node_id] = promoted.keys
+    return out
+
+
 class _RelationWalk:
     """Bottom-up candidate-key inference over one relational tree.
 

--- a/src/dblect/uniqueness/detector.py
+++ b/src/dblect/uniqueness/detector.py
@@ -19,17 +19,21 @@ inline-subquery scopes, which are not relations the propagator annotates.
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
+from typing import TypeVar
 
 import sqlglot.expressions as exp
 from sqlglot import Expr
 
 from dblect.lineage.builder import build_relation_graph
 from dblect.lineage.graph import SourceKind, SourceRef
-from dblect.lineage.properties.predicate_flow import predicate_flow_property
+from dblect.lineage.properties.predicate_flow import (
+    predicate_flow_property,
+    relation_scope_filters,
+)
 from dblect.lineage.properties.uniqueness import (
-    CandidateKeySet,
     Key,
     activate_conditional,
+    activated_scope_keys,
     relation_scope_keys,
     uniqueness_property,
 )
@@ -183,13 +187,16 @@ def make_fact_grounded_detectors(
     conditional_scopes = [ref for ref, ann in keys.items() if ann.value.conditional]
     flow = propagate(graph, predicate_flow_property(), subjects=conditional_scopes)
     activated = activate_conditional(keys, flow)
-    model_keys = _model_keys_by_name(manifest, activated)
+    model_keys = _by_name(manifest, activated, lambda cks: cks.keys)
+    conditional_by_name = _by_name(manifest, keys, lambda ann: ann.value.conditional)
+    flow_by_name = _by_name(manifest, flow, lambda ann: ann.value)
     cache: dict[int, ScopeIndex] = {}
 
     def scope_index(tree: Expr) -> ScopeIndex:
         hit = cache.get(id(tree))
         if hit is None:
-            hit = relation_scope_keys(tree, model_keys)
+            scope_flow = relation_scope_filters(tree, flow_by_name)
+            hit = activated_scope_keys(tree, model_keys, conditional_by_name, scope_flow)
             cache[id(tree)] = hit
         return hit
 
@@ -204,26 +211,31 @@ def make_fact_grounded_detectors(
     return (window_keys, fanout)
 
 
-def _model_keys_by_name(
-    manifest: Manifest, anns: Mapping[SourceRef, CandidateKeySet]
-) -> dict[str, frozenset[Key]]:
-    """Index propagated keys by the relation name as it appears in compiled SQL.
+_V = TypeVar("_V")
+_R = TypeVar("_R")
+
+
+def _by_name(
+    manifest: Manifest, anns: Mapping[SourceRef, _V], extract: Callable[[_V], _R]
+) -> dict[str, _R]:
+    """Index a per-relation value by the relation name as it appears in compiled SQL.
 
     A source resolves under ``identifier or name`` (dbt compiles
     ``{{ source(...) }}`` to its ``identifier``, which can diverge from ``name``);
     a model resolves under ``name``. This must match the relation-graph builder's
     ``_build_name_to_source`` so a name the detectors look up by lands on the same
-    keys the propagation produced. Models win over sources on a name collision
-    (applied last), matching how a ``ref`` resolves.
+    relation the propagation annotated. Models win over sources on a name collision
+    (applied last), matching how a ``ref`` resolves. ``extract`` pulls the field the
+    caller wants (keys, conditional keys, or flow) from each annotation.
     """
-    by_name: dict[str, frozenset[Key]] = {}
-    models: dict[str, frozenset[Key]] = {}
-    for ref, cks in anns.items():
+    by_name: dict[str, _R] = {}
+    models: dict[str, _R] = {}
+    for ref, value in anns.items():
         node = manifest.nodes.get(ref.unique_id)
         if node is None:
             continue
         target = models if ref.kind is SourceKind.MODEL else by_name
-        target[node.identifier or node.name] = cks.keys
+        target[node.identifier or node.name] = extract(value)
     by_name.update(models)
     return by_name
 

--- a/src/dblect/uniqueness/detector.py
+++ b/src/dblect/uniqueness/detector.py
@@ -183,7 +183,11 @@ def make_fact_grounded_detectors(
     keys = propagate(graph, uniqueness_property(manifest))
     # Predicate-flow is consulted only where a conditional key waits to activate, so
     # seed the flow pass with those scopes and let it pull in their upstreams rather
-    # than walking every relation in the graph.
+    # than walking every relation in the graph. The seed must stay exactly "every
+    # relation carrying a conditional key": intra-model activation reads flow at every
+    # such relation (via ``flow_by_name`` below), so narrowing the seed (e.g. to
+    # conditional *owners* only) would silently stop carriers from activating. It is
+    # the same set ``conditional_by_name`` indexes, both derived from ``keys``.
     conditional_scopes = [ref for ref, ann in keys.items() if ann.value.conditional]
     flow = propagate(graph, predicate_flow_property(), subjects=conditional_scopes)
     activated = activate_conditional(keys, flow)

--- a/tests/lineage/test_conditional_activation.py
+++ b/tests/lineage/test_conditional_activation.py
@@ -366,3 +366,56 @@ def test_cross_model_without_the_filter_the_fanout_finding_stands() -> None:
         _unique("test.shop.region", column="region", target="model.shop.dim"),
     )
     assert FindingKind.JOIN_FANOUT in kinds
+
+
+# --- intra-model scopes: a window over a CTE that filters an upstream -------------
+#
+# The conditional ``id`` key is on the source; ``region`` is an unconditional key, so
+# a window partitioned by ``id`` is not covered unless ``id`` activates. The CTE that
+# feeds the window is where the filter is applied, so activation has to happen at that
+# *intra-model* scope, not just at the model's own boundary.
+
+
+def _window_kinds(model_sql: str, *nodes: Node) -> list[FindingKind]:
+    manifest = Manifest(
+        schema_version="v12",
+        adapter_type="duckdb",
+        nodes={n.unique_id: n for n in nodes},
+    )
+    window_keys, _fanout = make_fact_grounded_detectors(manifest)
+    return [f.kind for f in window_keys(parse_sql(model_sql, dialect="duckdb"))]
+
+
+def test_intra_model_cte_activation_covers_a_window() -> None:
+    # ``events`` has an unconditional ``region`` key (which does not cover the window)
+    # and a conditional ``id`` key. The CTE filters to ``active``, so ``id`` activates
+    # at the CTE scope and the window partitioned by ``id`` is covered.
+    sql = (
+        "WITH c AS (SELECT * FROM events WHERE active) "
+        "SELECT row_number() OVER (PARTITION BY id ORDER BY ts) AS rn FROM c"
+    )
+    kinds = _window_kinds(
+        sql,
+        _source("source.shop.raw.events"),
+        _unique("test.shop.region", column="region", target="source.shop.raw.events"),
+        _unique("test.shop.id", column="id", target="source.shop.raw.events", where="active"),
+        _model("model.shop.win", sql),
+    )
+    assert FindingKind.NON_UNIQUE_WINDOW_ORDER_KEYS not in kinds
+
+
+def test_intra_model_cte_without_filter_leaves_the_window_uncovered() -> None:
+    # Same shape, but the CTE applies no filter, so ``id`` never activates: only
+    # ``region`` is known, it does not cover the partition, and the window is flagged.
+    sql = (
+        "WITH c AS (SELECT * FROM events) "
+        "SELECT row_number() OVER (PARTITION BY id ORDER BY ts) AS rn FROM c"
+    )
+    kinds = _window_kinds(
+        sql,
+        _source("source.shop.raw.events"),
+        _unique("test.shop.region", column="region", target="source.shop.raw.events"),
+        _unique("test.shop.id", column="id", target="source.shop.raw.events", where="active"),
+        _model("model.shop.win", sql),
+    )
+    assert FindingKind.NON_UNIQUE_WINDOW_ORDER_KEYS in kinds


### PR DESCRIPTION
Works toward #43. **Stacked on #58** (base is `cross-model-activation-43`).

This closes the uniqueness side of activation: a window or join over a **CTE/inline subquery that filters an upstream** now sees the key the filter activates. Stage 3c made cross-model activation land in the per-model key index (so a *materialized* filtered model helps downstream detectors); this extends the same to filters applied *inside* a model.

## The change

- `_FlowWalk` (predicate-flow) gains a record mode, and `relation_scope_filters(tree, model_flow)` returns the row filter in force at every SELECT/UNION scope of a tree.
- `activated_scope_keys(tree, model_keys, conditional_by_name, scope_flow)` walks the tree carrying each base relation's keys *and conditional keys*, then promotes per scope against that scope's flow (reusing the generic `activate`).
- The detector wiring builds per-name conditional-key and flow maps next to the existing per-name key map (factored into one generic `_by_name` helper) and feeds the activated scope index to the window and join detectors.

## Testing (test-first)

A contrast through `make_fact_grounded_detectors`, with the conditional `id` test on the **source** and an unconditional `region` key that does not cover the window:
- window `PARTITION BY id` over `WITH c AS (SELECT * FROM events WHERE active) ...` → **covered**, no finding (the CTE filter activates `id`);
- the same over `WITH c AS (SELECT * FROM events) ...` → **flagged** (no filter, `id` never activates).

Full suite green (390), strict ruff + ruff format + pyright clean.

## Remaining

Nullability activation. Note that **no detector consumes nullability annotations today**, so its activation is invisible infrastructure until a nullability-aware detector lands, and it is architecturally asymmetric (column-scoped, needs a relation-level predicate mapping the column reducer does not provide). Discussed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)