### PR TITLE
lineage(nullability): cross-model outer-join taint + design + introducers

### DIFF
--- a/docs/design/nullability-hazards.md
+++ b/docs/design/nullability-hazards.md
@@ -67,6 +67,10 @@ The two layers are complementary, and the split is clean.
 
 The de-duplication rule keeps them from talking over each other: a property-based detector fires only when the nullability is introduced non-locally, leaving the same-`SELECT` cases to the structural detector that already owns them. Over time some structural detectors may retire into their property-based generalization, but the broad net stays valuable on projects that declare little, where the property has little to prove from.
 
+## Adjacent hazards this property does not own
+
+Flattening an array with an inner lateral (`FROM t, UNNEST(t.arr)`, `CROSS JOIN UNNEST(...)`, `CROSS JOIN LATERAL ...`) silently drops the parent row whenever the array is empty or null. That looks like a nullability bug and is worth catching, but it is a row-preservation (cardinality) hazard, the deflation twin of join fanout: fanout multiplies rows, this annihilates them. The nullability property can prove only the null-array half of it and structurally misses the more common empty-array half (`[]` is a non-null, zero-length value), so it stays out of scope here and lives as a structural detector instead. A future collection-emptiness property could gate it precisely, reusing this engine's existential shape, once the static introducers for "can be empty" are rich enough to clear the firewall. Tracked separately as a `sql/patterns.py` detector.
+
 ## Implementation sketch
 
 Grounded in the current code, the work is three slices that can land in order, each independently useful.

--- a/docs/design/nullability-hazards.md
+++ b/docs/design/nullability-hazards.md
@@ -1,0 +1,101 @@
+# Nullability hazards: catching the goofs without the confetti
+
+Status: design notes. The firewall principle and the introducer catalog are worked through; the detector roster and the local-versus-inherited gate are the parts still open.
+
+Audience: anyone building the detectors that consume the nullability property, or reasoning about why those detectors stay quiet on healthy models. It assumes the propagation calculus in [`propagation-soundness.md`](./propagation-soundness.md), the substrate in [`lineage-facts.md`](./lineage-facts.md), and the column engine in [`column-level-lineage.md`](./column-level-lineage.md).
+
+## The promise and the trap
+
+A nullable column changes the meaning of the ordinary operations analysts reach for every day, and it does so silently. A `JOIN` on a nullable key drops the rows whose key is null, because null never equals null. A `GROUP BY` on a nullable column gathers every null row into one phantom group that downstream code rarely expects. `x NOT IN (subquery)` collapses to an empty result the moment the subquery yields a single null. None of these raise an error; the build stays green and the numbers quietly shift. This is the meaning-level class dblect exists to catch, and nullability is the property that sees it.
+
+The trap is that nullable is the *default*. In SQL a column is nullable unless something constrains it, so a detector that fires whenever a column "might be null" fires on almost every column in the project. That is a confetti cannon: thousands of findings, no signal, uninstalled by lunch. The whole design problem is to fire on the goofs and stay silent everywhere else.
+
+## The firewall: fire on proof, never on default
+
+The substrate already states the principle that makes this tractable. From [`propagation-soundness.md`](./propagation-soundness.md): top is the only value a rule may emit without proof, and every value below top is a positive claim. `NULLABLE` means "a null was proven to reach here," and `UNKNOWN` (the top) means "no information." A rule may emit `NULLABLE` only where the SQL establishes it, never as a fallback on uncertainty.
+
+That gives us the firewall in one sentence: **a nullability hazard detector consumes only proven `NULLABLE`, never `UNKNOWN`.** A column the property left at `UNKNOWN` produces no finding, because the framework never proved a null can occur there. The default state of the world is silence, and a finding is a positive claim that this column carries nulls into a position that mishandles them.
+
+This is the same opportunistic posture the uniqueness detectors already take, with the polarity flipped. Uniqueness fires on the *presence* of a scarce fact (a known key that fails to cover an operation); the valuable, hard-won fact there is "there is a key." Nullability fires on the presence of the other scarce fact (a proven null reaching a null-sensitive position); the valuable fact here is "this is non-null" or "this is provably nullable," and mere absence of a `NOT NULL` declaration is worth nothing. Both lead with proof, so neither sprays the project.
+
+## Where `NULLABLE` is born
+
+The firewall has a consequence that shapes the whole effort. Today the nullability property only ever *grounds* `NON_NULL`, from `not_null` generic tests and native `NOT NULL` constraints; every undeclared column rests at `UNKNOWN`. There is no source of positive `NULLABLE` evidence in the property at all. So under the firewall the detectors would fire on nothing. The enabling work is not the detectors; it is giving the property places to *prove* a null.
+
+These are the sound introducers of `NULLABLE`, in rough order of how much of the value they carry:
+
+- **The optional side of an outer join.** A `LEFT JOIN` makes every column drawn from its right side nullable in the result, even a column that is `NON_NULL` at its own source, because unmatched left rows pad those columns with nulls. `RIGHT JOIN` mints on the left side, `FULL JOIN` on both, `INNER` and `CROSS` mint nothing. This is the headline source, and it is the one that travels across models: the optional-side column flows downstream still nullable, while the SQL that consumes it three models later shows a plain column name with no local cue that it was ever optional. This introducer is relation-aware (it reads the join structure, not a single column expression), so it lives alongside the relation walk that uniqueness already runs, not in the per-column operator catalog.
+
+- **Null-introducing scalars.** `NULLIF(a, b)` is null whenever `a = b`; a `CASE` with no `ELSE` is null on every unmatched row; a bare `NULL` literal and an outer-applied subquery that can return no row are null by construction. These are ordinary per-column operator transfers, the same shape as the existing `COALESCE` and `IS NOT NULL` rules, and they mint `NULLABLE` locally and cheaply.
+
+- **Confluence of a nullable arm.** A `UNION ALL` whose one arm is proven nullable yields a nullable column. The property's existential semiring already does this correctly the moment an arm carries a proven `NULLABLE`; no new rule is needed, only an upstream introducer to give the arm its value.
+
+We never mint `NULLABLE` from observed data. A column is proven nullable by the *shape* of the SQL, not by a null someone happened to see in a sample. Static stays static, and the runtime layer is where observed nulls would earn their own, separately-justified finding.
+
+The dual direction matters as much: every introducer has guards that clear the taint back to `NON_NULL`, and those guards are how a healthy model stays silent. `COALESCE(optional_col, 0)` is non-null again (the existing operator rule already handles this). A downstream `WHERE optional_col IS NOT NULL` removes the null rows. An activated conditional `not_null` fact (the `where`-filtered tests the substrate already carries) re-establishes `NON_NULL` at the scope where its predicate holds. A detector that fires past any of these guards is a false positive, so the guards are part of the contract, not an afterthought.
+
+## Surprise is the signal, which is why this is cross-model
+
+The static analyzer already ships structural detectors for the locally-visible cases: `null_group_after_outer_join`, `where_on_outer_joined_nullable`, and `coalesce_on_join_key` each read a single model's AST and flag a hazard whose cause sits right there in the same `SELECT`. They are a deliberately broad net. As their module says, the static layer has no lineage, so it prefers false positives to false negatives and lets a typed contract or an ignore comment quiet the noise.
+
+The nullability property earns its keep on the case those detectors structurally cannot see: nullability introduced *upstream* and inherited. The optional-side column from a `LEFT JOIN` in `stg_orders` arrives in `customers` as a plain `customer_id`, and the analyst grouping by it has no local signal that it can be null. The AST of `customers` shows an innocent column. Only a walk back through the model graph proves the null is there. That inherited, non-local nullability is the goof a human reviewer misses precisely because the cause and the symptom live in different files.
+
+So **surprise is the ranking signal**, and surprise is what the property measures that a local detector cannot. Two design consequences follow. First, the property-based detectors should concentrate on the non-local case, both to avoid double-flagging the structural detectors and to spend the user's attention where no other tool looks. Second, the finding should carry the provenance that makes the surprise legible: not just "`customer_id` is nullable" but "`customer_id` is nullable because `stg_orders` left-joins it onto `orders`." The where-provenance property already records the source columns a value traces to; the introduction site is the extra witness worth carrying so the explanation, not just the flag, lands in the report.
+
+## The detector family
+
+Each detector sits on a null-sensitive position, consumes a column the property proved `NULLABLE`, and stays silent on `UNKNOWN`, on `NON_NULL`, and behind any clearing guard.
+
+- **Nullable join key (silent row loss).** A join equates a column the property proved nullable. The null-keyed rows drop, so the join is quietly an inner join on those rows even when written as an outer one. Highest value, and almost always cross-model, since the nullability usually rode in from an upstream optional side.
+
+- **Nullable group-by key (phantom group).** A `GROUP BY` references a proven-nullable column, gathering every null row into one group the consumer rarely models. This generalizes the existing structural null-group detector across model boundaries: the structural one needs the outer join in the same `SELECT`, while this one fires when the nullability was inherited. It escalates when the phantom group is then dropped downstream (the jaffle `customers.sql` shape, where the null group's total silently vanishes through a later join), which is the difference between a curiosity and lost money.
+
+- **`NOT IN (subquery)` with a nullable projected column.** The canonical three-valued-logic footgun: one null in the subquery makes the whole predicate never-true, so the result is silently empty. Narrow as a construct and high-severity when present; it falls out of the same machinery for free and is a clean first consumer to prove the property end to end.
+
+- **Comparison predicate on a proven-nullable column (candidate).** A `WHERE nullable_col = x` (or `<`, `>`, `IN`, `BETWEEN`, `LIKE`) drops the null rows. This generalizes `where_on_outer_joined_nullable` beyond the locally-visible outer join to any proven nullability. It overlaps the structural detector enough that merging the two, or gating this one to the inherited case, is an open question below.
+
+## Relationship to the structural detectors
+
+The two layers are complementary, and the split is clean.
+
+| | Structural (AST) | Property (lineage) |
+| --- | --- | --- |
+| Sees | one model's SQL | the whole upstream graph |
+| Posture | broad net, false-positive-tolerant | precise, silent unless proven |
+| Catches | locally-visible cause | inherited, non-local cause |
+| Quiets with | ignore comment / contract | a clearing guard or a `NON_NULL` proof |
+
+The de-duplication rule keeps them from talking over each other: a property-based detector fires only when the nullability is introduced non-locally, leaving the same-`SELECT` cases to the structural detector that already owns them. Over time some structural detectors may retire into their property-based generalization, but the broad net stays valuable on projects that declare little, where the property has little to prove from.
+
+## Implementation sketch
+
+Grounded in the current code, the work is three slices that can land in order, each independently useful.
+
+1. **Mint local `NULLABLE`.** Add `NULLIF`, `CASE`-without-`ELSE`, and the `NULL` literal to `NULLABILITY_OPERATORS` in `properties/nullability.py`. This is the smallest change that gives the property a real tri-state and lets the `NOT IN` detector fire on the local case.
+2. **Mint outer-join `NULLABLE`.** Teach the relation walk to mark columns drawn from an outer join's optional side as `NULLABLE`, mirroring how `relation_reduce` already reads join structure for uniqueness. This is what makes the property cross-model and is where the headline value lives.
+3. **The detectors.** A new module parallel to `uniqueness/detector.py`: propagate the nullability property once over the relation graph, curry the detectors against the resulting per-column annotations and a per-tree scope index, and join them into `make_fact_grounded_detectors` so they run in the existing single pass. New `FindingKind` members for the join-key, group-key, and `NOT IN` hazards; the `where_on_outer_joined_nullable` kind is reused or generalized depending on the open question below.
+
+The conditional `not_null` activation already built (the `where`-filtered tests flowed across relations) plugs in as a clearing guard: a scope where an activated `NON_NULL` holds suppresses the hazard there. That gives the activation work its first real consumer.
+
+## Soundness obligations
+
+- Only proven `NULLABLE` produces a finding. `UNKNOWN` never fires. This is the firewall and the rest depends on it.
+- The outer-join introducer marks only the genuinely optional side: nothing on `INNER` or `CROSS`, the right side on `LEFT`, the left on `RIGHT`, both on `FULL`. Over-minting here is the most likely source of false positives, so it is the first thing property-based tests should pin.
+- Every clearing guard is honored before a finding is emitted: `COALESCE` and `IS NOT NULL` and an `IS NOT NULL` filter and an activated conditional `not_null`. A finding past a guard is a bug.
+- The non-local gate is respected, so the property layer and the structural layer do not both flag the same construct.
+
+## What it catches in the demo
+
+The install-day jaffle finding (the `customers.sql` null group whose total is silently dropped) is exactly this property's home case, lifted from the structural approximation to a proven, explained, cross-model finding. The structural detector flags the shape; the property proves the `customer_id` feeding the `GROUP BY` is nullable because of the upstream `LEFT JOIN payments to orders`, names the source, and shows the consequence chain to the dropped group. Same headline catch, with the provenance that turns "look at this" into "here is the goof and here is where it came from."
+
+## Open questions
+
+- **Group-by on nullable: fire alone, or only when downstream-dropped?** The bare phantom group is sometimes intended; the dropped group rarely is. Gating on the downstream drop cuts noise at the cost of missing the cases where the drop is further away than the walk looks.
+- **How to carry the "why nullable" witness.** Options: extend the nullability value with the introduction site, or keep the value a plain tri-state and join against where-provenance at finding-construction time. The second keeps the property minimal; the first keeps the explanation local to the proof.
+- **Local versus inherited threshold.** Is "introduced non-locally" the right gate, or should the property-based detectors rank every hazard by surprise and show all of them, letting the user set a cut? The gate is simpler; the ranking is more honest about a continuum.
+- **The comparison-predicate detector: merge or keep separate?** It overlaps `where_on_outer_joined_nullable`. Merging gives one detector with a richer nullability source; keeping them separate preserves the broad-net structural version for low-declaration projects.
+- **Interaction with the conditional `not_null` activation.** Confirm an activated `NON_NULL` at a scope cleanly clears the hazard there and does not leave a stale `NULLABLE` from an upstream introducer.
+
+## Prior art
+
+The hazards themselves are the well-documented surprises of SQL's three-valued logic, charted thoroughly in the relational-database literature and the SQL standard's treatment of unknown; Date's critiques of nulls are the classic reference for why these operations behave as they do. The firewall is ordinary abstract interpretation: a sound, monotone analysis that falls back to top under uncertainty (Cousot and Cousot), which is what lets us promise silence rather than noise. The cross-model reach rests on the provenance line the substrate already draws on, where-provenance from Cheney, Chiticariu, and Tan and the propagation calculus from Green, Karvounarakis, and Tannen. Linters and type systems have long tracked nullability statically, from nullable-type checkers in general-purpose languages to schema-aware SQL analyzers; dblect's contribution is to carry that proof across dbt model boundaries and attach it to the specific analytic operations where a null changes a result, with the provenance that explains the surprise.

--- a/src/dblect/lineage/properties/nullability.py
+++ b/src/dblect/lineage/properties/nullability.py
@@ -142,6 +142,22 @@ def _is_not_null_rule(
     return Annotation(Nullability.NON_NULL, provisional=provisional)
 
 
+def _nullif_rule(
+    _expr: Expr, kids: tuple[Annotation[Nullability], ...], _ctx: DepContext
+) -> Annotation[Nullability]:
+    """``NULLIF(a, b)`` returns NULL when ``a = b``, so it admits a null by construction
+    whatever its inputs are. This is a positive structural claim (the local twin of the
+    outer-join optional side), not a fallback on uncertainty, so it grounds NULLABLE."""
+    return Annotation(Nullability.NULLABLE, provisional=any(k.provisional for k in kids))
+
+
+def _null_literal_rule(
+    _expr: Expr, _kids: tuple[Annotation[Nullability], ...], _ctx: DepContext
+) -> Annotation[Nullability]:
+    """A bare ``NULL`` literal is null."""
+    return Annotation(Nullability.NULLABLE)
+
+
 def _count_core(_expr: exp.AggFunc, child: Annotation[Nullability]) -> Annotation[Nullability]:
     """COUNT returns 0 for empty groups, never NULL."""
     return Annotation(Nullability.NON_NULL, provisional=child.provisional)
@@ -153,6 +169,8 @@ def _count_core(_expr: exp.AggFunc, child: Annotation[Nullability]) -> Annotatio
 NULLABILITY_OPERATORS: Mapping[type[Expr], OperatorTransfer[Nullability]] = {
     exp.Coalesce: _coalesce_rule,
     exp.Is: _is_not_null_rule,
+    exp.Nullif: _nullif_rule,
+    exp.Null: _null_literal_rule,
 }
 NULLABILITY_AGGREGATES: Mapping[type[exp.AggFunc], AggregateRule[Nullability]] = {
     exp.Count: AggregateRule(core=_count_core),

--- a/src/dblect/lineage/properties/nullability.py
+++ b/src/dblect/lineage/properties/nullability.py
@@ -426,19 +426,33 @@ def _conditional_columns_by_relation(
 # downstream through every consumer and a guard (COALESCE, IS NOT NULL) still clears it.
 
 
+def _relation_alias(e: Expr) -> str | None:
+    """The qualifier a FROM/JOIN source lends its columns downstream, case-folded to match
+    the graph, or ``None`` when it lends none. A table contributes its alias-or-name; an
+    aliased derived table (subquery) contributes its alias. Both are the qualifier the
+    builder stamps onto columns drawn from the source, so the taint can find them. Anything
+    else (an unaliased subquery, ``UNNEST``, a lateral) yields ``None`` and stays untainted:
+    a sound under-approximation, and lateral/unnest row-drop is a separate property's axis."""
+    if isinstance(e, (exp.Table, exp.Subquery)):
+        name = sg.name_of(e)
+        return name.lower() if name else None
+    return None
+
+
 def _optional_join_aliases(select: exp.Select) -> set[str]:
     """The FROM-clause aliases whose columns an outer join can pad with NULL: the
     joined-in side of a LEFT join, the accumulated left side of a RIGHT join, both for a
     FULL join. INNER and CROSS pad nothing. Aliases are case-folded to match the graph."""
-    from_ = select.args.get("from_") or select.args.get("from")
+    from_ = sg.from_of(select)
     left: set[str] = set()
-    if isinstance(from_, exp.From) and isinstance(from_.this, exp.Table):
-        left.add(sg.name_of(from_.this).lower())
+    if from_ is not None:
+        base = _relation_alias(from_.this)
+        if base is not None:
+            left.add(base)
     optional: set[str] = set()
     for join in sg.joins_of(select):
         side = sg.join_side_of(join)
-        target = join.this
-        alias = sg.name_of(target).lower() if isinstance(target, exp.Table) else None
+        alias = _relation_alias(join.this)
         if side is JoinSide.LEFT and alias is not None:
             optional.add(alias)
         elif side is JoinSide.RIGHT:
@@ -468,6 +482,9 @@ def _taint_outer_joins(graph: ColumnLineageGraph, manifest: Manifest) -> ColumnL
     optional-side column references. Each model's top-level FROM/JOIN structure decides
     which aliases are optional; CTE-collapsed or unparseable models are left untouched
     (the taint then simply does not fire, a sound under-approximation)."""
+    refs_by_source: dict[SourceRef, list[ColumnRef]] = {}
+    for ref in graph.expressions:
+        refs_by_source.setdefault(ref.source, []).append(ref)
     new_expressions = dict(graph.expressions)
     for node in manifest.nodes.values():
         if node.resource_type is not ResourceType.MODEL:
@@ -486,9 +503,8 @@ def _taint_outer_joins(graph: ColumnLineageGraph, manifest: Manifest) -> ColumnL
         if not optional:
             continue
         model_ref = SourceRef(SourceKind.MODEL, node.unique_id)
-        for ref, expr in graph.expressions.items():
-            if ref.source == model_ref:
-                new_expressions[ref] = _wrap_optional_columns(expr, optional)
+        for ref in refs_by_source.get(model_ref, ()):
+            new_expressions[ref] = _wrap_optional_columns(graph.expressions[ref], optional)
     return ColumnLineageGraph(edges=graph.edges, expressions=new_expressions)
 
 

--- a/src/dblect/lineage/properties/nullability.py
+++ b/src/dblect/lineage/properties/nullability.py
@@ -49,7 +49,7 @@ from dblect.lineage.facts.property import (
     column_property,
     relation_property,
 )
-from dblect.lineage.graph import ColumnRef, SourceKind, SourceRef
+from dblect.lineage.graph import ColumnLineageGraph, ColumnRef, SourceKind, SourceRef
 from dblect.lineage.predicate import atoms_of, parse_predicate
 from dblect.lineage.properties.predicate_flow import predicate_flow_property
 from dblect.lineage.properties.uniqueness import (
@@ -62,6 +62,9 @@ from dblect.lineage.properties.uniqueness import (
 )
 from dblect.lineage.property import propagate
 from dblect.manifest import ConstraintType, Manifest, ResourceType, generic_test_target_uid
+from dblect.sql import SQLParseError, parse_sql
+from dblect.sql import _sqlglot as sg
+from dblect.sql._sqlglot import JoinSide
 
 
 class Nullability(StrEnum):
@@ -158,6 +161,27 @@ def _null_literal_rule(
     return Annotation(Nullability.NULLABLE)
 
 
+class _OuterJoinNull(exp.Expression):  # pyright: ignore[reportPrivateImportUsage]
+    """A synthetic marker wrapping a column reference drawn from an outer join's optional
+    side. The taint rewrite (:func:`_taint_outer_joins`) inserts it into the nullability
+    graph only; the rule below reads it to taint the value NULLABLE. Other properties
+    never see it, since they run over the untainted graph. It subclasses ``Expression``
+    (the concrete base) rather than ``Func`` so the standard node constructor works."""
+
+    arg_types = {"this": True}  # noqa: RUF012 (sqlglot's arg-schema contract)
+
+
+def _outer_join_null_rule(
+    _expr: Expr, kids: tuple[Annotation[Nullability], ...], _ctx: DepContext
+) -> Annotation[Nullability]:
+    """An outer join pads its optional side with NULL on unmatched rows, so a column
+    drawn from that side is nullable whatever its source nullability. This is a positive
+    structural claim (the join's semantics admit a null here), not a fallback on
+    uncertainty. A downstream guard (COALESCE, an IS NOT NULL filter) still clears it,
+    because the guard's rule runs over this tainted child."""
+    return Annotation(Nullability.NULLABLE, provisional=any(k.provisional for k in kids))
+
+
 def _count_core(_expr: exp.AggFunc, child: Annotation[Nullability]) -> Annotation[Nullability]:
     """COUNT returns 0 for empty groups, never NULL."""
     return Annotation(Nullability.NON_NULL, provisional=child.provisional)
@@ -171,6 +195,7 @@ NULLABILITY_OPERATORS: Mapping[type[Expr], OperatorTransfer[Nullability]] = {
     exp.Is: _is_not_null_rule,
     exp.Nullif: _nullif_rule,
     exp.Null: _null_literal_rule,
+    _OuterJoinNull: _outer_join_null_rule,
 }
 NULLABILITY_AGGREGATES: Mapping[type[exp.AggFunc], AggregateRule[Nullability]] = {
     exp.Count: AggregateRule(core=_count_core),
@@ -389,21 +414,97 @@ def _conditional_columns_by_relation(
     return {relation: frozenset(claims) for relation, claims in out.items()}
 
 
-def activated_nullability(manifest: Manifest) -> Mapping[ColumnRef, Annotation[Nullability]]:
-    """Per-column nullability with conditional NON_NULL facts activated against the
-    predicate flow.
+# --- outer-join taint --------------------------------------------------------
+#
+# An outer join pads its optional side with NULL on unmatched rows, so a column drawn
+# from that side is nullable downstream even when it is NON_NULL at its own source. The
+# taint is a fact about the join, not the column expression, so it cannot be grounded
+# (a more precise NON_NULL inference would win the reconcile) and has to enter
+# inference. We do that by rewriting the nullability graph: each optional-side column
+# reference is wrapped in an :class:`_OuterJoinNull` marker whose rule taints NULLABLE.
+# Because the marker sits in the expression the propagator walks, the taint rides
+# downstream through every consumer and a guard (COALESCE, IS NOT NULL) still clears it.
 
-    The unconditional annotations come from the column-scoped property as usual; the
-    conditional carrier flows each ``where``-filtered NON_NULL across relations, the
-    flow says which scopes satisfy the predicate, and every activated column folds
-    NON_NULL into its annotation. No detector consumes nullability yet, so this is the
-    annotation-level entry point activation is exercised through.
+
+def _optional_join_aliases(select: exp.Select) -> set[str]:
+    """The FROM-clause aliases whose columns an outer join can pad with NULL: the
+    joined-in side of a LEFT join, the accumulated left side of a RIGHT join, both for a
+    FULL join. INNER and CROSS pad nothing. Aliases are case-folded to match the graph."""
+    from_ = select.args.get("from_") or select.args.get("from")
+    left: set[str] = set()
+    if isinstance(from_, exp.From) and isinstance(from_.this, exp.Table):
+        left.add(sg.name_of(from_.this).lower())
+    optional: set[str] = set()
+    for join in sg.joins_of(select):
+        side = sg.join_side_of(join)
+        target = join.this
+        alias = sg.name_of(target).lower() if isinstance(target, exp.Table) else None
+        if side is JoinSide.LEFT and alias is not None:
+            optional.add(alias)
+        elif side is JoinSide.RIGHT:
+            optional |= left
+        elif side is JoinSide.FULL:
+            if alias is not None:
+                optional.add(alias)
+            optional |= left
+        if alias is not None:
+            left.add(alias)
+    return optional
+
+
+def _wrap_optional_columns(expr: Expr, optional: set[str]) -> Expr:
+    """A copy of ``expr`` with every column qualified by an optional-side alias wrapped in
+    :class:`_OuterJoinNull`. Unqualified columns are left alone (the side is unknown), the
+    silent-when-unsure posture that keeps the taint from over-firing."""
+    rewritten = expr.copy()
+    targets = [c for c in rewritten.find_all(exp.Column) if c.table and c.table.lower() in optional]
+    for col in targets:
+        col.replace(_OuterJoinNull(this=col.copy()))
+    return rewritten
+
+
+def _taint_outer_joins(graph: ColumnLineageGraph, manifest: Manifest) -> ColumnLineageGraph:
+    """A copy of ``graph`` whose model output expressions taint their outer-join
+    optional-side column references. Each model's top-level FROM/JOIN structure decides
+    which aliases are optional; CTE-collapsed or unparseable models are left untouched
+    (the taint then simply does not fire, a sound under-approximation)."""
+    new_expressions = dict(graph.expressions)
+    for node in manifest.nodes.values():
+        if node.resource_type is not ResourceType.MODEL:
+            continue
+        sql = node.compiled_code
+        if not sql:
+            continue
+        try:
+            tree = parse_sql(sql, dialect="duckdb")
+        except SQLParseError:
+            continue
+        select = tree if isinstance(tree, exp.Select) else tree.find(exp.Select)
+        if not isinstance(select, exp.Select):
+            continue
+        optional = _optional_join_aliases(select)
+        if not optional:
+            continue
+        model_ref = SourceRef(SourceKind.MODEL, node.unique_id)
+        for ref, expr in graph.expressions.items():
+            if ref.source == model_ref:
+                new_expressions[ref] = _wrap_optional_columns(expr, optional)
+    return ColumnLineageGraph(edges=graph.edges, expressions=new_expressions)
+
+
+def activated_nullability(manifest: Manifest) -> Mapping[ColumnRef, Annotation[Nullability]]:
+    """Per-column nullability with outer-join optional sides tainted NULLABLE and
+    conditional NON_NULL facts activated against the predicate flow.
+
+    The base annotations come from the column-scoped property over the outer-join-tainted
+    graph, so an optional-side column reads NULLABLE even when its source is NON_NULL. On
+    top of that, the conditional carrier flows each ``where``-filtered NON_NULL across
+    relations, the flow says which scopes satisfy the predicate, and every activated
+    column folds NON_NULL into its annotation. No detector consumes nullability yet, so
+    this is the annotation-level entry point both refinements are exercised through.
     """
-    base = dict(
-        propagate(
-            build_manifest_graph(manifest).graph, nullability_property(manifest, name_to_source={})
-        )
-    )
+    tainted = _taint_outer_joins(build_manifest_graph(manifest).graph, manifest)
+    base = dict(propagate(tainted, nullability_property(manifest, name_to_source={})))
     relation_graph = build_relation_graph(manifest).graph
     carrier = propagate(relation_graph, _conditional_notnull_carrier(manifest))
     # Flow is consulted only where a conditional claim waits to activate, so seed the

--- a/tests/lineage/_duckdb_oracle.py
+++ b/tests/lineage/_duckdb_oracle.py
@@ -35,7 +35,9 @@ def materialized(
             con.execute(f"CREATE TABLE {name} ({', '.join(f'{c} INTEGER' for c in cols)})")
             if rows:
                 placeholders = ", ".join(["?"] * len(cols))
-                con.executemany(f"INSERT INTO {name} VALUES ({placeholders})", [list(r) for r in rows])
+                con.executemany(
+                    f"INSERT INTO {name} VALUES ({placeholders})", [list(r) for r in rows]
+                )
         con.execute(f"CREATE TABLE _m AS {model_sql}")
         yield con
     finally:

--- a/tests/lineage/_duckdb_oracle.py
+++ b/tests/lineage/_duckdb_oracle.py
@@ -1,0 +1,49 @@
+"""A duckdb materialization oracle for lineage soundness PBTs.
+
+The empirical soundness PBTs (uniqueness keys, nullability) share one move: build
+the generated sources in duckdb, materialize the model's SQL against them, and
+query the result as ground truth. This helper is that move, factored out so each
+PBT only writes its generator and its assertion. The oracle is the data, so a
+property the analyzer claims is checked against what the warehouse actually
+produces, not against a re-derivation of the rule.
+
+Columns are integer-typed (the generators produce small non-null ints); extend the
+DDL here if a future PBT needs another type.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator, Sequence
+from contextlib import contextmanager
+
+import duckdb
+
+# A source table to materialize: its name, its column names, and its rows.
+Table = tuple[str, tuple[str, ...], Sequence[Sequence[object]]]
+
+
+@contextmanager
+def materialized(
+    tables: Sequence[Table], model_sql: str
+) -> Generator[duckdb.DuckDBPyConnection, None, None]:
+    """Create ``tables`` in an in-memory duckdb, materialize ``model_sql`` as ``_m``,
+    and yield the connection for the caller to query. The connection is closed on exit.
+    """
+    con = duckdb.connect(":memory:")
+    try:
+        for name, cols, rows in tables:
+            con.execute(f"CREATE TABLE {name} ({', '.join(f'{c} INTEGER' for c in cols)})")
+            if rows:
+                placeholders = ", ".join(["?"] * len(cols))
+                con.executemany(f"INSERT INTO {name} VALUES ({placeholders})", [list(r) for r in rows])
+        con.execute(f"CREATE TABLE _m AS {model_sql}")
+        yield con
+    finally:
+        con.close()
+
+
+def scalar(con: duckdb.DuckDBPyConnection, query: str) -> int:
+    """Run ``query`` (expected to return one integer) and return it."""
+    row = con.execute(query).fetchone()
+    assert row is not None
+    return int(row[0])

--- a/tests/lineage/test_demo_nullability.py
+++ b/tests/lineage/test_demo_nullability.py
@@ -163,6 +163,43 @@ def test_scalar_expression_nullable_input_taints_unknown() -> None:
     assert anns[out].value is Nullability.NULLABLE
 
 
+def test_nullif_introduces_nullable_from_non_null_inputs() -> None:
+    """NULLIF(a, b) admits NULL by construction (it returns NULL when a == b), so the
+    result is NULLABLE even when both inputs are proven NON_NULL. This is a positive
+    structural claim, the local twin of the outer-join optional side: the operator's
+    semantics permit a null regardless of the data."""
+    graph = build_model_graph(
+        model_uid="model.test.m",
+        sql="SELECT NULLIF(t.a, t.b) AS out FROM t",
+        name_to_source={"t": _source("t")},
+        schema={"t": {"a": "INT", "b": "INT"}},
+    )
+
+    def src_rule(c: ColumnRef) -> Nullability:
+        return Nullability.NON_NULL if c.source.kind is SourceKind.SOURCE else Nullability.UNKNOWN
+
+    anns = propagate(graph, _with_source_rule(src_rule))
+    out = ColumnRef(_model("model.test.m"), "out")
+    assert anns[out].value is Nullability.NULLABLE
+
+
+def test_null_literal_is_nullable() -> None:
+    """A bare NULL literal projects a NULLABLE column."""
+    graph = build_model_graph(
+        model_uid="model.test.m",
+        sql="SELECT NULL AS out FROM t",
+        name_to_source={"t": _source("t")},
+        schema={"t": {"a": "INT"}},
+    )
+
+    def src_rule(c: ColumnRef) -> Nullability:
+        return Nullability.NON_NULL if c.source.kind is SourceKind.SOURCE else Nullability.UNKNOWN
+
+    anns = propagate(graph, _with_source_rule(src_rule))
+    out = ColumnRef(_model("model.test.m"), "out")
+    assert anns[out].value is Nullability.NULLABLE
+
+
 @given(_nullabilities, _nullabilities, _nullabilities)
 def test_nullability_lattice_laws(a: Nullability, b: Nullability, c: Nullability) -> None:
     """The nullability lattice is a bounded distributive chain, so it satisfies the

--- a/tests/lineage/test_nullability_outer_join.py
+++ b/tests/lineage/test_nullability_outer_join.py
@@ -1,0 +1,176 @@
+"""Outer-join optional-side NULLABLE taint at the annotation boundary.
+
+An outer join pads its optional side with NULL on unmatched rows, so a column drawn from
+that side is nullable downstream even when it is NON_NULL at its own source. These pin the
+contract: which side reads NULLABLE per join type, that the required side keeps a proven
+NON_NULL (precision, so detectors stay quiet there), that the taint rides across a model
+boundary (the headline, since the downstream SELECT shows a plain column with no local cue),
+that it reaches a column fed by a derived table, and that a guard clears it back to NON_NULL.
+The empirical companion (``test_pbt_nullability_soundness``) checks the same against
+materialized rows, where these pin the precise per-side outcome the data check cannot name.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from dblect.lineage.graph import ColumnRef, SourceKind, SourceRef
+from dblect.lineage.properties.nullability import Nullability, activated_nullability
+from dblect.manifest import DbtTestMetadata, Manifest, Node, ResourceType
+
+
+def _model(uid: str, sql: str) -> Node:
+    return Node(
+        unique_id=uid,
+        name=uid.split(".")[-1],
+        resource_type=ResourceType.MODEL,
+        fqn=(uid,),
+        package_name="shop",
+        schema="analytics",
+        raw_code=None,
+        compiled_code=sql,
+        original_file_path=None,
+        columns={},
+        constraints=(),
+    )
+
+
+def _source(uid: str) -> Node:
+    return Node(
+        unique_id=uid,
+        name=uid.split(".")[-1],
+        resource_type=ResourceType.SOURCE,
+        fqn=(uid,),
+        package_name="shop",
+        schema="raw",
+        raw_code=None,
+        compiled_code=None,
+        original_file_path=None,
+        columns={},
+    )
+
+
+def _not_null(uid: str, *, column: str, target: str) -> Node:
+    return Node(
+        unique_id=uid,
+        name=uid.split(".")[-1],
+        resource_type=ResourceType.OTHER,
+        fqn=(uid,),
+        package_name="shop",
+        schema=None,
+        raw_code=None,
+        compiled_code=None,
+        original_file_path=None,
+        columns={},
+        depends_on=frozenset({target}),
+        test_metadata=DbtTestMetadata(name="not_null", kwargs={"column_name": column}),
+        attached_node=target,
+    )
+
+
+def _activated(*nodes: Node) -> Mapping[ColumnRef, Nullability]:
+    manifest = Manifest(
+        schema_version="v12",
+        adapter_type="duckdb",
+        nodes={n.unique_id: n for n in nodes},
+    )
+    return {ref: ann.value for ref, ann in activated_nullability(manifest).items()}
+
+
+def _col(uid: str, col: str) -> ColumnRef:
+    return ColumnRef(SourceRef(SourceKind.MODEL, uid), col)
+
+
+# Both source columns carry a ``not_null`` test, so each is NON_NULL at its source. The
+# outer join is then the only thing that can introduce a null, which is exactly what these
+# isolate: a NULLABLE result is the taint beating a proven NON_NULL, not mere absence of a
+# declaration.
+_BASE = _source("source.shop.raw.base")
+_JOINED = _source("source.shop.raw.joined")
+_NN_BASE = _not_null("test.nn_base", column="bk", target="source.shop.raw.base")
+_NN_JOINED = _not_null("test.nn_joined", column="jv", target="source.shop.raw.joined")
+
+
+def _join_model(join: str) -> Node:
+    return _model(
+        "model.shop.m",
+        f"SELECT b.bk AS bk, j.jv AS jv FROM base b {join} joined j ON b.bk = j.jk",
+    )
+
+
+def test_left_join_taints_only_the_joined_in_side() -> None:
+    res = _activated(_BASE, _JOINED, _NN_BASE, _NN_JOINED, _join_model("LEFT JOIN"))
+    assert res[_col("model.shop.m", "bk")] is Nullability.NON_NULL
+    assert res[_col("model.shop.m", "jv")] is Nullability.NULLABLE
+
+
+def test_right_join_taints_the_accumulated_left_side() -> None:
+    res = _activated(_BASE, _JOINED, _NN_BASE, _NN_JOINED, _join_model("RIGHT JOIN"))
+    assert res[_col("model.shop.m", "bk")] is Nullability.NULLABLE
+    assert res[_col("model.shop.m", "jv")] is Nullability.NON_NULL
+
+
+def test_full_join_taints_both_sides() -> None:
+    res = _activated(_BASE, _JOINED, _NN_BASE, _NN_JOINED, _join_model("FULL JOIN"))
+    assert res[_col("model.shop.m", "bk")] is Nullability.NULLABLE
+    assert res[_col("model.shop.m", "jv")] is Nullability.NULLABLE
+
+
+def test_inner_join_taints_nothing() -> None:
+    res = _activated(_BASE, _JOINED, _NN_BASE, _NN_JOINED, _join_model("INNER JOIN"))
+    assert res[_col("model.shop.m", "bk")] is Nullability.NON_NULL
+    assert res[_col("model.shop.m", "jv")] is Nullability.NON_NULL
+
+
+def test_taint_rides_across_a_model_boundary() -> None:
+    # The LEFT JOIN lives in ``stg``; ``dim`` selects plain column names with no local cue
+    # that ``jv`` was ever optional. The taint must ride the boundary for ``dim.jv`` to read
+    # NULLABLE, while ``dim.bk`` (the required side) keeps its proven NON_NULL.
+    res = _activated(
+        _BASE,
+        _JOINED,
+        _NN_BASE,
+        _NN_JOINED,
+        _model(
+            "model.shop.stg",
+            "SELECT b.bk AS bk, j.jv AS jv FROM base b LEFT JOIN joined j ON b.bk = j.jk",
+        ),
+        _model("model.shop.dim", "SELECT bk, jv FROM stg"),
+    )
+    assert res[_col("model.shop.dim", "bk")] is Nullability.NON_NULL
+    assert res[_col("model.shop.dim", "jv")] is Nullability.NULLABLE
+
+
+def test_taint_reaches_a_column_drawn_from_a_derived_table() -> None:
+    # The optional side is an aliased derived table rather than a bare relation; its alias
+    # still qualifies ``s.jv`` downstream, so the taint finds it.
+    res = _activated(
+        _BASE,
+        _JOINED,
+        _NN_BASE,
+        _NN_JOINED,
+        _model(
+            "model.shop.m",
+            "SELECT b.bk AS bk, s.jv AS jv "
+            "FROM base b LEFT JOIN (SELECT jk, jv FROM joined) s ON b.bk = s.jk",
+        ),
+    )
+    assert res[_col("model.shop.m", "bk")] is Nullability.NON_NULL
+    assert res[_col("model.shop.m", "jv")] is Nullability.NULLABLE
+
+
+def test_coalesce_guard_clears_the_taint() -> None:
+    # COALESCE over the optional-side column restores NON_NULL: the guard's rule runs over
+    # the tainted child and a non-null fallback wins, so a healthy model stays silent.
+    res = _activated(
+        _BASE,
+        _JOINED,
+        _NN_BASE,
+        _NN_JOINED,
+        _model(
+            "model.shop.m",
+            "SELECT b.bk AS bk, COALESCE(j.jv, b.bk) AS jv "
+            "FROM base b LEFT JOIN joined j ON b.bk = j.jk",
+        ),
+    )
+    assert res[_col("model.shop.m", "jv")] is Nullability.NON_NULL

--- a/tests/lineage/test_pbt_nullability_soundness.py
+++ b/tests/lineage/test_pbt_nullability_soundness.py
@@ -1,0 +1,159 @@
+"""Empirical soundness PBT for nullability: the oracle is execution, not re-derivation.
+
+The soundness invariant for nullability is the analogue of "a promoted key is never
+wrong": **no column the propagator calls ``NON_NULL`` is ever null in materialized
+data.** This test generates a model that joins two sources under each join type,
+runs the analyzer to get every output column's nullability, materializes the model
+against generated data in duckdb, and asserts every ``NON_NULL`` column has no nulls
+in the result.
+
+The teeth come from the join. Each source column carries a ``not_null`` test, so the
+analyzer grounds it ``NON_NULL`` at its source. Under an outer join the optional
+side's columns are padded with nulls for unmatched rows, so a column that traces to
+a ``not_null`` source is nonetheless null in the output. Until the analyzer accounts
+for the outer-join optional side, it calls those columns ``NON_NULL`` and this test
+fails on exactly the rows the join padded; once it does, the optional-side columns
+read ``NULLABLE`` and drop out of the check, while the required side stays sound.
+
+The generator stays inside an executable grammar and the data is non-null in every
+``not_null`` column (so the declarations hold), following the discipline of the
+uniqueness soundness PBT it shares an oracle with.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from dblect.lineage.graph import ColumnRef, SourceKind, SourceRef
+from dblect.lineage.properties import Nullability
+from dblect.lineage.properties.nullability import activated_nullability
+from dblect.manifest import DbtTestMetadata, Manifest, Node, ResourceType
+from tests.lineage._duckdb_oracle import Table, materialized, scalar
+
+_MODEL_UID = "model.test.m"
+_OUTPUT_COLS = ("bk", "bv", "jk", "jv")
+_JOIN_SQL = {
+    "inner": "INNER JOIN",
+    "left": "LEFT JOIN",
+    "right": "RIGHT JOIN",
+    "full": "FULL JOIN",
+}
+
+
+@dataclass(frozen=True)
+class NullScenario:
+    join: str
+    rows_bt: tuple[tuple[int, int], ...]  # (bk, bv)
+    rows_jt: tuple[tuple[int, int], ...]  # (jk, jv)
+
+
+@st.composite
+def _rows(draw: st.DrawFn) -> tuple[tuple[int, int], ...]:
+    """Rows of two small non-null ints. The small domain makes the join both match and
+    miss, so an outer join produces padded nulls on the optional side."""
+    n = draw(st.integers(min_value=0, max_value=6))
+    return tuple(
+        (draw(st.integers(0, 3)), draw(st.integers(0, 3))) for _ in range(n)
+    )
+
+
+@st.composite
+def _null_scenario(draw: st.DrawFn) -> NullScenario:
+    return NullScenario(
+        join=draw(st.sampled_from(tuple(_JOIN_SQL))),
+        rows_bt=draw(_rows()),
+        rows_jt=draw(_rows()),
+    )
+
+
+def _null_sql(s: NullScenario) -> str:
+    return (
+        f"SELECT bt.bk, bt.bv, jt.jk, jt.jv "
+        f"FROM bt {_JOIN_SQL[s.join]} jt ON bt.bk = jt.jk"
+    )
+
+
+def _source(name: str) -> Node:
+    return Node(
+        unique_id=f"source.test.raw.{name}",
+        name=name,
+        resource_type=ResourceType.SOURCE,
+        fqn=("test", name),
+        package_name="test",
+        schema="raw",
+        raw_code=None,
+        compiled_code=None,
+        original_file_path=None,
+        columns={},
+    )
+
+
+def _not_null_test(source_name: str, column: str) -> Node:
+    target = f"source.test.raw.{source_name}"
+    return Node(
+        unique_id=f"test.test.{source_name}_{column}_not_null",
+        name=f"{source_name}_{column}_not_null",
+        resource_type=ResourceType.OTHER,
+        fqn=("test", f"{source_name}_{column}_not_null"),
+        package_name="test",
+        schema=None,
+        raw_code=None,
+        compiled_code=None,
+        original_file_path=None,
+        columns={},
+        depends_on=frozenset({target}),
+        test_metadata=DbtTestMetadata(name="not_null", kwargs={"column_name": column}),
+        attached_node=target,
+    )
+
+
+def _manifest(s: NullScenario) -> Manifest:
+    sql = _null_sql(s)
+    nodes = [
+        _source("bt"),
+        _source("jt"),
+        _not_null_test("bt", "bk"),
+        _not_null_test("bt", "bv"),
+        _not_null_test("jt", "jk"),
+        _not_null_test("jt", "jv"),
+        Node(
+            unique_id=_MODEL_UID,
+            name="m",
+            resource_type=ResourceType.MODEL,
+            fqn=("test", "m"),
+            package_name="test",
+            schema="analytics",
+            raw_code=sql,
+            compiled_code=sql,
+            original_file_path=None,
+            columns={},
+            depends_on=frozenset({"source.test.raw.bt", "source.test.raw.jt"}),
+        ),
+    ]
+    return Manifest(
+        schema_version="v12", adapter_type="duckdb", nodes={n.unique_id: n for n in nodes}
+    )
+
+
+@given(_null_scenario())
+@settings(max_examples=300, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+def test_non_null_columns_are_never_null_over_materialized_rows(s: NullScenario) -> None:
+    """Every output column the analyzer calls NON_NULL has no nulls in the duckdb
+    materialization. The check never recomputes which columns should be nullable; the
+    data is the judge."""
+    anns = activated_nullability(_manifest(s))
+    model = SourceRef(SourceKind.MODEL, _MODEL_UID)
+    non_null_cols = [
+        c for c in _OUTPUT_COLS if anns[ColumnRef(model, c)].value is Nullability.NON_NULL
+    ]
+    tables: list[Table] = [("bt", ("bk", "bv"), s.rows_bt), ("jt", ("jk", "jv"), s.rows_jt)]
+    with materialized(tables, _null_sql(s)) as con:
+        for col in non_null_cols:
+            nulls = scalar(con, f"SELECT COUNT(*) FROM _m WHERE {col} IS NULL")
+            assert nulls == 0, (
+                f"column {col} claimed NON_NULL but has {nulls} null rows "
+                f"for sql={_null_sql(s)!r} bt={s.rows_bt!r} jt={s.rows_jt!r}"
+            )

--- a/tests/lineage/test_pbt_nullability_soundness.py
+++ b/tests/lineage/test_pbt_nullability_soundness.py
@@ -55,9 +55,7 @@ def _rows(draw: st.DrawFn) -> tuple[tuple[int, int], ...]:
     """Rows of two small non-null ints. The small domain makes the join both match and
     miss, so an outer join produces padded nulls on the optional side."""
     n = draw(st.integers(min_value=0, max_value=6))
-    return tuple(
-        (draw(st.integers(0, 3)), draw(st.integers(0, 3))) for _ in range(n)
-    )
+    return tuple((draw(st.integers(0, 3)), draw(st.integers(0, 3))) for _ in range(n))
 
 
 @st.composite
@@ -70,10 +68,7 @@ def _null_scenario(draw: st.DrawFn) -> NullScenario:
 
 
 def _null_sql(s: NullScenario) -> str:
-    return (
-        f"SELECT bt.bk, bt.bv, jt.jk, jt.jv "
-        f"FROM bt {_JOIN_SQL[s.join]} jt ON bt.bk = jt.jk"
-    )
+    return f"SELECT bt.bk, bt.bv, jt.jk, jt.jv FROM bt {_JOIN_SQL[s.join]} jt ON bt.bk = jt.jk"
 
 
 def _source(name: str) -> Node:

--- a/tests/lineage/test_pbt_uniqueness_soundness.py
+++ b/tests/lineage/test_pbt_uniqueness_soundness.py
@@ -39,7 +39,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 
-import duckdb
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
@@ -53,13 +52,11 @@ from dblect.lineage.properties.uniqueness import (
 )
 from dblect.lineage.property import propagate
 from dblect.manifest import DbtTestMetadata, Manifest, Node, ResourceType
+from tests.lineage._duckdb_oracle import Table, materialized, scalar
 
 _MODEL_UID = "model.test.m"
 
 # --- shared analyzer + duckdb oracle ----------------------------------------------
-
-# A materialized table: its name, its column names, and its rows (non-null ints).
-Table = tuple[str, tuple[str, ...], tuple[tuple[int, ...], ...]]
 
 
 def _promoted_keys(manifest: Manifest) -> frozenset[Key]:
@@ -75,31 +72,15 @@ def _promoted_keys(manifest: Manifest) -> frozenset[Key]:
 def _assert_keys_sound(tables: Sequence[Table], model_sql: str, keys: frozenset[Key]) -> None:
     """Materialize ``tables`` and the model in duckdb; assert every key in ``keys`` has
     as many distinct key tuples as the model has rows (so it is genuinely unique)."""
-    con = duckdb.connect(":memory:")
-    try:
-        for name, cols, rows in tables:
-            con.execute(f"CREATE TABLE {name} ({', '.join(f'{c} INTEGER' for c in cols)})")
-            if rows:
-                placeholders = ", ".join(["?"] * len(cols))
-                con.executemany(
-                    f"INSERT INTO {name} VALUES ({placeholders})", [list(r) for r in rows]
-                )
-        con.execute(f"CREATE TABLE _m AS {model_sql}")
-        total_row = con.execute("SELECT COUNT(*) FROM _m").fetchone()
-        assert total_row is not None
-        total = total_row[0]
+    with materialized(tables, model_sql) as con:
+        total = scalar(con, "SELECT COUNT(*) FROM _m")
         for key in keys:
             cols = ", ".join(sorted(key))
-            distinct_row = con.execute(
-                f"SELECT COUNT(*) FROM (SELECT DISTINCT {cols} FROM _m)"
-            ).fetchone()
-            assert distinct_row is not None
-            assert distinct_row[0] == total, (
-                f"unsound key {sorted(key)}: {total} rows but {distinct_row[0]} distinct tuples "
+            distinct = scalar(con, f"SELECT COUNT(*) FROM (SELECT DISTINCT {cols} FROM _m)")
+            assert distinct == total, (
+                f"unsound key {sorted(key)}: {total} rows but {distinct} distinct tuples "
                 f"for sql={model_sql!r} tables={tables!r}"
             )
-    finally:
-        con.close()
 
 
 def _source_node(name: str, schema: str = "raw") -> Node:


### PR DESCRIPTION
Builds the nullability property up to where it proves and propagates cross-model NULLABLE, the foundation for the NULL-hazard detectors. Property-level only; the consuming detectors land in a follow-up.

## What's here

**Design** (`docs/design/nullability-hazards.md`). The confetti firewall is the substrate's own rule: a hazard detector fires on proven `NULLABLE`, never on `UNKNOWN`. The property's unique value is *inherited, cross-model* nullability the local AST cannot see, with surprise as the ranking signal and a complement to the existing structural detectors. Issue #63 (the `UNNEST`/`CROSS JOIN` empty-array row-drop) is scoped out as an adjacent cardinality hazard.

**Local NULLABLE introducers.** The property previously only ever grounded `NON_NULL`, so nothing proved a null. `NULLIF(a, b)` and the bare `NULL` literal now mint `NULLABLE` (positive structural claims). `CASE`-without-`ELSE` is deferred (a precise rule needs reducer support so condition columns do not over-mint).

**Outer-join taint (the cross-model headline).** A column drawn from an outer join's optional side is padded with NULL on unmatched rows, so it is nullable downstream even when `NON_NULL` at its source. This is a fact about the join, not the column expression, so it cannot be grounded (a more precise `NON_NULL` inference wins the reconcile) and instead enters inference: the nullability graph is rewritten to wrap each optional-side column reference in a synthetic marker whose rule taints `NULLABLE`. Because the marker sits in the expression the propagator walks, the taint rides downstream cross-model and a `COALESCE` / `IS NOT NULL` guard still clears it. LEFT taints the joined-in side, RIGHT the accumulated left side, FULL both; INNER and CROSS taint nothing. Wired into `activated_nullability`.

## Tests

An empirical soundness PBT (`test_pbt_nullability_soundness.py`) reusing the #62 duckdb oracle, now factored into `tests/lineage/_duckdb_oracle.py`. The invariant: no column the analyzer calls `NON_NULL` is ever null in materialized data. It fails before the taint (an optional-side column tracing to a `not_null` source is wrongly `NON_NULL`, and the join pads it null) and passes after, across all four join types. Verified the taint is precise as well as sound: only the optional side reads `NULLABLE` per join type, so the required side stays available to detectors.

## Not here yet

The detectors that consume the property (nullable group-by key, nullable join key, `NOT IN`), gated to the non-local case. That is the user-visible payoff and the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)