### PR TITLE
lineage: activate conditional NOT_NULL across relations (#43, stage 3e)

### DIFF
--- a/src/dblect/lineage/properties/nullability.py
+++ b/src/dblect/lineage/properties/nullability.py
@@ -28,6 +28,7 @@ from enum import StrEnum
 from sqlglot import Expr
 from sqlglot import expressions as exp
 
+from dblect.lineage.builder import build_manifest_graph, build_relation_graph
 from dblect.lineage.facts.grounding import collect, grounding
 from dblect.lineage.facts.lattice import Lattice
 from dblect.lineage.facts.model import (
@@ -46,8 +47,20 @@ from dblect.lineage.facts.property import (
     OperatorTransfer,
     Property,
     column_property,
+    relation_property,
 )
 from dblect.lineage.graph import ColumnRef, SourceKind, SourceRef
+from dblect.lineage.predicate import atoms_of, parse_predicate
+from dblect.lineage.properties.predicate_flow import predicate_flow_property
+from dblect.lineage.properties.uniqueness import (
+    NO_KEYS,
+    UNIQUENESS_LATTICE,
+    CandidateKeySet,
+    ConditionalKey,
+    activate_conditional,
+    relation_reduce,
+)
+from dblect.lineage.property import propagate
 from dblect.manifest import ConstraintType, Manifest, ResourceType, generic_test_target_uid
 
 
@@ -287,3 +300,94 @@ def nullability_property(
         ground=grounding(facts, opaque=set(), lat=NULLABILITY_LATTICE),
         semiring=NullabilitySemiring(),
     )
+
+
+# --- conditional activation --------------------------------------------------
+#
+# A ``where``-filtered ``not_null`` activates the same way a conditional key does: at
+# a scope whose row filter implies the predicate. Nullability is column-scoped, but
+# the carrying and predicate-renaming a conditional claim needs are relation-scoped,
+# so we reuse the uniqueness carrier: a conditional NON_NULL column is a one-column
+# conditional "key" (the column is non-null under the predicate), flowed across
+# relations by ``relation_reduce`` and promoted by ``activate_conditional``. The
+# activated columns then fold NON_NULL into the column annotations.
+
+
+def _conditional_notnull_carrier(manifest: Manifest) -> Property[CandidateKeySet, SourceRef]:
+    """A relation-scoped carrier for conditional NON_NULL columns, grounded from the
+    ``where``-filtered ``not_null`` tests and flowed across model boundaries."""
+    facts = collect(
+        manifest,
+        (not_null_test_discoverer(), native_not_null_discoverer(manifest.adapter_type)),
+        name_to_source={},
+    )
+    conditional = _conditional_columns_by_relation(facts)
+
+    def ground(scope: SourceRef) -> Annotation[CandidateKeySet]:
+        cks = conditional.get(scope)
+        if cks is None:
+            return Annotation(NO_KEYS, Opacity.IMPLICIT)
+        # CONCRETE so reconcile keeps the conditional payload (an IMPLICIT grounded
+        # value is dropped in favour of the inferred one).
+        return Annotation(CandidateKeySet(frozenset(), cks), Opacity.CONCRETE)
+
+    return relation_property(
+        name="conditional_not_null",
+        lattice=UNIQUENESS_LATTICE,
+        operators={},
+        aggregates={},
+        ground=ground,
+        reconcile_by_meet=True,
+        reducer=relation_reduce,
+    )
+
+
+def _conditional_columns_by_relation(
+    facts: Mapping[ColumnRef, tuple[Fact[Nullability, ColumnRef], ...]],
+) -> dict[SourceRef, frozenset[ConditionalKey]]:
+    """Group ``where``-filtered NON_NULL facts into one-column conditional keys per
+    relation, parsing each predicate to atoms. A predicate that does not parse carries
+    no information, so its column is dropped rather than activated on a guess."""
+    out: dict[SourceRef, set[ConditionalKey]] = {}
+    for bucket in facts.values():
+        for fact in bucket:
+            if fact.condition is None:
+                continue
+            parsed = parse_predicate(fact.condition.sql)
+            if parsed is None:
+                continue
+            claim = ConditionalKey(frozenset({fact.scope.column}), atoms_of(parsed))
+            out.setdefault(fact.scope.source, set()).add(claim)
+    return {relation: frozenset(claims) for relation, claims in out.items()}
+
+
+def activated_nullability(manifest: Manifest) -> Mapping[ColumnRef, Annotation[Nullability]]:
+    """Per-column nullability with conditional NON_NULL facts activated against the
+    predicate flow.
+
+    The unconditional annotations come from the column-scoped property as usual; the
+    conditional carrier flows each ``where``-filtered NON_NULL across relations, the
+    flow says which scopes satisfy the predicate, and every activated column folds
+    NON_NULL into its annotation. No detector consumes nullability yet, so this is the
+    annotation-level entry point activation is exercised through.
+    """
+    base = dict(
+        propagate(
+            build_manifest_graph(manifest).graph, nullability_property(manifest, name_to_source={})
+        )
+    )
+    relation_graph = build_relation_graph(manifest).graph
+    carrier = propagate(relation_graph, _conditional_notnull_carrier(manifest))
+    flow = propagate(relation_graph, predicate_flow_property())
+    for ref, activated in activate_conditional(carrier, flow).items():
+        for key in activated.keys:
+            for column in key:
+                column_ref = ColumnRef(ref, column)
+                prior = base.get(column_ref)
+                if prior is None:
+                    base[column_ref] = Annotation(Nullability.NON_NULL, Opacity.CONCRETE)
+                else:
+                    base[column_ref] = Annotation(
+                        _meet(prior.value, Nullability.NON_NULL), prior.opacity, prior.provisional
+                    )
+    return base

--- a/src/dblect/lineage/properties/nullability.py
+++ b/src/dblect/lineage/properties/nullability.py
@@ -315,7 +315,17 @@ def nullability_property(
 
 def _conditional_notnull_carrier(manifest: Manifest) -> Property[CandidateKeySet, SourceRef]:
     """A relation-scoped carrier for conditional NON_NULL columns, grounded from the
-    ``where``-filtered ``not_null`` tests and flowed across model boundaries."""
+    ``where``-filtered ``not_null`` tests and flowed across model boundaries.
+
+    The value type is uniqueness's :class:`CandidateKeySet` because the relation-algebra
+    carrying it needs (rename columns and predicates through each projection, drop on a
+    join / group / computed projection) is property-agnostic; only the *meaning* of the
+    payload differs, and a one-column key reads here as "this column is non-null under
+    the predicate". The borrow is the pragmatic reuse for the second axis. If a third
+    axis wants the same carrying, lift this into a generic
+    ``conditional_carrier(claims, lattice)`` rather than reaching further into
+    uniqueness, so the shared mechanism stops depending on one property's value type.
+    """
     facts = collect(
         manifest,
         (not_null_test_discoverer(), native_not_null_discoverer(manifest.adapter_type)),
@@ -378,7 +388,14 @@ def activated_nullability(manifest: Manifest) -> Mapping[ColumnRef, Annotation[N
     )
     relation_graph = build_relation_graph(manifest).graph
     carrier = propagate(relation_graph, _conditional_notnull_carrier(manifest))
-    flow = propagate(relation_graph, predicate_flow_property())
+    # Flow is consulted only where a conditional claim waits to activate, so seed the
+    # flow pass with those scopes and let it pull in their upstreams rather than walking
+    # every relation. ``activate_conditional`` reads flow only at carrier scopes whose
+    # value carries a conditional payload, so a scope left out of the seed activates
+    # nothing it would have otherwise (the same seeding invariant the uniqueness
+    # detector relies on).
+    conditional_scopes = [ref for ref, ann in carrier.items() if ann.value.conditional]
+    flow = propagate(relation_graph, predicate_flow_property(), subjects=conditional_scopes)
     for ref, activated in activate_conditional(carrier, flow).items():
         for key in activated.keys:
             for column in key:

--- a/src/dblect/lineage/properties/uniqueness.py
+++ b/src/dblect/lineage/properties/uniqueness.py
@@ -375,7 +375,7 @@ _EMPTY: _Carried = _Carried(frozenset())
 _BaseResolve = Callable[["exp.Table"], _Carried]
 
 
-def _relation_reduce(
+def relation_reduce(
     deriv: Expr,
     prop: Property[CandidateKeySet, SourceRef],
     recurse: Callable[[SourceRef], Annotation[CandidateKeySet]],
@@ -387,6 +387,11 @@ def _relation_reduce(
     A base table resolves through ``recurse`` on its stamped ``SourceRef``, so
     cross-model keys, conditional keys, declarations, and the provisional taint flow
     in. CTEs and inline subqueries are resolved structurally within the walk.
+
+    This also serves as the relation-algebra carrier for any one-column conditional
+    claim, since a relation that grounds no unconditional keys carries only its
+    conditional payload: nullability reuses it to flow conditional NON_NULL columns
+    (a one-column :class:`ConditionalKey` per column) across model boundaries.
     """
     provisional = False
 
@@ -819,7 +824,7 @@ def uniqueness_property(
         aggregates={},
         ground=_grounding_with_conditional(facts),
         reconcile_by_meet=True,
-        reducer=_relation_reduce,
+        reducer=relation_reduce,
     )
 
 

--- a/tests/lineage/test_nullability_activation.py
+++ b/tests/lineage/test_nullability_activation.py
@@ -1,0 +1,140 @@
+"""Activation of conditional ``not_null`` facts against the predicate flow.
+
+A ``where``-filtered ``not_null`` test grounds a conditional NON_NULL: captured,
+carried across relations, and promoted at a scope whose accumulated row filter
+implies the test's predicate. Nullability is column-scoped, so activation rides a
+relation-level carrier (a column is non-null *under a predicate*) that renames the
+column and predicate through projections exactly as the uniqueness carrier does,
+then folds NON_NULL into the column annotations. These pin that promotion at the
+annotation boundary; no detector consumes nullability yet, so there is no
+finding-level case.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from dblect.lineage.graph import ColumnRef, SourceKind, SourceRef
+from dblect.lineage.properties.nullability import Nullability, activated_nullability
+from dblect.manifest import DbtTestMetadata, Manifest, Node, ResourceType
+
+
+def _model(uid: str, sql: str) -> Node:
+    return Node(
+        unique_id=uid,
+        name=uid.split(".")[-1],
+        resource_type=ResourceType.MODEL,
+        fqn=(uid,),
+        package_name="shop",
+        schema="analytics",
+        raw_code=None,
+        compiled_code=sql,
+        original_file_path=None,
+        columns={},
+        constraints=(),
+    )
+
+
+def _source(uid: str) -> Node:
+    return Node(
+        unique_id=uid,
+        name=uid.split(".")[-1],
+        resource_type=ResourceType.SOURCE,
+        fqn=(uid,),
+        package_name="shop",
+        schema="raw",
+        raw_code=None,
+        compiled_code=None,
+        original_file_path=None,
+        columns={},
+    )
+
+
+def _not_null(uid: str, *, column: str, target: str, where: str | None = None) -> Node:
+    return Node(
+        unique_id=uid,
+        name=uid.split(".")[-1],
+        resource_type=ResourceType.OTHER,
+        fqn=(uid,),
+        package_name="shop",
+        schema=None,
+        raw_code=None,
+        compiled_code=None,
+        original_file_path=None,
+        columns={},
+        depends_on=frozenset({target}),
+        test_metadata=DbtTestMetadata(name="not_null", kwargs={"column_name": column}, where=where),
+        attached_node=target,
+    )
+
+
+def _activated(*nodes: Node) -> Mapping[ColumnRef, Nullability]:
+    manifest = Manifest(
+        schema_version="v12",
+        adapter_type="duckdb",
+        nodes={n.unique_id: n for n in nodes},
+    )
+    return {ref: ann.value for ref, ann in activated_nullability(manifest).items()}
+
+
+def _model_col(uid: str, col: str) -> ColumnRef:
+    return ColumnRef(SourceRef(SourceKind.MODEL, uid), col)
+
+
+def test_conditional_not_null_activates_cross_model() -> None:
+    # The test is on the source; the model applies the implying filter. ``email``
+    # carries to the model and promotes to NON_NULL.
+    res = _activated(
+        _source("source.shop.raw.events"),
+        _not_null("test.nn", column="email", target="source.shop.raw.events", where="amount > 0"),
+        _model("model.shop.dim", "SELECT email, amount FROM events WHERE amount > 0"),
+    )
+    assert res[_model_col("model.shop.dim", "email")] is Nullability.NON_NULL
+
+
+def test_conditional_not_null_activates_under_a_narrower_filter() -> None:
+    res = _activated(
+        _source("source.shop.raw.events"),
+        _not_null("test.nn", column="email", target="source.shop.raw.events", where="amount > 0"),
+        _model("model.shop.dim", "SELECT email, amount FROM events WHERE amount > 10"),
+    )
+    assert res[_model_col("model.shop.dim", "email")] is Nullability.NON_NULL
+
+
+def test_conditional_not_null_not_activated_without_a_filter() -> None:
+    res = _activated(
+        _source("source.shop.raw.events"),
+        _not_null("test.nn", column="email", target="source.shop.raw.events", where="amount > 0"),
+        _model("model.shop.dim", "SELECT email, amount FROM events"),
+    )
+    assert res.get(_model_col("model.shop.dim", "email")) is not Nullability.NON_NULL
+
+
+def test_within_relation_conditional_not_null_activates() -> None:
+    # The test is on the model that applies its own filter.
+    res = _activated(
+        _source("source.shop.raw.events"),
+        _model("model.shop.dim", "SELECT email, amount FROM events WHERE amount > 0"),
+        _not_null("test.nn", column="email", target="model.shop.dim", where="amount > 0"),
+    )
+    assert res[_model_col("model.shop.dim", "email")] is Nullability.NON_NULL
+
+
+def test_predicate_column_renames_through_the_projection() -> None:
+    # ``amount`` is projected as ``amt``; the carried predicate renames with it and
+    # matches the model's flow, so activation still fires.
+    res = _activated(
+        _source("source.shop.raw.events"),
+        _not_null("test.nn", column="email", target="source.shop.raw.events", where="amount > 0"),
+        _model("model.shop.dim", "SELECT email, amount AS amt FROM events WHERE amount > 0"),
+    )
+    assert res[_model_col("model.shop.dim", "email")] is Nullability.NON_NULL
+
+
+def test_unconditional_not_null_is_unaffected() -> None:
+    res = _activated(
+        _source("source.shop.raw.events"),
+        _not_null("test.nn", column="email", target="model.shop.dim"),
+        _model("model.shop.dim", "SELECT email FROM events"),
+    )
+    assert res[_model_col("model.shop.dim", "email")] is Nullability.NON_NULL


### PR DESCRIPTION
Works toward #43. **Stacked on #59** (base is `detector-scope-activation-43`). Final deferral.

A `where`-filtered `not_null` test now activates the same way a conditional key does: at a scope whose accumulated row filter implies the predicate, the column promotes to `NON_NULL`. This is the cross-model shape (test on a source/staging relation, filter applied downstream), symmetric with uniqueness.

## Mechanism — reuse, not duplication

Nullability is column-scoped, but the *carrying* and *predicate-renaming* a conditional claim needs are relation-scoped. So instead of threading conditional payloads through the generic column reducer (which would also need a relation-level predicate map it does not have), this reuses the uniqueness carrier:

- a conditional `NON_NULL` column is represented as a **one-column conditional "key"** — "this column is non-null under the predicate";
- `relation_reduce` (made public; it carries only its conditional payload when no unconditional keys are grounded) flows those claims across model boundaries, renaming the column and predicate through each projection exactly as it does for keys;
- `activate_conditional` promotes the ones the flow implies;
- `activated_nullability` folds each activated column's `NON_NULL` into the column-scoped annotations (the unconditional ones still come from the column graph as before).

## Scope note

**No detector consumes nullability annotations yet**, so this is infrastructure (you chose to land it now rather than wait for a consumer). It is exercised at the annotation level: cross-model activation, narrower-filter activation, predicate-column renaming through a projection (`amount AS amt`), no activation without a filter, within-relation activation, and the unconditional path unaffected. It lands ahead of its first consumer the same way predicate flow landed before activation.

Like the uniqueness carrier, the conditional column is tracked through **bare/aliased columns in single-source scopes** (it drops on JOIN/UNION/GROUP BY and on a computed projection) — coarser than the unconditional nullability path, which follows transforms via column lineage. Conservative: it under-activates, never over-claims.

Full suite green (396), strict ruff + ruff format + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)