### PR TITLE
domain-type: companion-binding column property (currency story, stage 1)

### DIFF
--- a/docs/design/domain-type-algebra.md
+++ b/docs/design/domain-type-algebra.md
@@ -192,6 +192,53 @@ That picture is the single-unit slice. The general structure is the flat lattice
 - **Multi-grain stacking.** `ROLLUP`, `CUBE`, and `GROUPING SETS` raise the obligation at several group keys at once, with `NULL`-padded subtotal rows that overlap the nullability property. The conservative reading (require the obligation at the coarsest set) is stated above; the precise per-set treatment and its reconciliation with nullability want a real cube-shaped mart to settle.
 - **Function signatures.** The catalog of built-in signatures, the extension surface for custom functions, call-site resolution, and the open spellings around them are specified in [domain-type-functions.md](domain-type-functions.md).
 
+## Lenient and strict modes
+
+The produce rules above resolve a no-claim (`Top`) operand by widening rather than
+flagging: where the analyzer cannot discharge an operator's agreement requirement
+because one side carries no tag, it makes no claim about the result instead of calling
+the expression an error. This is the lenient default, and it is the right one for a
+codebase being onboarded, where most columns are still untagged and an eager finding on
+every contact with an untyped magnitude would bury the real ones.
+
+A future strict mode would keep the same lattice and the same produce rules everywhere
+the operands carry claims, and differ only in how it treats a `Top` operand under an
+operator that requires agreement: where lenient widens, strict raises a finding, on the
+reading that the author was obliged to tag every magnitude that reaches such an operator.
+The divergence points, recorded as they are found so the mode is a coherent switch rather
+than a scatter of flags:
+
+- **Additive `Top` operand.** `money + untagged` (and `-`). Lenient produces `Top` (the
+  sum carries no dimensional claim, no finding). Strict treats adding an un-dimensioned
+  magnitude to a dimensioned one as the finding, since the addend's unit was required and
+  absent. This is the one the rescaling PBT exercises: holding the untagged column fixed
+  under the group action witnesses that the lenient `Top` is the only sound claim, and a
+  rule that instead inherited the dimensioned side's unit is unsound.
+- **Comparison against a `Top` operand.** `money = untagged`, ordering, join-key equality.
+  Lenient produces a tag-free boolean and asks nothing of an untagged side. Strict flags
+  comparing a dimensioned value against an un-dimensioned one, the same obligation the
+  join-key-types row raises for two *disagreeing* known tags, extended to the no-claim
+  side.
+
+Multiplication and division are deliberately absent from this list, but for a different
+reason than addition. `*` and `/` carry no agreement requirement at all (any two units
+compose), so a `Top` operand is never a requirement violation, in either mode. It is
+still absorbing: a no-claim factor may carry hidden units (a widened sum such as
+`c0 + c1` is exactly such a value), so the product's dimension is unknown rather than the
+other operand's unit. The rescaling PBT surfaced this: claiming `(c0 + c1) * c1` is clean
+`usd` breaks the law, because the naked factor is not a rescaling-invariant scalar.
+
+The ordinary scalar case (`amount * 0.9`) is kept typed by a separate distinction rather
+than by waving `Top` through: a bare numeric literal is *polymorphic*, not no-claim. A
+polymorphic literal takes its unit from context, acting as the identity under `+`/`-` (so
+`amount + 5` stays the amount's currency) and as a dimensionless factor under `*`/`/` (so
+`amount * 0.9` keeps it). This is the algebra's "a literal sits at bottom, polymorphic,
+until context fixes it", and it is what separates a known scalar from an untagged
+magnitude, the two having been conflated as `Top` before. A further may/must refinement
+that would let a widened sum still carry a *provisional* unit (so `(usd + naked) + eur`
+could be recovered as a conflict, a completeness gain rather than a soundness fix) is left
+as a follow-up.
+
 ## References
 
 - Albano, A., Cardelli, L., & Orsini, R. (1985). Galileo: A Strongly-Typed, Interactive Conceptual Language. *ACM Transactions on Database Systems*, 10(2), 230-260.

--- a/src/dblect/lineage/builder.py
+++ b/src/dblect/lineage/builder.py
@@ -37,17 +37,20 @@ from sqlglot.optimizer.qualify import qualify
 from sqlglot.optimizer.scope import Scope, ScopeType, build_scope
 
 from dblect.lineage.graph import (
+    AggregationSite,
     ColumnLineageGraph,
     ColumnRef,
     RelationLineageGraph,
     SourceKind,
     SourceRef,
+    attach_aggregation_site,
     attach_source_ref,
 )
 from dblect.lineage.property import UnionConfluence, attach_column_ref
 from dblect.manifest import Manifest, ResourceType
 from dblect.manifest import Node as ManifestNode
 from dblect.sql import SQLParseError, parse_sql
+from dblect.sql import _sqlglot as sg
 
 
 @dataclass(frozen=True, slots=True)
@@ -239,6 +242,9 @@ class _Walker:
         # the scope's inner expression (``exp.Subquery.this``) so the stamper can
         # find the scope for a subquery it meets inside a projection.
         self._subquery_scope_by_expr: dict[int, Scope] = {}
+        # One AggregationSite per SELECT scope, resolved lazily and shared by every
+        # aggregate stamped in that scope.
+        self._site_by_scope: dict[int, AggregationSite | None] = {}
 
     def walk(
         self,
@@ -322,6 +328,7 @@ class _Walker:
             return
         col_ref = ColumnRef(source=scope_source, column=out_name.lower())
         immediate = self._stamp_columns(select, scope=scope)
+        self._stamp_aggregates(select, scope=scope)
         self.expressions[col_ref] = select
         self.edges[col_ref] = immediate
 
@@ -380,6 +387,86 @@ class _Walker:
         if scope_ref is None:
             return None
         return ColumnRef(source=scope_ref, column=col_name.lower())
+
+    def _stamp_aggregates(self, projection: Expr, *, scope: Scope) -> None:
+        """Stamp each aggregate call in ``projection`` with its scope's
+        :class:`AggregationSite`, the context the coherence guard judges it in:
+        the projection expression alone carries neither the GROUP BY, nor the
+        relation being aggregated over, nor the scope's literal pins. An aggregate
+        inside a window reduces per partition rather than per group, so it is left
+        unstamped (the guard then stays silent-when-unproven) until window
+        structure is read.
+        """
+        aggs = [a for a in projection.find_all(exp.AggFunc) if a.find_ancestor(exp.Window) is None]
+        if not aggs:
+            return
+        site = self._aggregation_site(scope)
+        if site is None:
+            return
+        for agg in aggs:
+            attach_aggregation_site(agg, site)
+
+    def _aggregation_site(self, scope: Scope) -> AggregationSite | None:
+        key = id(scope)
+        if key not in self._site_by_scope:
+            sel = scope.expression
+            self._site_by_scope[key] = (
+                AggregationSite(
+                    input_source=self._aggregation_input(sel, scope),
+                    group_refs=self._group_refs(sel, scope),
+                    pinned=self._pinned_refs(sel, scope),
+                )
+                if isinstance(sel, exp.Select)
+                else None
+            )
+        return self._site_by_scope[key]
+
+    def _aggregation_input(self, sel: exp.Select, scope: Scope) -> SourceRef | None:
+        """The one relation the scope aggregates over: a join-free FROM of a single
+        resolvable table (a manifest relation, or a CTE/derived table's synthetic
+        ref). ``None`` closes the guard's dependency read, since the FD property
+        has no scope to answer for."""
+        if sg.joins_of(sel):
+            return None
+        from_ = sg.from_of(sel)
+        if from_ is None or not isinstance(from_.this, exp.Table):
+            return None
+        src = scope.sources.get(from_.this.alias_or_name)
+        if isinstance(src, exp.Table):
+            return self._name_to_source.get(src.name)
+        if src is not None:
+            return self._scope_source_ref.get(id(src))
+        return None
+
+    def _group_refs(self, sel: exp.Select, scope: Scope) -> frozenset[ColumnRef] | None:
+        """The GROUP BY columns resolved to their upstream refs; ``None`` for a
+        group shape that is not all plain resolvable columns (positional or
+        computed keys), which a guard must treat as unprovable."""
+        group = sel.args.get("group")
+        if not isinstance(group, exp.Group) or not group.expressions:
+            return frozenset()
+        out: set[ColumnRef] = set()
+        for g in group.expressions:
+            if not isinstance(g, exp.Column) or isinstance(g.this, exp.Star):
+                return None
+            ref = self._resolve_column(g, scope=scope)
+            if ref is None:
+                return None
+            out.add(ref)
+        return frozenset(out)
+
+    def _pinned_refs(self, sel: exp.Select, scope: Scope) -> frozenset[ColumnRef]:
+        """Columns the scope's own WHERE equates to a literal, constant across
+        every group by construction. An unresolvable pin is dropped, never guessed."""
+        where = sg.where_of(sel)
+        if where is None or not isinstance(where.this, Expr):
+            return frozenset()
+        out: set[ColumnRef] = set()
+        for col in sg.equality_literal_columns(where.this):
+            ref = self._resolve_column(col, scope=scope)
+            if ref is not None:
+                out.add(ref)
+        return frozenset(out)
 
     def _register_derived_table_union(
         self,
@@ -464,6 +551,7 @@ class _Walker:
                 arm_col_ref = ColumnRef(source=arm_ref, column=out_name.lower())
                 arm_refs_per_col[col_idx].append(arm_col_ref)
                 immediate = self._stamp_columns(arm_select, scope=arm_scope)
+                self._stamp_aggregates(arm_select, scope=arm_scope)
                 self.expressions[arm_col_ref] = arm_select
                 self.edges[arm_col_ref] = immediate
 

--- a/src/dblect/lineage/facts/property.py
+++ b/src/dblect/lineage/facts/property.py
@@ -77,15 +77,29 @@ class DepContext(Protocol):
 OperatorTransfer = Callable[[Expr, tuple[Annotation[K], ...], DepContext], Annotation[K]]
 
 
-@dataclass(frozen=True, slots=True)
-class CoherenceGuard:
-    """A precondition an aggregate's meaning rests on: the ``within`` columns must
-    be constant across each aggregated group. The guard reads that dependency from
-    ``fd``; where it does not hold, the aggregate clears to top and the seam rule
-    reports it. See ``propagation-soundness.md``."""
+F = TypeVar("F")
 
-    fd: PropertyRef[Any, SourceRef]
-    within: tuple[str, ...]
+
+@dataclass(frozen=True, slots=True)
+class CoherenceGuard(Generic[K, F]):
+    """A precondition an aggregate's meaning rests on: every per-row companion
+    column the aggregated value references must be constant within each group.
+
+    ``companions`` reads those columns off the value being aggregated (a per-row
+    currency binding on a money amount). The propagator discharges each one
+    against the :class:`~dblect.lineage.graph.AggregationSite` the builder stamped
+    on the aggregate call: membership in the group key, a literal pin in the
+    aggregating scope's own WHERE, or an ``entails`` read of the ``fd`` dependency
+    at the aggregation input (antecedent: the group columns, in the input
+    relation's names). Where no path discharges a companion, the aggregate clears
+    to top and the seam rule reports it. See ``propagation-soundness.md``.
+
+    ``fd`` must appear in the carrying property's ``depends_on``, so the registry
+    orders the dependency first and the read is never silently unevaluated."""
+
+    fd: PropertyRef[F, SourceRef]
+    companions: Callable[[K], Collection[ColumnRef]]
+    entails: Callable[[F, frozenset[str], str], bool]
 
 
 @dataclass(frozen=True, slots=True)
@@ -95,7 +109,7 @@ class AggregateRule(Generic[K]):
     optional clear-on-failure guard through which any dependency enters."""
 
     core: Callable[[exp.AggFunc, Annotation[K]], Annotation[K]]
-    coherence: CoherenceGuard | None = None
+    coherence: CoherenceGuard[K, Any] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -171,6 +185,20 @@ class Property(Generic[K, S]):
                     f"property {self.ref.name!r} carries a semiring, so {names} must not "
                     "be redefined in operators; the relational combine derives from the semiring"
                 )
+        # A coherence guard reads its fd through the DepContext; that read is only
+        # ordered (and the handle only verified against a registered property) when
+        # the edge is declared, so an undeclared guard dependency is a construction
+        # error here rather than a silently-unevaluated read at propagation time.
+        undeclared = sorted(
+            rule.coherence.fd.name
+            for rule in self.aggregates.values()
+            if rule.coherence is not None and rule.coherence.fd not in self.depends_on
+        )
+        if undeclared:
+            raise ValueError(
+                f"property {self.ref.name!r} carries a coherence guard reading "
+                f"{', '.join(undeclared)}, which is not declared in depends_on"
+            )
 
     @property
     def name(self) -> str:

--- a/src/dblect/lineage/graph.py
+++ b/src/dblect/lineage/graph.py
@@ -181,6 +181,48 @@ def source_ref_meta(table: exp.Table) -> SourceRef | None:
 
 
 @dataclass(frozen=True, slots=True)
+class AggregationSite:
+    """The scope context an aggregate's coherence obligation is judged in.
+
+    The column builder resolves it once per SELECT scope and stamps it onto each
+    aggregate call in that scope's projections, because the projection expression
+    alone (``Alias(Sum(Column))``) carries neither the GROUP BY nor the relation
+    being aggregated over. The guard then has the three things a discharge can
+    rest on, all resolved to graph identities rather than names:
+
+    * ``input_source``: the single FROM relation the scope aggregates over, when
+      it is one resolvable relation with no joins; ``None`` closes the dependency
+      read (the FD property has no scope to answer for).
+    * ``group_refs``: the GROUP BY columns; ``None`` marks a group shape the
+      builder cannot resolve to plain columns (positional or computed group keys),
+      which a guard must treat as unprovable rather than as an empty group key.
+    * ``pinned``: columns the scope's own WHERE equates to a literal, constant
+      across every group by construction.
+    """
+
+    input_source: SourceRef | None
+    group_refs: frozenset[ColumnRef] | None
+    pinned: frozenset[ColumnRef]
+
+
+# Key on ``exp.AggFunc.meta`` where the column builder records the aggregate's
+# ``AggregationSite``. Centralised so builder and propagator stay in sync.
+AGGREGATION_SITE_META_KEY = "dblect_aggregation_site"
+
+
+def attach_aggregation_site(agg: exp.AggFunc, site: AggregationSite) -> None:
+    """Stamp ``agg`` with the scope context its coherence guard is judged in."""
+    agg.meta[AGGREGATION_SITE_META_KEY] = site
+
+
+def aggregation_site_meta(agg: exp.AggFunc) -> AggregationSite | None:
+    """Read the ``AggregationSite`` the builder stamped on ``agg``; ``None`` if
+    unstamped (a windowed aggregate, or a scope the builder did not model)."""
+    meta = agg.meta.get(AGGREGATION_SITE_META_KEY)
+    return meta if isinstance(meta, AggregationSite) else None
+
+
+@dataclass(frozen=True, slots=True)
 class RelationLineageGraph:
     """Per-audit relation lineage: each model relation paired with the SQL tree
     that derives it.

--- a/src/dblect/lineage/properties/__init__.py
+++ b/src/dblect/lineage/properties/__init__.py
@@ -14,6 +14,18 @@ dispatches it with no global registration step.
 """
 
 from dblect.lineage.properties.aggregation_depth import aggregation_depth
+from dblect.lineage.properties.domain_type import (
+    CONFLICT,
+    NAKED,
+    Concrete,
+    Dimension,
+    DomainTag,
+    PerRow,
+    Tagged,
+    domain_type_grounding,
+    domain_type_property,
+    tagged,
+)
 from dblect.lineage.properties.nullability import (
     Nullability,
     native_not_null_discoverer,
@@ -30,13 +42,23 @@ from dblect.lineage.properties.uniqueness import (
 from dblect.lineage.properties.where_provenance import where_provenance
 
 __all__ = [
+    "CONFLICT",
+    "NAKED",
     "CandidateKeySet",
+    "Concrete",
+    "Dimension",
+    "DomainTag",
     "Nullability",
+    "PerRow",
+    "Tagged",
     "aggregation_depth",
+    "domain_type_grounding",
+    "domain_type_property",
     "native_key_discoverer",
     "native_not_null_discoverer",
     "not_null_test_discoverer",
     "nullability_property",
+    "tagged",
     "unique_combination_discoverer",
     "unique_test_discoverer",
     "uniqueness_property",

--- a/src/dblect/lineage/properties/__init__.py
+++ b/src/dblect/lineage/properties/__init__.py
@@ -26,6 +26,13 @@ from dblect.lineage.properties.domain_type import (
     domain_type_property,
     tagged,
 )
+from dblect.lineage.properties.functional_dependency import (
+    FD,
+    FDSet,
+    determines,
+    functional_dependency_grounding,
+    functional_dependency_property,
+)
 from dblect.lineage.properties.nullability import (
     Nullability,
     native_not_null_discoverer,
@@ -43,17 +50,22 @@ from dblect.lineage.properties.where_provenance import where_provenance
 
 __all__ = [
     "CONFLICT",
+    "FD",
     "NAKED",
     "CandidateKeySet",
     "Concrete",
     "Dimension",
     "DomainTag",
+    "FDSet",
     "Nullability",
     "PerRow",
     "Tagged",
     "aggregation_depth",
+    "determines",
     "domain_type_grounding",
     "domain_type_property",
+    "functional_dependency_grounding",
+    "functional_dependency_property",
     "native_key_discoverer",
     "native_not_null_discoverer",
     "not_null_test_discoverer",

--- a/src/dblect/lineage/properties/domain_type.py
+++ b/src/dblect/lineage/properties/domain_type.py
@@ -64,9 +64,13 @@ from dblect.lineage.properties.functional_dependency import FDSet, determines
 class Concrete:
     """A pinned unit or category identity: a literal currency ``"usd"``, a literal
     ``contains_tax`` value. Case-folded so identities line up the way the graph
-    folds column names."""
+    folds column names: a ``usd`` declared on one model agrees with a ``USD``
+    declared on another rather than silently conflicting at their confluence."""
 
     name: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "name", self.name.casefold())
 
 
 @final
@@ -140,6 +144,29 @@ class Dimension:
 Nominal = Concrete | PerRow
 
 
+# --- the polymorphic literal -------------------------------------------------
+
+
+@final
+@dataclass(frozen=True, slots=True)
+class _Polymorphic:
+    """The dimension of a bare numeric literal: no fixed unit, but not a no-claim
+    unknown either. It adopts the other operand's unit under ``+``/``-`` (so
+    ``amount + 5`` stays the amount's currency rather than conflicting on a scalar)
+    and acts as dimensionless under ``*``/``/`` (so ``amount * 0.9`` keeps it). This
+    is the "a literal sits at bottom, polymorphic, until context fixes it" reading of
+    the algebra doc, kept distinct from ``None`` (an unknown magnitude, which absorbs
+    under every operator) and from the empty monomial (a *certified* dimensionless
+    value, which conflicts when added to a unit). A singleton; carries no payload."""
+
+
+POLYMORPHIC: Final[_Polymorphic] = _Polymorphic()
+
+# A column's dimensional claim: a known monomial, no claim (``None``), or the
+# polymorphic literal that takes its unit from context.
+DimClaim = Dimension | None | _Polymorphic
+
+
 # --- the per-column value ----------------------------------------------------
 
 
@@ -148,13 +175,15 @@ Nominal = Concrete | PerRow
 class Tagged:
     """A known domain tagging on a magnitude column.
 
-    ``dimension`` is the dimensional monomial (currency and units), or ``None`` when
-    the column makes no dimensional claim (a plain magnitude, or one whose dimension
-    widened away at a confluence). ``nominal`` holds the categorical bindings keyed
-    by tag name. ``NAKED`` is ``Tagged(None, {})``, the lattice top.
+    ``dimension`` is the dimensional monomial (currency and units), ``None`` when the
+    column makes no dimensional claim (a plain magnitude, or one whose dimension
+    widened away at a confluence or a no-claim addend), or :data:`POLYMORPHIC` for a
+    bare numeric literal that takes its unit from context. ``nominal`` holds the
+    categorical bindings keyed by tag name. ``NAKED`` is ``Tagged(None, {})``, the
+    lattice top.
     """
 
-    dimension: Dimension | None
+    dimension: DimClaim
     nominal: frozenset[tuple[str, Nominal]]
 
     def nominal_map(self) -> dict[str, Nominal]:
@@ -190,12 +219,13 @@ def tagged(*, dimension: Dimension | None = None, nominal: Mapping[str, Nominal]
 # --- the lattice -------------------------------------------------------------
 
 
-def _meet_dimension(a: Dimension | None, b: Dimension | None) -> Dimension | None | _Conflict:
-    """``None`` is the no-claim identity. Two known, equal monomials agree; two known,
+def _meet_dimension(a: DimClaim, b: DimClaim) -> DimClaim | _Conflict:
+    """``None`` (no claim) and the polymorphic literal are both identities here, so a
+    known monomial on either side wins. Two known, equal monomials agree; two known,
     unequal monomials are a contradiction on the same column."""
-    if a is None:
+    if a is None or a is POLYMORPHIC:
         return b
-    if b is None:
+    if b is None or b is POLYMORPHIC:
         return a
     return a if a == b else CONFLICT
 
@@ -263,17 +293,65 @@ def _annotate(value: DomainTag, kids: tuple[Annotation[DomainTag], ...]) -> Anno
 # --- operator transfers ------------------------------------------------------
 
 
+def _additive_combine(values: tuple[DomainTag, ...]) -> DomainTag:
+    """The produce rule for the operands of one ``+`` or ``-`` node: Kennedy's
+    same-dimension requirement lifted to the no-claim top and the conflict bottom.
+
+    This is *not* the lattice ``meet``. ``meet`` combines several claims about one
+    column and so treats the no-claim top as its identity (a silent source does not
+    erase a known tag). Addition combines the dimensions of distinct values being
+    summed, where a no-claim operand is an addend of *unknown* dimension that
+    destroys the claim, so the top is absorbing here, not identity. A genuine
+    disagreement among the *known* operands at this node is the mixed-magnitude
+    finding (``CONFLICT``); a no-claim operand alongside agreeing knowns widens the
+    result to no-claim, per coordinate (the dimension, and each nominal key). This
+    is the lenient resolution of the top; strict mode would flag it (see
+    ``docs/design/domain-type-algebra.md``).
+
+    The conflict is per node, between operands actually summed there. ``sqlglot``
+    builds an ``a + b + c`` chain as nested binary nodes, so a no-claim addend
+    between two disagreeing currencies (``(usd + naked) + eur``) widens the inner
+    sum to no-claim and the outer node sees no disagreement. That is sound: the
+    intermediate sum genuinely has unknown dimension, so there is no conflict left
+    to find. A disagreement is reported only where two known, differing dimensions
+    meet directly (``(usd + eur) + naked`` conflicts, and the conflict rides on)."""
+    if any(isinstance(v, _Conflict) for v in values):
+        return CONFLICT
+    taggeds = [v for v in values if isinstance(v, Tagged)]
+    known_dims = {t.dimension for t in taggeds if isinstance(t.dimension, Dimension)}
+    if len(known_dims) > 1:
+        return CONFLICT  # a real currency mix, checked before any widening can mask it
+    any_naked_dim = any(t.dimension is None for t in taggeds)
+    any_poly = any(t.dimension is POLYMORPHIC for t in taggeds)
+    # A known unit, if present, is the result unless a no-claim operand widens it
+    # away; a polymorphic literal adopts the unit and so neither widens nor conflicts.
+    # With no unit at all, a sum of only literals stays polymorphic.
+    dim: DimClaim
+    if known_dims:
+        dim = None if any_naked_dim else next(iter(known_dims))
+    elif any_naked_dim:
+        dim = None
+    elif any_poly:
+        dim = POLYMORPHIC
+    else:
+        dim = None
+    nominal: dict[str, Nominal] = {}
+    for key in {name for t in taggeds for name in t.nominal_map()}:
+        bindings = [t.nominal_map().get(key) for t in taggeds]
+        known = {b for b in bindings if b is not None}
+        if len(known) > 1:
+            return CONFLICT
+        if None not in bindings:  # every operand pins this category, and they agree
+            nominal[key] = next(iter(known))
+    return Tagged(dim, _froze(nominal))
+
+
 def _additive_rule(
     _expr: Expr, kids: tuple[Annotation[DomainTag], ...], _ctx: DepContext
 ) -> Annotation[DomainTag]:
-    """``+`` and ``-`` require every tag to agree (the same currency, the same
-    categories), producing that tag. Disagreement meets to ``CONFLICT``, which a
-    detector reads as a mixed-magnitude addition. A naked operand carries no claim,
-    so it composes onto the other side rather than tainting it."""
     if not kids:
         return Annotation(NAKED, Opacity.IMPLICIT)
-    value = reduce(_meet, (k.value for k in kids))
-    return _annotate(value, kids)
+    return _annotate(_additive_combine(tuple(k.value for k in kids)), kids)
 
 
 def _multiply_tags(a: DomainTag, b: DomainTag) -> DomainTag:
@@ -290,15 +368,17 @@ def _divide_tags(a: DomainTag, b: DomainTag) -> DomainTag:
 
 def _dimensional_combine(a: Tagged, b: Tagged, *, multiply: bool) -> Tagged:
     """The Kennedy multiplicative fragment: dimensions compose by adding (``*``) or
-    subtracting (``/``) exponents, treating a no-claim operand as dimensionless so a
-    scalar factor leaves a magnitude's currency intact. Two no-claim operands stay
-    no-claim rather than minting a spurious dimensionless ratio. A nominal tag rides
-    through when only one side carries it and widens away when both do."""
-    if a.dimension is None and b.dimension is None:
-        dim: Dimension | None = None
+    subtracting (``/``) exponents. A no-claim operand is an *unknown* factor (it may
+    carry hidden units, as a widened sum like ``c0 + c1`` does), so it is absorbing
+    here: the product's dimension is unknown too. A polymorphic literal, by contrast,
+    is a dimensionless scalar factor and leaves the other operand's currency intact
+    (``amount * 0.9``). A nominal tag rides through when only one side carries it and
+    widens away when both do."""
+    if a.dimension is None or b.dimension is None:
+        dim: DimClaim = None  # an unknown factor leaves the product's dimension unknown
     else:
-        da = a.dimension if a.dimension is not None else Dimension.dimensionless()
-        db = b.dimension if b.dimension is not None else Dimension.dimensionless()
+        da = a.dimension if isinstance(a.dimension, Dimension) else Dimension.dimensionless()
+        db = b.dimension if isinstance(b.dimension, Dimension) else Dimension.dimensionless()
         dim = da.multiply(db) if multiply else da.divide(db)
     am, bm = a.nominal_map(), b.nominal_map()
     nominal = {name: binding for name, binding in am.items() if name not in bm}
@@ -329,7 +409,19 @@ def _comparison_rule(
     return Annotation(NAKED, Opacity.IMPLICIT, provisional=any(k.provisional for k in kids))
 
 
+def _literal_rule(
+    expr: Expr, _kids: tuple[Annotation[DomainTag], ...], _ctx: DepContext
+) -> Annotation[DomainTag]:
+    """A bare numeric literal is polymorphic: it has no unit of its own but takes one
+    from context (a scalar factor under ``*``, the other addend's unit under ``+``).
+    A string literal makes no magnitude claim and stays naked."""
+    if isinstance(expr, exp.Literal) and not expr.is_string:
+        return Annotation(Tagged(POLYMORPHIC, frozenset()), Opacity.IMPLICIT)
+    return Annotation(NAKED, Opacity.IMPLICIT)
+
+
 DOMAIN_TYPE_OPERATORS: Mapping[type[Expr], OperatorTransfer[DomainTag]] = {
+    exp.Literal: _literal_rule,
     exp.Add: _additive_rule,
     exp.Sub: _additive_rule,
     exp.Mul: _multiplicative_rule(_multiply_tags),
@@ -377,7 +469,7 @@ def companion_columns(tag: DomainTag) -> frozenset[ColumnRef]:
     if isinstance(tag, _Conflict):
         return frozenset()
     out: set[ColumnRef] = set()
-    if tag.dimension is not None:
+    if isinstance(tag.dimension, Dimension):
         out.update(unit.column for unit, _ in tag.dimension.exponents if isinstance(unit, PerRow))
     out.update(binding.column for _, binding in tag.nominal if isinstance(binding, PerRow))
     return frozenset(out)

--- a/src/dblect/lineage/properties/domain_type.py
+++ b/src/dblect/lineage/properties/domain_type.py
@@ -1,0 +1,399 @@
+"""Domain-type property: per-column tagged magnitudes (the currency story).
+
+A magnitude column (``amount``) carries a :class:`DomainTag`: a dimensional
+monomial (currency and units, which do exponent arithmetic under ``*`` and ``/``)
+plus categorical nominal tags (``contains_tax``, ``country``, carried by equality
+only). Each tag binds either to a literal (a pinned currency) or to a companion
+column travelling with the amount (a per-row currency column). This is the
+multi-column companion binding the substrate-readiness notes name as the first
+genuine build over the lineage engine: the property value is structured, so the
+work is a lattice and transfer rules rather than engine plumbing.
+
+The lattice orders by tag knowledge. ``NAKED`` (no tag) is the top, the
+freely-summable magnitude making no claim; a known tagging refines it; two known
+taggings that disagree meet to ``CONFLICT``, the bottom (``MoneyUSD`` added to
+``MoneyEUR``). ``meet`` unions agreeing tags and conflicts on disagreement;
+``join`` keeps only the tags both sides agree on, widening the rest back to
+``NAKED``. The algebra is read off the field types the author declares, following
+the dimension-type tradition (Kennedy, *Dimension Types*, ESOP 1994) and the
+summarizability story (Lenz & Shoshani, SSDBM 1997); see
+``docs/design/domain-type-algebra.md``.
+
+Naked-amount taint falls out of lineage: when ``amount`` flows to a model where
+its companion ``currency`` column was projected away, the binding rides as a
+reference that no longer agrees at a confluence and widens to ``NAKED``; the
+coherence guard (a separate build) then blocks a downstream sum until a
+dependency discharges it.
+
+Grounding for the first version comes from synthetic facts supplied by a caller
+(the same way the uniqueness and nullability tests ground their properties); the
+typed source is the contract bridge in the authoring layer.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Collection, Mapping
+from dataclasses import dataclass
+from functools import reduce
+from typing import Final, final
+
+from sqlglot import Expr
+from sqlglot import expressions as exp
+
+from dblect.lineage.facts.grounding import grounding
+from dblect.lineage.facts.lattice import Lattice
+from dblect.lineage.facts.model import Annotation, Fact, Opacity
+from dblect.lineage.facts.property import (
+    AggregateRule,
+    DepContext,
+    OperatorTransfer,
+    Property,
+    column_property,
+)
+from dblect.lineage.graph import ColumnRef
+
+# --- unit and tag identities -------------------------------------------------
+
+
+@final
+@dataclass(frozen=True, slots=True)
+class Concrete:
+    """A pinned unit or category identity: a literal currency ``"usd"``, a literal
+    ``contains_tax`` value. Case-folded so identities line up the way the graph
+    folds column names."""
+
+    name: str
+
+
+@final
+@dataclass(frozen=True, slots=True)
+class PerRow:
+    """A per-row identity: the companion column travelling with the magnitude (the
+    ``currency`` column a ``Money`` amount references). Two amounts share a unit
+    only when they reference the *same* column, which is how ``PerRow(c) / PerRow(c)``
+    cancels while two different currency columns do not."""
+
+    column: ColumnRef
+
+
+# The identity of a unit (dimensional) or a nominal category binding. A dimensional
+# tag rides as a ``Unit`` exponent; a nominal tag rides as a ``Unit`` value under its
+# tag name. Both share the literal-or-companion shape.
+Unit = Concrete | PerRow
+
+
+# --- the dimensional monomial ------------------------------------------------
+
+
+def _drop_zeros(items: Mapping[Unit, int]) -> frozenset[tuple[Unit, int]]:
+    return frozenset((u, e) for u, e in items.items() if e != 0)
+
+
+@final
+@dataclass(frozen=True, slots=True)
+class Dimension:
+    """A monomial in the free abelian group over units: each unit to a nonzero
+    integer exponent, zero exponents dropped, so the empty map is dimensionless and
+    equality is content equality. ``money`` is ``{usd: 1}``, ``money^2`` is
+    ``{usd: 2}``, an exchange rate is ``{eur: 1, usd: -1}``, a ratio that cancelled
+    is ``{}``. The operations are the group operations: ``*`` adds exponents, ``/``
+    subtracts them."""
+
+    exponents: frozenset[tuple[Unit, int]]
+
+    @staticmethod
+    def dimensionless() -> Dimension:
+        return Dimension(frozenset())
+
+    @staticmethod
+    def of(unit: Unit, power: int = 1) -> Dimension:
+        return Dimension(_drop_zeros({unit: power}))
+
+    @property
+    def is_dimensionless(self) -> bool:
+        return not self.exponents
+
+    def _map(self) -> dict[Unit, int]:
+        return dict(self.exponents)
+
+    def multiply(self, other: Dimension) -> Dimension:
+        merged = self._map()
+        for unit, power in other.exponents:
+            merged[unit] = merged.get(unit, 0) + power
+        return Dimension(_drop_zeros(merged))
+
+    def divide(self, other: Dimension) -> Dimension:
+        merged = self._map()
+        for unit, power in other.exponents:
+            merged[unit] = merged.get(unit, 0) - power
+        return Dimension(_drop_zeros(merged))
+
+
+# --- nominal categorical tags ------------------------------------------------
+
+# A nominal tag binds to a literal (``Concrete``) or a companion column (``PerRow``),
+# carried by equality only: there is no ``contains_tax^2``.
+Nominal = Concrete | PerRow
+
+
+# --- the per-column value ----------------------------------------------------
+
+
+@final
+@dataclass(frozen=True, slots=True)
+class Tagged:
+    """A known domain tagging on a magnitude column.
+
+    ``dimension`` is the dimensional monomial (currency and units), or ``None`` when
+    the column makes no dimensional claim (a plain magnitude, or one whose dimension
+    widened away at a confluence). ``nominal`` holds the categorical bindings keyed
+    by tag name. ``NAKED`` is ``Tagged(None, {})``, the lattice top.
+    """
+
+    dimension: Dimension | None
+    nominal: frozenset[tuple[str, Nominal]]
+
+    def nominal_map(self) -> dict[str, Nominal]:
+        return dict(self.nominal)
+
+
+@final
+@dataclass(frozen=True, slots=True)
+class _Conflict:
+    """The lattice bottom: two known taggings that no value can satisfy at once
+    (``MoneyUSD`` met with ``MoneyEUR``). A singleton; carries no payload."""
+
+
+CONFLICT: Final[_Conflict] = _Conflict()
+
+# A column's domain tag is either a known tagging or the conflict bottom.
+DomainTag = Tagged | _Conflict
+
+# The lattice top: a magnitude with no tag, freely summable, making no claim.
+NAKED: Final[DomainTag] = Tagged(dimension=None, nominal=frozenset())
+
+
+def _froze(nominal: Mapping[str, Nominal]) -> frozenset[tuple[str, Nominal]]:
+    return frozenset(nominal.items())
+
+
+def tagged(*, dimension: Dimension | None = None, nominal: Mapping[str, Nominal] = {}) -> Tagged:
+    """Build a :class:`Tagged` from a dimension and a nominal mapping. The public
+    constructor callers use so the frozenset packing of ``nominal`` stays in one place."""
+    return Tagged(dimension=dimension, nominal=_froze(nominal))
+
+
+# --- the lattice -------------------------------------------------------------
+
+
+def _meet_dimension(a: Dimension | None, b: Dimension | None) -> Dimension | None | _Conflict:
+    """``None`` is the no-claim identity. Two known, equal monomials agree; two known,
+    unequal monomials are a contradiction on the same column."""
+    if a is None:
+        return b
+    if b is None:
+        return a
+    return a if a == b else CONFLICT
+
+
+def _meet_nominal(a: Mapping[str, Nominal], b: Mapping[str, Nominal]) -> dict[str, Nominal] | None:
+    """Union the bindings; a tag both sides carry must agree, else the meet conflicts
+    (``None``). A tag only one side carries is taken on (compose)."""
+    merged = dict(a)
+    for name, binding in b.items():
+        existing = merged.get(name)
+        if existing is not None and existing != binding:
+            return None
+        merged[name] = binding
+    return merged
+
+
+def _meet(a: DomainTag, b: DomainTag) -> DomainTag:
+    if isinstance(a, _Conflict) or isinstance(b, _Conflict):
+        return CONFLICT
+    dim = _meet_dimension(a.dimension, b.dimension)
+    if isinstance(dim, _Conflict):
+        return CONFLICT
+    nominal = _meet_nominal(a.nominal_map(), b.nominal_map())
+    if nominal is None:
+        return CONFLICT
+    return Tagged(dim, _froze(nominal))
+
+
+def _join(a: DomainTag, b: DomainTag) -> DomainTag:
+    if isinstance(a, _Conflict):
+        return b
+    if isinstance(b, _Conflict):
+        return a
+    dim = a.dimension if a.dimension == b.dimension else None
+    bm = b.nominal_map()
+    agreeing = {
+        name: binding for name, binding in a.nominal_map().items() if bm.get(name) == binding
+    }
+    return Tagged(dim, _froze(agreeing))
+
+
+DOMAIN_TYPE_LATTICE: Final[Lattice[DomainTag]] = Lattice(
+    meet=_meet,
+    join=_join,
+    top=NAKED,
+    bottom=CONFLICT,
+)
+
+
+# --- transfer helpers --------------------------------------------------------
+
+
+def _annotate(value: DomainTag, kids: tuple[Annotation[DomainTag], ...]) -> Annotation[DomainTag]:
+    """Wrap a transfer's result value with the diagnostic bits derived from its inputs:
+    a non-top result is CONCRETE, a top result inherits EXPLICIT from a declared opt-out
+    or is IMPLICIT, and provisional is the OR of the inputs."""
+    provisional = any(k.provisional for k in kids)
+    if value != NAKED:
+        return Annotation(value, Opacity.CONCRETE, provisional=provisional)
+    explicit = any(k.opacity is Opacity.EXPLICIT for k in kids)
+    opacity = Opacity.EXPLICIT if explicit else Opacity.IMPLICIT
+    return Annotation(value, opacity, provisional=provisional)
+
+
+# --- operator transfers ------------------------------------------------------
+
+
+def _additive_rule(
+    _expr: Expr, kids: tuple[Annotation[DomainTag], ...], _ctx: DepContext
+) -> Annotation[DomainTag]:
+    """``+`` and ``-`` require every tag to agree (the same currency, the same
+    categories), producing that tag. Disagreement meets to ``CONFLICT``, which a
+    detector reads as a mixed-magnitude addition. A naked operand carries no claim,
+    so it composes onto the other side rather than tainting it."""
+    if not kids:
+        return Annotation(NAKED, Opacity.IMPLICIT)
+    value = reduce(_meet, (k.value for k in kids))
+    return _annotate(value, kids)
+
+
+def _multiply_tags(a: DomainTag, b: DomainTag) -> DomainTag:
+    if isinstance(a, _Conflict) or isinstance(b, _Conflict):
+        return CONFLICT
+    return _dimensional_combine(a, b, multiply=True)
+
+
+def _divide_tags(a: DomainTag, b: DomainTag) -> DomainTag:
+    if isinstance(a, _Conflict) or isinstance(b, _Conflict):
+        return CONFLICT
+    return _dimensional_combine(a, b, multiply=False)
+
+
+def _dimensional_combine(a: Tagged, b: Tagged, *, multiply: bool) -> Tagged:
+    """The Kennedy multiplicative fragment: dimensions compose by adding (``*``) or
+    subtracting (``/``) exponents, treating a no-claim operand as dimensionless so a
+    scalar factor leaves a magnitude's currency intact. Two no-claim operands stay
+    no-claim rather than minting a spurious dimensionless ratio. A nominal tag rides
+    through when only one side carries it and widens away when both do."""
+    if a.dimension is None and b.dimension is None:
+        dim: Dimension | None = None
+    else:
+        da = a.dimension if a.dimension is not None else Dimension.dimensionless()
+        db = b.dimension if b.dimension is not None else Dimension.dimensionless()
+        dim = da.multiply(db) if multiply else da.divide(db)
+    am, bm = a.nominal_map(), b.nominal_map()
+    nominal = {name: binding for name, binding in am.items() if name not in bm}
+    nominal.update({name: binding for name, binding in bm.items() if name not in am})
+    return Tagged(dim, _froze(nominal))
+
+
+def _multiplicative_rule(
+    combine: Callable[[DomainTag, DomainTag], DomainTag],
+) -> OperatorTransfer[DomainTag]:
+    def rule(
+        _expr: Expr, kids: tuple[Annotation[DomainTag], ...], _ctx: DepContext
+    ) -> Annotation[DomainTag]:
+        if not kids:
+            return Annotation(NAKED, Opacity.IMPLICIT)
+        value = reduce(combine, (k.value for k in kids))
+        return _annotate(value, kids)
+
+    return rule
+
+
+def _comparison_rule(
+    _expr: Expr, kids: tuple[Annotation[DomainTag], ...], _ctx: DepContext
+) -> Annotation[DomainTag]:
+    """A comparison yields a boolean, which carries no magnitude tag. The operands'
+    tags must agree for the comparison to mean anything, but that obligation is a
+    seam concern; the produced value is always tag-free."""
+    return Annotation(NAKED, Opacity.IMPLICIT, provisional=any(k.provisional for k in kids))
+
+
+DOMAIN_TYPE_OPERATORS: Mapping[type[Expr], OperatorTransfer[DomainTag]] = {
+    exp.Add: _additive_rule,
+    exp.Sub: _additive_rule,
+    exp.Mul: _multiplicative_rule(_multiply_tags),
+    exp.Div: _multiplicative_rule(_divide_tags),
+    exp.EQ: _comparison_rule,
+    exp.NEQ: _comparison_rule,
+    exp.LT: _comparison_rule,
+    exp.LTE: _comparison_rule,
+    exp.GT: _comparison_rule,
+    exp.GTE: _comparison_rule,
+}
+
+
+# --- aggregate transfers -----------------------------------------------------
+
+
+def _passthrough_core(_expr: exp.AggFunc, child: Annotation[DomainTag]) -> Annotation[DomainTag]:
+    """``sum`` and ``avg`` accumulate the magnitude, ``min``/``max`` select one of its
+    values; either way the result carries the child's tag. Whether the accumulation is
+    *sound* (the tag constant per group) is the coherence guard's obligation, wired
+    separately; the pure value-domain map keeps the tag."""
+    return child
+
+
+def _count_core(_expr: exp.AggFunc, child: Annotation[DomainTag]) -> Annotation[DomainTag]:
+    """``count`` does not inspect values, so it is always safe and yields a tag-free
+    ``Count`` whatever the child's tag."""
+    return Annotation(NAKED, Opacity.IMPLICIT, provisional=child.provisional)
+
+
+DOMAIN_TYPE_AGGREGATES: Mapping[type[exp.AggFunc], AggregateRule[DomainTag]] = {
+    exp.Sum: AggregateRule(core=_passthrough_core),
+    exp.Avg: AggregateRule(core=_passthrough_core),
+    exp.Min: AggregateRule(core=_passthrough_core),
+    exp.Max: AggregateRule(core=_passthrough_core),
+    exp.Count: AggregateRule(core=_count_core),
+}
+
+
+# --- the property ------------------------------------------------------------
+
+
+def domain_type_grounding(
+    facts: Mapping[ColumnRef, tuple[Fact[DomainTag, ColumnRef], ...]],
+    *,
+    opaque: Collection[ColumnRef] = (),
+) -> Callable[[ColumnRef], Annotation[DomainTag]]:
+    """Fold the per-column domain-type facts into grounded annotations. The same fold
+    every property uses: an opt-out grounds EXPLICIT top, a resolved bucket grounds its
+    value CONCRETE, everything else the IMPLICIT-top default."""
+    return grounding(facts, opaque, DOMAIN_TYPE_LATTICE)
+
+
+def domain_type_property(
+    ground: Callable[[ColumnRef], Annotation[DomainTag]],
+) -> Property[DomainTag, ColumnRef]:
+    """The column-scoped domain-type property over a caller-supplied grounding.
+
+    The transfer catalogs (the Kennedy arithmetic, the additive agree-or-conflict
+    rule, the tag-passthrough aggregates) are the reusable surface; the grounding is
+    the only part that varies between a synthetic-fact test and the eventual contract
+    bridge. No semiring: a confluence widens by the lattice ``join``, which is the
+    correct "keep only what both arms agree on" for tags.
+    """
+    return column_property(
+        name="domain_type",
+        lattice=DOMAIN_TYPE_LATTICE,
+        operators=DOMAIN_TYPE_OPERATORS,
+        aggregates=DOMAIN_TYPE_AGGREGATES,
+        ground=ground,
+    )

--- a/src/dblect/lineage/properties/domain_type.py
+++ b/src/dblect/lineage/properties/domain_type.py
@@ -22,8 +22,9 @@ summarizability story (Lenz & Shoshani, SSDBM 1997); see
 Naked-amount taint falls out of lineage: when ``amount`` flows to a model where
 its companion ``currency`` column was projected away, the binding rides as a
 reference that no longer agrees at a confluence and widens to ``NAKED``; the
-coherence guard (a separate build) then blocks a downstream sum until a
-dependency discharges it.
+coherence guard then blocks a downstream sum until a dependency discharges it.
+The guard is armed by :func:`domain_type_property` when the caller passes the
+functional-dependency property's ref.
 
 Grounding for the first version comes from synthetic facts supplied by a caller
 (the same way the uniqueness and nullability tests ground their properties); the
@@ -45,12 +46,15 @@ from dblect.lineage.facts.lattice import Lattice
 from dblect.lineage.facts.model import Annotation, Fact, Opacity
 from dblect.lineage.facts.property import (
     AggregateRule,
+    CoherenceGuard,
     DepContext,
     OperatorTransfer,
     Property,
+    PropertyRef,
     column_property,
 )
-from dblect.lineage.graph import ColumnRef
+from dblect.lineage.graph import ColumnRef, SourceRef
+from dblect.lineage.properties.functional_dependency import FDSet, determines
 
 # --- unit and tag identities -------------------------------------------------
 
@@ -365,6 +369,36 @@ DOMAIN_TYPE_AGGREGATES: Mapping[type[exp.AggFunc], AggregateRule[DomainTag]] = {
 }
 
 
+def companion_columns(tag: DomainTag) -> frozenset[ColumnRef]:
+    """The per-row companion columns a tag's meaning rests on: every ``PerRow``
+    unit in the dimension and every ``PerRow`` nominal binding. These are what an
+    aggregate's coherence guard must prove constant per group; a ``Concrete``
+    identity is constant everywhere, so it asks for nothing."""
+    if isinstance(tag, _Conflict):
+        return frozenset()
+    out: set[ColumnRef] = set()
+    if tag.dimension is not None:
+        out.update(unit.column for unit, _ in tag.dimension.exponents if isinstance(unit, PerRow))
+    out.update(binding.column for _, binding in tag.nominal if isinstance(binding, PerRow))
+    return frozenset(out)
+
+
+def _guarded_aggregates(
+    fd: PropertyRef[FDSet, SourceRef],
+) -> Mapping[type[exp.AggFunc], AggregateRule[DomainTag]]:
+    """The aggregate catalog with the coherence obligation armed on the combining
+    aggregates. ``sum`` and ``avg`` synthesize a new value out of many, so a
+    varying tag corrupts the result and the guard clears it unless discharged.
+    ``min``/``max`` select an existing value and ``count`` ignores values, so
+    they keep their unguarded rules."""
+    guard = CoherenceGuard(fd=fd, companions=companion_columns, entails=determines)
+    return {
+        **DOMAIN_TYPE_AGGREGATES,
+        exp.Sum: AggregateRule(core=_passthrough_core, coherence=guard),
+        exp.Avg: AggregateRule(core=_passthrough_core, coherence=guard),
+    }
+
+
 # --- the property ------------------------------------------------------------
 
 
@@ -381,6 +415,8 @@ def domain_type_grounding(
 
 def domain_type_property(
     ground: Callable[[ColumnRef], Annotation[DomainTag]],
+    *,
+    fd: PropertyRef[FDSet, SourceRef] | None = None,
 ) -> Property[DomainTag, ColumnRef]:
     """The column-scoped domain-type property over a caller-supplied grounding.
 
@@ -389,11 +425,19 @@ def domain_type_property(
     the only part that varies between a synthetic-fact test and the eventual contract
     bridge. No semiring: a confluence widens by the lattice ``join``, which is the
     correct "keep only what both arms agree on" for tags.
+
+    Passing the functional-dependency property's ref arms the coherence guard on
+    ``sum`` and ``avg``: an aggregate over a per-row companion tag keeps its tag
+    only where the group key holds the companion constant (membership, a pin, or
+    an FD entailment at the aggregation input) and clears to top otherwise. The
+    edge is declared in ``depends_on``, so the registry evaluates dependencies
+    first and the guard's read is always answered.
     """
     return column_property(
         name="domain_type",
         lattice=DOMAIN_TYPE_LATTICE,
         operators=DOMAIN_TYPE_OPERATORS,
-        aggregates=DOMAIN_TYPE_AGGREGATES,
+        aggregates=DOMAIN_TYPE_AGGREGATES if fd is None else _guarded_aggregates(fd),
         ground=ground,
+        depends_on=() if fd is None else (fd,),
     )

--- a/src/dblect/lineage/properties/functional_dependency.py
+++ b/src/dblect/lineage/properties/functional_dependency.py
@@ -1,0 +1,364 @@
+"""Functional-dependency property: the dependencies a relation's rows satisfy.
+
+A relation's value is a set of functional dependencies over its output column
+names, each one ``X -> y``: rows equal on ``X`` are equal on ``y``. This is the
+discharge substrate the aggregate coherence guard reads. ``sum(amount) group by
+country`` over a per-row currency is well typed exactly when the group key holds
+the currency constant per group, and a ``country -> currency`` dependency is the
+summarizability argument for that (Lenz & Shoshani, SSDBM 1997; Hurtado &
+Mendelzon, ICDT 2001). Entailment (:func:`determines`) is attribute closure under
+Armstrong's axioms.
+
+The lattice orders by precision exactly as uniqueness orders keys: knowing more
+dependencies is more precise, so ``meet`` (resolution of declarations) unions the
+sets, ``join`` (confluence) intersects them, ``top`` is the empty set, and
+``bottom`` is a formal universal element no real resolution reaches.
+
+Dependencies come from four places. A declaration grounds one directly (synthetic
+facts until the authoring bridge lands; the ``determines(...)`` contract is its
+eventual source). An equality filter pins a column constant, the empty-determinant
+dependency. A GROUP BY makes its group key determine every output (the key of the
+grouped result). And a candidate key read from the uniqueness property determines
+every column selected alongside it, since a relation unique on ``K`` admits one
+row per ``K`` value. Posture elsewhere is silent-when-unproven: a join can pair
+determinant values across sources and two UNION arms can each satisfy a dependency
+their union violates, so both prove nothing (the join transfer is a later build,
+alongside the rest of the join concerns).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Collection, Mapping
+from dataclasses import dataclass
+
+import sqlglot.expressions as exp
+from sqlglot import Expr
+
+from dblect.lineage.facts.grounding import grounding
+from dblect.lineage.facts.lattice import Lattice
+from dblect.lineage.facts.model import Annotation, Fact, Opacity
+from dblect.lineage.facts.property import DepContext, Property, PropertyRef, relation_property
+from dblect.lineage.graph import SourceRef, source_ref_meta
+from dblect.lineage.properties.predicate_flow import explicit_rename, has_star
+from dblect.lineage.properties.uniqueness import CandidateKeySet, Key
+from dblect.sql import _sqlglot as sg
+
+# --- the value type ------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class FD:
+    """One dependency over a relation's output column names, in canonical
+    single-dependent form (``X -> yz`` splits into ``X -> y`` and ``X -> z``).
+    Names are case-folded to match the graph. An empty determinant says the
+    dependent is constant over the whole relation, the strongest claim."""
+
+    determinant: frozenset[str]
+    dependent: str
+
+
+@dataclass(frozen=True, slots=True)
+class FDSet:
+    """The dependencies a relation is known to satisfy.
+
+    ``fds`` holds the known dependencies; the empty set is the lattice ``top``
+    ("no dependency known"). ``is_bottom`` marks the formal universal element (the
+    lattice ``bottom``): it absorbs under ``meet`` and is the identity under
+    ``join``, and no resolution of real declarations reaches it, since dependency
+    claims only ever union. Equality is structural, so ``FDSet(frozenset())``
+    (top) and the bottom sentinel are distinct values.
+    """
+
+    fds: frozenset[FD]
+    is_bottom: bool = False
+
+    @staticmethod
+    def of(*fds: FD) -> FDSet:
+        return FDSet(frozenset(fds))
+
+
+# The empty dependency set: "we know of no dependency", the value every
+# undeclared relation grounds to and the meet identity.
+NO_FDS: FDSet = FDSet(frozenset())
+
+# The formal universal element. Unreachable when resolving real declarations
+# (they only union), present so the lattice is bounded.
+ALL_FDS: FDSet = FDSet(frozenset(), is_bottom=True)
+
+
+def _meet(a: FDSet, b: FDSet) -> FDSet:
+    """Most precise value consistent with both: the union of the dependencies."""
+    if a.is_bottom or b.is_bottom:
+        return ALL_FDS
+    return FDSet(a.fds | b.fds)
+
+
+def _join(a: FDSet, b: FDSet) -> FDSet:
+    """Least precise value both refine: the dependencies both sides carry."""
+    if a.is_bottom:
+        return b
+    if b.is_bottom:
+        return a
+    return FDSet(a.fds & b.fds)
+
+
+FUNCTIONAL_DEPENDENCY_LATTICE: Lattice[FDSet] = Lattice(
+    meet=_meet,
+    join=_join,
+    top=NO_FDS,
+    bottom=ALL_FDS,
+)
+
+
+def determines(value: FDSet, given: frozenset[str], target: str) -> bool:
+    """Whether ``value`` entails ``given -> target``: attribute closure under
+    Armstrong's axioms (sound and complete for FD entailment). The bottom sentinel
+    entails everything, and a target inside ``given`` holds by reflexivity."""
+    if target in given:
+        return True
+    if value.is_bottom:
+        return True
+    closure = set(given)
+    changed = True
+    while changed:
+        changed = False
+        for fd in value.fds:
+            if fd.dependent not in closure and fd.determinant <= closure:
+                closure.add(fd.dependent)
+                changed = True
+    return target in closure
+
+
+# --- grounding -----------------------------------------------------------------
+
+
+def functional_dependency_grounding(
+    facts: Mapping[SourceRef, tuple[Fact[FDSet, SourceRef], ...]],
+    *,
+    opaque: Collection[SourceRef] = (),
+) -> Callable[[SourceRef], Annotation[FDSet]]:
+    """Fold the per-relation dependency facts into grounded annotations. The same
+    fold every property uses: an opt-out grounds EXPLICIT top, a resolved bucket
+    grounds its value CONCRETE, everything else the IMPLICIT-top default."""
+    return grounding(facts, opaque, FUNCTIONAL_DEPENDENCY_LATTICE)
+
+
+# --- the relation reducer --------------------------------------------------------
+#
+# The relation-algebra walk for dependencies, the same shape as the predicate-flow
+# walk: single-source scopes carry, rename through the projection, and every shape
+# outside the modelled fragment drops to the empty set rather than over-claiming.
+
+
+@dataclass(frozen=True, slots=True)
+class _Base:
+    """What a resolved FROM source contributes: its dependencies (in its output
+    column names) and, for a base table with the uniqueness edge live, its
+    candidate keys (each of which determines the columns read alongside it)."""
+
+    fds: frozenset[FD]
+    keys: frozenset[Key] = frozenset()
+
+
+_NOTHING: _Base = _Base(frozenset())
+
+# Resolves a base (non-CTE) table reference to what it contributes. The reducer's
+# implementation recurses through the shared propagator via the table's stamped
+# SourceRef, so declarations and the provisional taint flow across models.
+_BaseResolve = Callable[["exp.Table"], _Base]
+
+
+class _FdWalk:
+    """Bottom-up dependency inference over one relational tree.
+
+    ``base_resolve`` resolves a base table; CTEs and inline subqueries are
+    resolved structurally within the walk. Only single-source scopes carry:
+    a join or a UNION proves nothing, and an unmodellable group shape (positional
+    or computed group keys) drops the scope's dependencies entirely.
+    """
+
+    def __init__(self, base_resolve: _BaseResolve) -> None:
+        self._base_resolve = base_resolve
+
+    def scope_fds(self, node: Expr, *, cte_scope: Mapping[str, frozenset[FD]]) -> frozenset[FD]:
+        if isinstance(node, exp.Select):
+            return self._select(node, cte_scope=cte_scope)
+        return frozenset()
+
+    def _select(self, sel: exp.Select, *, cte_scope: Mapping[str, frozenset[FD]]) -> frozenset[FD]:
+        local = dict(cte_scope)
+        with_ = sel.args.get("with_")
+        if isinstance(with_, exp.With):
+            for cte in with_.expressions:
+                if isinstance(cte, exp.CTE) and isinstance(cte.this, Expr):
+                    local[cte.alias_or_name] = self.scope_fds(cte.this, cte_scope=local)
+
+        from_ = sg.from_of(sel)
+        if from_ is None or not isinstance(from_.this, Expr):
+            return frozenset()
+        if sg.joins_of(sel):
+            return frozenset()  # a join can pair determinant values across sources
+        base = self._resolve_source(from_.this, cte_scope=local)
+        if base is None:
+            return frozenset()
+        carried = base.fds
+
+        # A dependency is universally quantified over row pairs, and a WHERE only
+        # removes pairs, so everything carries; an equality filter additionally pins
+        # its column constant, the empty-determinant dependency.
+        where = sg.where_of(sel)
+        if where is not None and isinstance(where.this, Expr):
+            carried = carried | {
+                FD(frozenset(), sg.column_name(col).lower())
+                for col in sg.equality_literal_columns(where.this)
+            }
+
+        star = has_star(sel)
+        rename = explicit_rename(sel)
+
+        # A relation unique on K admits one row per K value, so K determines every
+        # column this scope reads from it. Minted only over named projections: under
+        # a bare star the column universe is unknown.
+        for key in base.keys:
+            carried = carried | {FD(key, dep) for dep in rename if dep not in key}
+
+        group = sg.group_of(sel)
+        group_names: frozenset[str] | None = None
+        if group is not None and group.expressions:
+            group_names = _group_columns(group)
+            if group_names is None:
+                return frozenset()  # unmodellable group shape: prove nothing
+            # Grouping aggregates everything outside the group key away, so only a
+            # dependency lying entirely within it still describes the output rows.
+            carried = frozenset(
+                fd for fd in carried if fd.determinant | {fd.dependent} <= group_names
+            )
+
+        out = carried if star else _remap(carried, rename)
+        if group_names is not None:
+            group_out = group_names if star else _remap_columns(group_names, rename)
+            if group_out is not None:
+                # The group key is a key of the grouped result (one row per group),
+                # so it determines every named output.
+                out = out | {
+                    FD(group_out, name) for name in _named_outputs(sel) if name not in group_out
+                }
+        return out
+
+    def _resolve_source(
+        self, node: Expr, *, cte_scope: Mapping[str, frozenset[FD]]
+    ) -> _Base | None:
+        if isinstance(node, exp.Table):
+            if node.name in cte_scope:
+                return _Base(cte_scope[node.name])
+            return self._base_resolve(node)
+        if isinstance(node, exp.Subquery):
+            inner = node.this
+            if not isinstance(inner, Expr):
+                return None
+            return _Base(self.scope_fds(inner, cte_scope=cte_scope))
+        return None
+
+
+def _group_columns(group: exp.Group) -> frozenset[str] | None:
+    """The group key as case-folded input column names, or ``None`` for a shape we
+    cannot name (positional or expression group keys)."""
+    out: set[str] = set()
+    for g in group.expressions:
+        if not isinstance(g, exp.Column) or isinstance(g.this, exp.Star):
+            return None
+        out.add(sg.column_name(g).lower())
+    return frozenset(out)
+
+
+def _remap(fds: frozenset[FD], rename: Mapping[str, tuple[str, ...]]) -> frozenset[FD]:
+    """Rename each dependency onto the projection's output names, dropping any whose
+    columns do not all survive. One output name per input column suffices (copies of
+    a column carry equal values), picked stably."""
+    out: set[FD] = set()
+    for fd in fds:
+        determinant = _remap_columns(fd.determinant, rename)
+        dependent = rename.get(fd.dependent)
+        if determinant is None or not dependent:
+            continue
+        out.add(FD(determinant, min(dependent)))
+    return frozenset(out)
+
+
+def _remap_columns(
+    columns: frozenset[str], rename: Mapping[str, tuple[str, ...]]
+) -> frozenset[str] | None:
+    out: set[str] = set()
+    for col in columns:
+        names = rename.get(col)
+        if not names:
+            return None
+        out.add(min(names))
+    return frozenset(out)
+
+
+def _named_outputs(sel: exp.Select) -> frozenset[str]:
+    """Every output column the projection names: bare columns and aliases, computed
+    projections included (an aggregate's alias is exactly what a group key
+    determines). Unnamed shapes contribute nothing."""
+    names: set[str] = set()
+    for proj in sel.expressions:
+        if isinstance(proj, exp.Alias):
+            names.add(proj.alias_or_name.lower())
+        elif isinstance(proj, exp.Column) and not isinstance(proj.this, exp.Star):
+            names.add(sg.column_name(proj).lower())
+    return frozenset(names)
+
+
+# --- the property ------------------------------------------------------------
+
+
+def functional_dependency_property(
+    ground: Callable[[SourceRef], Annotation[FDSet]],
+    *,
+    uniqueness: PropertyRef[CandidateKeySet, SourceRef] | None = None,
+) -> Property[FDSet, SourceRef]:
+    """The relation-scoped functional-dependency property over a caller-supplied
+    grounding (synthetic facts in tests; the contract bridge is the eventual
+    source). Declared and inferred dependencies both hold, so they compose by meet
+    (``reconcile_by_meet``), exactly as uniqueness composes keys. Passing the
+    uniqueness property's ref switches on the key-derived source and declares the
+    dependency edge the registry orders by."""
+
+    def reduce_(
+        deriv: Expr,
+        _prop: Property[FDSet, SourceRef],
+        recurse: Callable[[SourceRef], Annotation[FDSet]],
+        ctx: DepContext,
+        _default: Annotation[FDSet],
+    ) -> Annotation[FDSet]:
+        provisional = False
+
+        def base_resolve(table: exp.Table) -> _Base:
+            nonlocal provisional
+            ref = source_ref_meta(table)
+            if ref is None:
+                return _NOTHING
+            ann = recurse(ref)
+            provisional = provisional or ann.provisional
+            keys: frozenset[Key] = frozenset()
+            if uniqueness is not None:
+                key_ann = ctx.annotation(uniqueness, ref)
+                if key_ann is not None:
+                    keys = key_ann.value.keys
+            return _Base(ann.value.fds, keys)
+
+        fds = _FdWalk(base_resolve).scope_fds(deriv, cte_scope={})
+        opacity = Opacity.CONCRETE if fds else Opacity.IMPLICIT
+        return Annotation(FDSet(fds), opacity, provisional=provisional)
+
+    return relation_property(
+        name="functional_dependency",
+        lattice=FUNCTIONAL_DEPENDENCY_LATTICE,
+        operators={},
+        aggregates={},
+        ground=ground,
+        depends_on=(uniqueness,) if uniqueness is not None else (),
+        reconcile_by_meet=True,
+        reducer=reduce_,
+    )

--- a/src/dblect/lineage/properties/predicate_flow.py
+++ b/src/dblect/lineage/properties/predicate_flow.py
@@ -211,9 +211,9 @@ def _project_filter(sel: exp.Select, atoms: frozenset[Canon]) -> frozenset[Canon
     drops if its column has no image; an opaque atom drops, since its column is
     unknown and cannot be tracked through the rename.
     """
-    if _has_star(sel):
+    if has_star(sel):
         return atoms
-    rename = _explicit_rename(sel)
+    rename = explicit_rename(sel)
     out: set[Canon] = set()
     for atom in atoms:
         if not isinstance(atom, CmpAtom | InAtom):
@@ -226,7 +226,7 @@ def _project_filter(sel: exp.Select, atoms: frozenset[Canon]) -> frozenset[Canon
     return frozenset(out)
 
 
-def _has_star(sel: exp.Select) -> bool:
+def has_star(sel: exp.Select) -> bool:
     for proj in sel.expressions:
         if isinstance(proj, exp.Star):
             return True
@@ -235,7 +235,7 @@ def _has_star(sel: exp.Select) -> bool:
     return False
 
 
-def _explicit_rename(sel: exp.Select) -> Mapping[str, tuple[str, ...]]:
+def explicit_rename(sel: exp.Select) -> Mapping[str, tuple[str, ...]]:
     """Each input column's output name(s) under an explicit (star-free) projection.
 
     An output name that more than one input column resolves to is ambiguous and is

--- a/src/dblect/lineage/property.py
+++ b/src/dblect/lineage/property.py
@@ -40,13 +40,21 @@ from dblect.lineage.facts.lattice import Lattice, consistent
 from dblect.lineage.facts.model import Annotation, Opacity, ScopeKind
 from dblect.lineage.facts.property import (
     AggregateRule,
+    CoherenceGuard,
     DepContext,
     OperatorTransfer,
     Property,
     Reducer,
 )
 from dblect.lineage.facts.registry import AnnotationStore, PropertyRegistry
-from dblect.lineage.graph import ColumnLineageGraph, ColumnRef, LineageView, SourceRef
+from dblect.lineage.graph import (
+    AggregationSite,
+    ColumnLineageGraph,
+    ColumnRef,
+    LineageView,
+    SourceRef,
+    aggregation_site_meta,
+)
 
 K = TypeVar("K")
 S = TypeVar("S", ColumnRef, SourceRef)
@@ -257,7 +265,7 @@ def _column_reduce(
             if child is None:
                 return default_ann
             child_ann = _column_reduce(child, prop, annotate, dep_context, default_ann)
-            return _apply_aggregate(rule, expr, child_ann)
+            return _apply_aggregate(rule, expr, child_ann, dep_context, lat)
         # An aggregate with no registered rule falls through to operator dispatch.
 
     op = _lookup_subclass(prop.operators, type(expr))
@@ -274,15 +282,62 @@ def _column_reduce(
 
 
 def _apply_aggregate(
-    rule: AggregateRule[K], expr: exp.AggFunc, child: Annotation[K]
+    rule: AggregateRule[K],
+    expr: exp.AggFunc,
+    child: Annotation[K],
+    dep_context: DepContext,
+    lat: Lattice[K],
 ) -> Annotation[K]:
-    """Apply an aggregate rule's pure ``core``.
+    """Apply an aggregate rule's pure ``core``, then its coherence guard.
 
-    The optional coherence guard (an FD read that clears to top on failure) reads a
-    dependency property and lands with the first aggregate that needs it; the
-    shipping properties carry no guard, so the core is the whole rule here.
+    The guard is the one channel a dependency enters an aggregate through: where a
+    per-row companion of the aggregated value is not provably constant per group,
+    the result clears to the lattice top. The cleared top is IMPLICIT, so a
+    downstream seam warns on it rather than reading it as a declared opt-out.
     """
-    return rule.core(expr, child)
+    result = rule.core(expr, child)
+    guard = rule.coherence
+    if guard is None or _coherent(guard, child.value, aggregation_site_meta(expr), dep_context):
+        return result
+    return Annotation(lat.top, Opacity.IMPLICIT, provisional=child.provisional)
+
+
+def _coherent(
+    guard: CoherenceGuard[K, Any],
+    value: K,
+    site: AggregationSite | None,
+    dep_context: DepContext,
+) -> bool:
+    """Whether every companion column the aggregated value references is constant
+    within each group: in the group key, pinned by the scope's own filter, or
+    functionally determined by the group columns at the aggregation input.
+
+    Posture is silent-when-unproven. No stamped site (a windowed aggregate, an
+    unmodelled scope) or an unresolvable group shape fails the guard rather than
+    guessing. The dependency path applies only to a companion bound to a column of
+    the aggregation input itself: a binding that survived from a relation further
+    upstream is not chased (rebinding companions through projections is a later
+    build), so it discharges only through group membership or a pin.
+    """
+    companions = guard.companions(value)
+    if not companions:
+        return True
+    if site is None or site.group_refs is None:
+        return False
+    fd_ann = (
+        dep_context.annotation(guard.fd, site.input_source)
+        if site.input_source is not None
+        else None
+    )
+    antecedent = frozenset(g.column for g in site.group_refs if g.source == site.input_source)
+    for companion in companions:
+        if companion in site.group_refs or companion in site.pinned:
+            continue
+        if fd_ann is None or companion.source != site.input_source:
+            return False
+        if not guard.entails(fd_ann.value, antecedent, companion.column):
+            return False
+    return True
 
 
 def _fold(

--- a/src/dblect/sql/_sqlglot.py
+++ b/src/dblect/sql/_sqlglot.py
@@ -155,6 +155,30 @@ def equality_cols_on_alias(predicate: Expr, alias: str) -> frozenset[str] | None
     return frozenset(cols)
 
 
+def equality_literal_columns(predicate: Expr) -> tuple[exp.Column, ...]:
+    """Columns a conjunct of `predicate` pins to a literal (``col = 'usd'``).
+
+    Walks the AND-conjunction; a leaf contributes its column only when it is an
+    ``exp.EQ`` between a bare column and a literal, in either order. Other leaves
+    are simply skipped (unlike :func:`equality_cols_on_alias`, a non-equality
+    conjunct does not poison the rest: each pin stands on its own conjunct).
+    """
+    out: list[exp.Column] = []
+    for leaf in _conjunctive_leaves(predicate):
+        if not isinstance(leaf, exp.EQ):
+            continue
+        sides = (leaf.this, leaf.expression)
+        for col, lit in (sides, sides[::-1]):
+            if (
+                isinstance(col, exp.Column)
+                and not isinstance(col.this, exp.Star)
+                and isinstance(lit, exp.Literal)
+            ):
+                out.append(col)
+                break
+    return tuple(out)
+
+
 def _conjunctive_leaves(predicate: Expr) -> list[Expr]:
     """Flatten an ``AND``-only conjunction into its leaves; non-AND nodes are leaves."""
     if isinstance(predicate, exp.And):

--- a/tests/lineage/test_domain_type_coherence.py
+++ b/tests/lineage/test_domain_type_coherence.py
@@ -1,0 +1,264 @@
+"""The aggregate coherence guard: a sum over a per-row tag clears unless discharged.
+
+This is the headline aggregation contract from the currency story. ``amount``
+carries a per-row currency binding (a ``Money`` whose unit is the companion
+``currency`` column), and ``SUM(amount) GROUP BY country`` is meaningful only when
+the currency is constant within each group. The discharge paths are exactly the
+three the algebra admits: the companion is in the group key, the companion is
+pinned (a literal binding, or an equality filter in the aggregating scope), or the
+group key functionally determines the companion (a ``country -> currency``
+dependency read from the FD property). Where no path discharges, the aggregate
+clears to the lattice top, which is what a downstream seam reports as the
+mixed-currency-sum finding.
+
+The guard's posture everywhere it cannot see is silent-when-unproven: a join
+input, a windowed aggregate, or a companion bound to a column of some other
+relation all clear rather than guess.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from dblect.lineage.builder import build_model_graph, build_relation_graph
+from dblect.lineage.facts.model import Annotation, Declared, DeclaredSource, Fact, Opacity
+from dblect.lineage.facts.registry import AnnotationStore, PropertyRegistry
+from dblect.lineage.graph import ColumnLineageGraph, ColumnRef, SourceKind, SourceRef
+from dblect.lineage.properties.domain_type import (
+    NAKED,
+    Concrete,
+    Dimension,
+    DomainTag,
+    PerRow,
+    domain_type_grounding,
+    domain_type_property,
+    tagged,
+)
+from dblect.lineage.properties.functional_dependency import (
+    FD,
+    NO_FDS,
+    FDSet,
+    functional_dependency_grounding,
+    functional_dependency_property,
+)
+from dblect.lineage.property import propagate
+from dblect.manifest import Manifest, Node, ResourceType
+
+_SRC = SourceRef(SourceKind.SOURCE, "source.shop.raw.payments")
+_CUSTOMERS = SourceRef(SourceKind.SOURCE, "source.shop.raw.customers")
+_STG = SourceRef(SourceKind.MODEL, "model.shop.stg")
+_MODEL = SourceRef(SourceKind.MODEL, "model.shop.m")
+
+_PER_ROW = tagged(dimension=Dimension.of(PerRow(ColumnRef(_SRC, "currency"))))
+_USD = tagged(dimension=Dimension.of(Concrete("usd")))
+
+_SCHEMA: Mapping[str, Mapping[str, str]] = {
+    "payments": {
+        "amount": "DECIMAL",
+        "currency": "VARCHAR",
+        "country": "VARCHAR",
+        "customer_id": "INT",
+    },
+    "customers": {"id": "INT", "region": "VARCHAR"},
+    "stg": {"amount": "DECIMAL", "currency": "VARCHAR", "country": "VARCHAR"},
+}
+_NAME_TO_SOURCE: Mapping[str, SourceRef] = {
+    "payments": _SRC,
+    "customers": _CUSTOMERS,
+    "stg": _STG,
+}
+
+
+def _node(ref: SourceRef, sql: str | None) -> Node:
+    kind = ResourceType.MODEL if ref.kind is SourceKind.MODEL else ResourceType.SOURCE
+    return Node(
+        unique_id=ref.unique_id,
+        name=ref.unique_id.split(".")[-1],
+        resource_type=kind,
+        fqn=(ref.unique_id,),
+        package_name="shop",
+        schema="analytics",
+        raw_code=None,
+        compiled_code=sql,
+        original_file_path=None,
+        columns={},
+    )
+
+
+def _run(
+    sql: str,
+    *,
+    amount: DomainTag = _PER_ROW,
+    fds: FDSet = NO_FDS,
+    stg_sql: str | None = None,
+    out: str = "total",
+) -> Annotation[DomainTag]:
+    """Propagate functional dependencies over the relation graph, then domain type
+    over the column graph with the FD store as its dependency context, and read the
+    aggregate output column ``out`` of the leaf model."""
+    nodes = [_node(_SRC, None), _node(_CUSTOMERS, None), _node(_MODEL, sql)]
+    if stg_sql is not None:
+        nodes.append(_node(_STG, stg_sql))
+    manifest = Manifest(
+        schema_version="v12",
+        adapter_type="duckdb",
+        nodes={n.unique_id: n for n in nodes},
+    )
+
+    fd_fact = Fact(scope=_SRC, value=fds, provenance=Declared(DeclaredSource.USER_ASSERTED))
+    fd_prop = functional_dependency_property(functional_dependency_grounding({_SRC: (fd_fact,)}))
+    store = AnnotationStore()
+    for scope, ann in propagate(build_relation_graph(manifest).graph, fd_prop).items():
+        store.record(fd_prop.name, scope, ann)
+
+    amount_ref = ColumnRef(_SRC, "amount")
+    dt_facts = {
+        amount_ref: (
+            Fact(scope=amount_ref, value=amount, provenance=Declared(DeclaredSource.USER_ASSERTED)),
+        )
+    }
+    dt_prop = domain_type_property(domain_type_grounding(dt_facts), fd=fd_prop.ref)
+    ctx = PropertyRegistry((fd_prop, dt_prop)).dep_context(store)
+
+    graph = ColumnLineageGraph.empty()
+    for ref, model_sql in ((_STG, stg_sql), (_MODEL, sql)):
+        if model_sql is None:
+            continue
+        graph = graph.merge(
+            build_model_graph(
+                model_uid=ref.unique_id,
+                sql=model_sql,
+                name_to_source=_NAME_TO_SOURCE,
+                schema=_SCHEMA,
+            )
+        )
+    anns = propagate(graph, dt_prop, dep_context=ctx)
+    return anns[ColumnRef(_MODEL, out)]
+
+
+_HEADLINE = "SELECT country, SUM(amount) AS total FROM payments GROUP BY country"
+
+
+# --- the finding ---------------------------------------------------------------
+
+
+def test_undischarged_sum_clears_to_naked() -> None:
+    """The headline: summing a per-row-currency amount grouped by country, with no
+    dependency in sight, is not well typed; the tag clears."""
+    ann = _run(_HEADLINE)
+    assert ann.value == NAKED
+    assert ann.opacity is Opacity.IMPLICIT  # incidental top: a seam warns on it
+
+
+def test_ungrouped_sum_clears_to_naked() -> None:
+    """No GROUP BY reduces over the whole relation, the strictest obligation."""
+    ann = _run("SELECT SUM(amount) AS total FROM payments")
+    assert ann.value == NAKED
+
+
+# --- the discharges ------------------------------------------------------------
+
+
+def test_declared_fd_discharges_the_sum() -> None:
+    """``country -> currency`` holds each group to one currency, so the sum keeps
+    its tag even though the currency column was never read."""
+    fds = FDSet.of(FD(frozenset({"country"}), "currency"))
+    ann = _run(_HEADLINE, fds=fds)
+    assert ann.value == _PER_ROW
+
+
+def test_group_by_membership_discharges_the_sum() -> None:
+    sql = "SELECT country, currency, SUM(amount) AS total FROM payments GROUP BY country, currency"
+    ann = _run(sql)
+    assert ann.value == _PER_ROW
+
+
+def test_where_pin_discharges_the_sum() -> None:
+    sql = (
+        "SELECT country, SUM(amount) AS total FROM payments WHERE currency = 'usd' GROUP BY country"
+    )
+    ann = _run(sql)
+    assert ann.value == _PER_ROW
+
+
+def test_where_pin_discharges_an_ungrouped_sum() -> None:
+    ann = _run("SELECT SUM(amount) AS total FROM payments WHERE currency = 'usd'")
+    assert ann.value == _PER_ROW
+
+
+def test_constancy_fd_discharges_an_ungrouped_sum() -> None:
+    """A declared ``{} -> currency`` (single-currency relation) discharges even the
+    whole-relation reduction."""
+    ann = _run(
+        "SELECT SUM(amount) AS total FROM payments", fds=FDSet.of(FD(frozenset(), "currency"))
+    )
+    assert ann.value == _PER_ROW
+
+
+def test_concrete_binding_needs_no_discharge() -> None:
+    """A pinned literal currency is constant everywhere; the guard has nothing to ask."""
+    ann = _run(_HEADLINE, amount=_USD)
+    assert ann.value == _USD
+
+
+# --- aggregate kinds -----------------------------------------------------------
+
+
+def test_avg_is_guarded_like_sum() -> None:
+    assert (
+        _run("SELECT country, AVG(amount) AS total FROM payments GROUP BY country").value == NAKED
+    )
+    fds = FDSet.of(FD(frozenset({"country"}), "currency"))
+    sql = "SELECT country, AVG(amount) AS total FROM payments GROUP BY country"
+    assert _run(sql, fds=fds).value == _PER_ROW
+
+
+def test_count_is_unaffected() -> None:
+    ann = _run("SELECT country, COUNT(amount) AS total FROM payments GROUP BY country")
+    assert ann.value == NAKED
+    assert not ann.provisional
+
+
+# --- shapes the guard cannot see clear conservatively ----------------------------
+
+
+def test_join_input_blocks_the_fd_discharge() -> None:
+    """The aggregation input is not one relation the FD property annotates, so the
+    dependency path is closed; only group membership or a pin can discharge."""
+    fds = FDSet.of(FD(frozenset({"country"}), "currency"))
+    sql = (
+        "SELECT p.country, SUM(p.amount) AS total FROM payments p "
+        "JOIN customers c ON p.customer_id = c.id GROUP BY p.country"
+    )
+    assert _run(sql, fds=fds).value == NAKED
+
+
+def test_group_membership_still_discharges_over_a_join() -> None:
+    """The companion in the group key is constant per group whatever the join did;
+    fan-out is the grain axis, not tag coherence."""
+    sql = (
+        "SELECT p.country, p.currency, SUM(p.amount) AS total FROM payments p "
+        "JOIN customers c ON p.customer_id = c.id GROUP BY p.country, p.currency"
+    )
+    assert _run(sql).value == _PER_ROW
+
+
+def test_companion_bound_to_another_relation_clears() -> None:
+    """The amount reaches the aggregate through an intermediate model, so its
+    companion still names the original source's column while the aggregation input
+    is the intermediate. The guard does not chase bindings across relations yet, so
+    it clears; rebinding the companion through projections is future work."""
+    fds = FDSet.of(FD(frozenset({"country"}), "currency"))
+    ann = _run(
+        "SELECT country, SUM(amount) AS total FROM stg GROUP BY country",
+        fds=fds,
+        stg_sql="SELECT country, currency, amount FROM payments",
+    )
+    assert ann.value == NAKED
+
+
+def test_windowed_aggregate_clears() -> None:
+    """A window's partition list, not the scope's GROUP BY, is its group key; until
+    the guard reads window structure it stays silent-when-unproven."""
+    sql = "SELECT SUM(amount) OVER (PARTITION BY currency) AS total FROM payments"
+    assert _run(sql).value == NAKED

--- a/tests/lineage/test_domain_type_lattice.py
+++ b/tests/lineage/test_domain_type_lattice.py
@@ -97,6 +97,17 @@ def test_meet_composes_agreeing_tags() -> None:
     )
 
 
+def test_concrete_identities_are_case_folded() -> None:
+    """A currency declared ``usd`` on one model and ``USD`` on another names the
+    same unit, so the identities fold together rather than meeting to a spurious
+    conflict (or widening away at a confluence)."""
+    assert Concrete("USD") == Concrete("usd")
+    lower = tagged(dimension=Dimension.of(Concrete("usd")))
+    upper = tagged(dimension=Dimension.of(Concrete("USD")))
+    assert DOMAIN_TYPE_LATTICE.meet(lower, upper) == lower
+    assert DOMAIN_TYPE_LATTICE.join(lower, upper) == lower
+
+
 def test_meet_of_disagreeing_currencies_is_conflict() -> None:
     usd = tagged(dimension=Dimension.of(Concrete("usd")))
     eur = tagged(dimension=Dimension.of(Concrete("eur")))

--- a/tests/lineage/test_domain_type_lattice.py
+++ b/tests/lineage/test_domain_type_lattice.py
@@ -1,0 +1,199 @@
+"""The domain-type lattice and the dimensional group underneath it.
+
+Tag knowledge orders by precision: ``NAKED`` (no claim) is the top, a known tagging
+refines it, and two disagreeing taggings meet to ``CONFLICT``. ``meet`` composes
+agreeing tags and conflicts on disagreement; ``join`` keeps only what both sides
+agree on. The shared :func:`assert_lattice_laws` pins the bounded-lattice algebra;
+the targeted tests pin the domain-type reading of meet and join, and the dimension
+tests pin the free-abelian-group arithmetic ``*`` and ``/`` ride on.
+"""
+
+from __future__ import annotations
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from dblect.lineage.facts.lattice import resolve
+from dblect.lineage.facts.model import Declared, DeclaredSource, Fact
+from dblect.lineage.graph import ColumnRef, SourceKind, SourceRef
+from dblect.lineage.properties.domain_type import (
+    CONFLICT,
+    DOMAIN_TYPE_LATTICE,
+    NAKED,
+    Concrete,
+    Dimension,
+    DomainTag,
+    Nominal,
+    PerRow,
+    Tagged,
+    Unit,
+    tagged,
+)
+from tests.lineage._lattice_laws import assert_consistency_laws, assert_lattice_laws
+
+_REL = SourceRef(SourceKind.MODEL, "model.shop.charges")
+_CURRENCY_COL = ColumnRef(_REL, "currency")
+_COUNTRY_COL = ColumnRef(_REL, "country")
+
+# A small unit alphabet: two pinned currencies and one per-row companion column.
+_units: st.SearchStrategy[Unit] = st.one_of(
+    st.just(Concrete("usd")),
+    st.just(Concrete("eur")),
+    st.just(PerRow(_CURRENCY_COL)),
+)
+_nominal_bindings: st.SearchStrategy[Nominal] = st.one_of(
+    st.just(Concrete("true")),
+    st.just(Concrete("false")),
+    st.just(PerRow(_COUNTRY_COL)),
+)
+
+
+@st.composite
+def _dimensions(draw: st.DrawFn) -> Dimension:
+    raw: dict[Unit, int] = draw(st.dictionaries(_units, st.integers(-2, 2), max_size=3))
+    dim = Dimension.dimensionless()
+    for unit, power in raw.items():
+        dim = dim.multiply(Dimension.of(unit, power))
+    return dim
+
+
+@st.composite
+def _tagged(draw: st.DrawFn) -> Tagged:
+    dim: Dimension | None = draw(st.none() | _dimensions())
+    nominal: dict[str, Nominal] = draw(
+        st.dictionaries(st.sampled_from(("contains_tax", "country")), _nominal_bindings, max_size=2)
+    )
+    return tagged(dimension=dim, nominal=nominal)
+
+
+# Mostly real taggings, occasionally the conflict bottom, so the law arms that
+# touch bottom are exercised without swamping the normal cases.
+_values: st.SearchStrategy[DomainTag] = st.one_of(_tagged(), st.just(CONFLICT))
+
+
+@given(_values, _values, _values)
+def test_domain_type_lattice_laws(a: DomainTag, b: DomainTag, c: DomainTag) -> None:
+    assert_lattice_laws(DOMAIN_TYPE_LATTICE, a, b, c)
+
+
+@given(_values, _values)
+def test_domain_type_consistency_laws(declared: DomainTag, value: DomainTag) -> None:
+    assert_consistency_laws(DOMAIN_TYPE_LATTICE, declared, value)
+
+
+def test_top_is_naked() -> None:
+    assert DOMAIN_TYPE_LATTICE.top == NAKED
+    assert Tagged(dimension=None, nominal=frozenset()) == NAKED
+
+
+def test_meet_composes_agreeing_tags() -> None:
+    """A taxed-revenue claim met with a shipped-revenue claim carries both, the
+    ``compose`` operation of the algebra."""
+    taxed = tagged(nominal={"contains_tax": Concrete("false")})
+    shipped = tagged(nominal={"contains_shipping": Concrete("true")})
+    both = DOMAIN_TYPE_LATTICE.meet(taxed, shipped)
+    assert both == tagged(
+        nominal={"contains_tax": Concrete("false"), "contains_shipping": Concrete("true")}
+    )
+
+
+def test_meet_of_disagreeing_currencies_is_conflict() -> None:
+    usd = tagged(dimension=Dimension.of(Concrete("usd")))
+    eur = tagged(dimension=Dimension.of(Concrete("eur")))
+    assert DOMAIN_TYPE_LATTICE.meet(usd, eur) is CONFLICT
+
+
+def test_meet_of_disagreeing_nominal_is_conflict() -> None:
+    taxed = tagged(nominal={"contains_tax": Concrete("true")})
+    untaxed = tagged(nominal={"contains_tax": Concrete("false")})
+    assert DOMAIN_TYPE_LATTICE.meet(taxed, untaxed) is CONFLICT
+
+
+def test_meet_with_naked_keeps_the_known_tag() -> None:
+    usd = tagged(dimension=Dimension.of(Concrete("usd")))
+    assert DOMAIN_TYPE_LATTICE.meet(usd, NAKED) == usd
+    assert DOMAIN_TYPE_LATTICE.meet(NAKED, usd) == usd
+
+
+def test_join_widens_disagreement_to_naked() -> None:
+    """Two known currencies at a confluence widen to ``NAKED``: the result is
+    summable-by-omission only because the analyzer no longer knows the unit."""
+    usd = tagged(dimension=Dimension.of(Concrete("usd")))
+    eur = tagged(dimension=Dimension.of(Concrete("eur")))
+    assert DOMAIN_TYPE_LATTICE.join(usd, eur) == NAKED
+
+
+def test_join_keeps_the_tags_both_sides_share() -> None:
+    a = tagged(
+        dimension=Dimension.of(Concrete("usd")),
+        nominal={"contains_tax": Concrete("false"), "country": PerRow(_COUNTRY_COL)},
+    )
+    b = tagged(
+        dimension=Dimension.of(Concrete("usd")),
+        nominal={"contains_tax": Concrete("true"), "country": PerRow(_COUNTRY_COL)},
+    )
+    joined = DOMAIN_TYPE_LATTICE.join(a, b)
+    assert joined == tagged(
+        dimension=Dimension.of(Concrete("usd")), nominal={"country": PerRow(_COUNTRY_COL)}
+    )
+
+
+def test_known_tag_refines_naked() -> None:
+    usd = tagged(dimension=Dimension.of(Concrete("usd")))
+    assert DOMAIN_TYPE_LATTICE.refines(usd, NAKED)
+    assert not DOMAIN_TYPE_LATTICE.refines(NAKED, usd)
+
+
+def test_resolution_detects_a_currency_contradiction() -> None:
+    """Two pinned-currency facts on one column are mutually unsatisfiable, the
+    contradiction grounding reports rather than silently picking one."""
+    usd: Fact[DomainTag, ColumnRef] = Fact(
+        scope=_CURRENCY_COL,
+        value=tagged(dimension=Dimension.of(Concrete("usd"))),
+        provenance=Declared(DeclaredSource.USER_ASSERTED),
+    )
+    eur: Fact[DomainTag, ColumnRef] = Fact(
+        scope=_CURRENCY_COL,
+        value=tagged(dimension=Dimension.of(Concrete("eur"))),
+        provenance=Declared(DeclaredSource.USER_ASSERTED),
+    )
+    value, is_contradiction = resolve(DOMAIN_TYPE_LATTICE, (usd, eur))
+    assert is_contradiction
+    assert value is CONFLICT
+
+
+# --- the dimensional group ---------------------------------------------------
+
+
+@given(_dimensions(), _dimensions(), _dimensions())
+def test_dimension_multiply_is_a_commutative_monoid(
+    a: Dimension, b: Dimension, c: Dimension
+) -> None:
+    assert a.multiply(b) == b.multiply(a)
+    assert a.multiply(b).multiply(c) == a.multiply(b.multiply(c))
+    assert a.multiply(Dimension.dimensionless()) == a
+
+
+@given(_dimensions(), _dimensions())
+def test_dimension_divide_inverts_multiply(a: Dimension, b: Dimension) -> None:
+    assert a.multiply(b).divide(b) == a
+
+
+def test_same_currency_ratio_cancels_to_dimensionless() -> None:
+    usd = Dimension.of(Concrete("usd"))
+    assert usd.divide(usd).is_dimensionless
+
+
+def test_money_squared_is_a_known_point_not_dimensionless() -> None:
+    usd = Dimension.of(Concrete("usd"))
+    squared = usd.multiply(usd)
+    assert squared == Dimension.of(Concrete("usd"), 2)
+    assert not squared.is_dimensionless
+
+
+def test_per_row_units_cancel_only_for_the_same_column() -> None:
+    other = ColumnRef(_REL, "settlement_currency")
+    same = Dimension.of(PerRow(_CURRENCY_COL))
+    assert same.divide(same).is_dimensionless
+    mixed = Dimension.of(PerRow(_CURRENCY_COL)).divide(Dimension.of(PerRow(other)))
+    assert not mixed.is_dimensionless

--- a/tests/lineage/test_domain_type_propagation.py
+++ b/tests/lineage/test_domain_type_propagation.py
@@ -1,0 +1,167 @@
+"""Grounding and propagation for the domain-type property.
+
+Each source column grounds from a synthetic domain-type fact (the typed contract
+bridge is a later build); the propagator then carries the tag through projections,
+arithmetic, confluences, and aggregates by the algebra rules. These pin the
+transfer contracts at the boundary: same-currency arithmetic stays typed, mixed
+currency contradicts, a same-currency ratio cancels, a confluence widens
+disagreement, and a companion binding rides through a projection chain so a
+downstream coherence guard can later read it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from dblect.lineage import propagate
+from dblect.lineage.builder import build_model_graph
+from dblect.lineage.facts.model import Annotation, Declared, DeclaredSource, Fact
+from dblect.lineage.facts.property import Property
+from dblect.lineage.graph import ColumnRef, SourceKind, SourceRef
+from dblect.lineage.properties.domain_type import (
+    CONFLICT,
+    NAKED,
+    Concrete,
+    Dimension,
+    DomainTag,
+    PerRow,
+    domain_type_grounding,
+    domain_type_property,
+    tagged,
+)
+
+_SRC = SourceRef(SourceKind.SOURCE, "source.shop.raw.charges")
+_MODEL = SourceRef(SourceKind.MODEL, "model.shop.m")
+
+_USD = tagged(dimension=Dimension.of(Concrete("usd")))
+_EUR = tagged(dimension=Dimension.of(Concrete("eur")))
+_DIMENSIONLESS = tagged(dimension=Dimension.dimensionless())
+
+
+def _facts(**by_column: DomainTag) -> Mapping[ColumnRef, tuple[Fact[DomainTag, ColumnRef], ...]]:
+    out: dict[ColumnRef, tuple[Fact[DomainTag, ColumnRef], ...]] = {}
+    for column, value in by_column.items():
+        ref = ColumnRef(_SRC, column)
+        out[ref] = (
+            Fact(scope=ref, value=value, provenance=Declared(DeclaredSource.USER_ASSERTED)),
+        )
+    return out
+
+
+def _prop(
+    facts: Mapping[ColumnRef, tuple[Fact[DomainTag, ColumnRef], ...]],
+) -> Property[DomainTag, ColumnRef]:
+    return domain_type_property(domain_type_grounding(facts))
+
+
+def _run(
+    sql: str, facts: Mapping[ColumnRef, tuple[Fact[DomainTag, ColumnRef], ...]], *, out: str
+) -> Annotation[DomainTag]:
+    graph = build_model_graph(
+        model_uid=_MODEL.unique_id,
+        sql=sql,
+        name_to_source={"charges": _SRC},
+        schema={"charges": {"a": "DECIMAL", "b": "DECIMAL", "amount": "DECIMAL", "k": "INT"}},
+    )
+    anns = propagate(graph, _prop(facts))
+    return anns[ColumnRef(_MODEL, out)]
+
+
+# --- grounding ---------------------------------------------------------------
+
+
+def test_grounded_leaf_carries_its_declared_tag() -> None:
+    facts = _facts(amount=_USD)
+    leaf = ColumnRef(_SRC, "amount")
+    ground = domain_type_grounding(facts)
+    assert ground(leaf).value == _USD
+
+
+def test_undeclared_column_grounds_naked() -> None:
+    ground = domain_type_grounding(_facts())
+    assert ground(ColumnRef(_SRC, "amount")).value == NAKED
+
+
+# --- passthrough and companion binding ---------------------------------------
+
+
+def test_rename_preserves_the_tag() -> None:
+    ann = _run("SELECT c.amount AS total FROM charges c", _facts(amount=_USD), out="total")
+    assert ann.value == _USD
+
+
+def test_companion_binding_rides_through_a_projection_chain() -> None:
+    """A per-row currency binding references the upstream ``currency`` column and
+    must survive projection even after that column is dropped, so a downstream
+    coherence guard can still read the binding it has to discharge."""
+    currency_col = ColumnRef(_SRC, "currency")
+    per_row = tagged(dimension=Dimension.of(PerRow(currency_col)))
+    ann = _run("SELECT c.amount AS amount FROM charges c", _facts(amount=per_row), out="amount")
+    assert ann.value == per_row
+
+
+# --- additive arithmetic -----------------------------------------------------
+
+
+def test_same_currency_addition_stays_typed() -> None:
+    ann = _run("SELECT c.a + c.b AS total FROM charges c", _facts(a=_USD, b=_USD), out="total")
+    assert ann.value == _USD
+
+
+def test_mixed_currency_addition_is_a_conflict() -> None:
+    ann = _run("SELECT c.a + c.b AS total FROM charges c", _facts(a=_USD, b=_EUR), out="total")
+    assert ann.value is CONFLICT
+
+
+# --- multiplicative arithmetic -----------------------------------------------
+
+
+def test_same_currency_ratio_cancels_to_dimensionless() -> None:
+    ann = _run("SELECT c.a / c.b AS ratio FROM charges c", _facts(a=_USD, b=_USD), out="ratio")
+    assert ann.value == _DIMENSIONLESS
+    assert ann.value != NAKED
+
+
+def test_scalar_multiply_keeps_currency() -> None:
+    ann = _run("SELECT c.a * 0.9 AS scaled FROM charges c", _facts(a=_USD), out="scaled")
+    assert ann.value == _USD
+
+
+def test_money_times_money_is_squared() -> None:
+    ann = _run("SELECT c.a * c.b AS prod FROM charges c", _facts(a=_USD, b=_USD), out="prod")
+    assert ann.value == tagged(dimension=Dimension.of(Concrete("usd"), 2))
+
+
+# --- confluence --------------------------------------------------------------
+
+
+def test_union_of_matching_currencies_stays_typed() -> None:
+    sql = "SELECT c.a AS amt FROM charges c UNION ALL SELECT c.b AS amt FROM charges c"
+    ann = _run(sql, _facts(a=_USD, b=_USD), out="amt")
+    assert ann.value == _USD
+
+
+def test_union_of_differing_currencies_widens_to_naked() -> None:
+    sql = "SELECT c.a AS amt FROM charges c UNION ALL SELECT c.b AS amt FROM charges c"
+    ann = _run(sql, _facts(a=_USD, b=_EUR), out="amt")
+    assert ann.value == NAKED
+
+
+# --- aggregates --------------------------------------------------------------
+
+
+def test_sum_passes_the_tag_through() -> None:
+    """Without a discharge the soundness of the sum is the coherence guard's
+    concern; the pure value-domain map keeps the tag for the guard to judge."""
+    ann = _run("SELECT SUM(c.a) AS total FROM charges c", _facts(a=_USD), out="total")
+    assert ann.value == _USD
+
+
+def test_count_is_tag_free() -> None:
+    ann = _run("SELECT COUNT(c.a) AS n FROM charges c", _facts(a=_USD), out="n")
+    assert ann.value == NAKED
+
+
+def test_min_preserves_the_tag() -> None:
+    ann = _run("SELECT MIN(c.a) AS lo FROM charges c", _facts(a=_USD), out="lo")
+    assert ann.value == _USD

--- a/tests/lineage/test_domain_type_propagation.py
+++ b/tests/lineage/test_domain_type_propagation.py
@@ -113,6 +113,35 @@ def test_mixed_currency_addition_is_a_conflict() -> None:
     assert ann.value is CONFLICT
 
 
+def test_adding_a_naked_operand_widens_to_naked() -> None:
+    """A magnitude added to a column that makes no dimensional claim can no longer be
+    claimed to carry the magnitude's unit: the unknown addend could be anything, so the
+    sum widens to ``NAKED`` rather than inheriting the currency (the lenient resolution;
+    strict mode would call the untagged addend a finding). ``amount`` is left ungrounded,
+    so it grounds naked."""
+    ann = _run("SELECT c.a + c.amount AS total FROM charges c", _facts(a=_USD), out="total")
+    assert ann.value == NAKED
+
+
+def test_mixed_currency_conflict_survives_a_later_naked_addend() -> None:
+    """The currency mix is the finding even when a no-claim addend follows it: the
+    ``c.a + c.b`` node conflicts on the spot, and adding the naked ``amount`` cannot
+    launder that conflict back to a clean tag."""
+    ann = _run(
+        "SELECT c.a + c.b + c.amount AS total FROM charges c", _facts(a=_USD, b=_EUR), out="total"
+    )
+    assert ann.value is CONFLICT
+
+
+def test_literal_added_to_money_keeps_currency() -> None:
+    """A bare numeric literal is polymorphic: it takes the unit of what it is added to,
+    so ``amount + 5`` stays the amount's currency rather than conflicting on a scalar.
+    This is what keeps the additive no-claim rule from firing on a literal, which is a
+    no-claim value of a different kind (a known scalar) than an untagged column."""
+    ann = _run("SELECT c.a + 5 AS total FROM charges c", _facts(a=_USD), out="total")
+    assert ann.value == _USD
+
+
 # --- multiplicative arithmetic -----------------------------------------------
 
 
@@ -130,6 +159,16 @@ def test_scalar_multiply_keeps_currency() -> None:
 def test_money_times_money_is_squared() -> None:
     ann = _run("SELECT c.a * c.b AS prod FROM charges c", _facts(a=_USD, b=_USD), out="prod")
     assert ann.value == tagged(dimension=Dimension.of(Concrete("usd"), 2))
+
+
+def test_multiplying_by_a_naked_value_does_not_remint_a_tag() -> None:
+    """A no-claim operand is an *unknown* factor, not a dimensionless scalar: it may
+    carry hidden units. ``(a + b)`` with ``b`` typed and ``a`` untagged widens to
+    naked, and multiplying that by the typed ``b`` must stay naked rather than
+    re-claiming the currency. The empirical-soundness PBT is what surfaced this: the
+    rescaling law fails if the product claims a clean dimension here."""
+    ann = _run("SELECT (c.a + c.b) * c.b AS prod FROM charges c", _facts(b=_USD), out="prod")
+    assert ann.value == NAKED
 
 
 # --- confluence --------------------------------------------------------------

--- a/tests/lineage/test_functional_dependency_lattice.py
+++ b/tests/lineage/test_functional_dependency_lattice.py
@@ -1,0 +1,151 @@
+"""The FD-set lattice for the functional-dependency property, and its entailment.
+
+Functional dependencies order by precision where knowing more dependencies is more
+precise, exactly as uniqueness orders keys: ``meet`` unions the FD sets (two
+declarations both hold), ``join`` intersects them (a confluence keeps only shared
+dependencies), ``top`` is the empty set, and ``bottom`` is a formal universal
+element no real resolution reaches. The shared :func:`assert_lattice_laws` pins
+the bounded-lattice algebra.
+
+``determines`` is pinned against the semantic definition of FD entailment rather
+than a restated closure: a set of FDs entails ``X -> t`` exactly when every
+two-row relation satisfying the set satisfies ``X -> t`` (the two-row construction
+in the classic completeness proof for Armstrong's axioms), so the test enumerates
+those models and demands agreement. That keeps the test honest about both
+directions: an under-claiming ``determines`` misses an entailed dependency, an
+over-claiming one breaks soundness.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, product
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from dblect.lineage.facts.lattice import resolve
+from dblect.lineage.facts.model import Declared, DeclaredSource, Fact
+from dblect.lineage.graph import SourceKind, SourceRef
+from dblect.lineage.properties.functional_dependency import (
+    ALL_FDS,
+    FD,
+    FUNCTIONAL_DEPENDENCY_LATTICE,
+    NO_FDS,
+    FDSet,
+    determines,
+)
+from tests.lineage._lattice_laws import assert_consistency_laws, assert_lattice_laws
+
+_COLS = ("a", "b", "c", "d")
+
+_col_sets = st.frozensets(st.sampled_from(_COLS), max_size=3)
+_fds = st.builds(FD, determinant=_col_sets, dependent=st.sampled_from(_COLS))
+_fd_sets = st.frozensets(_fds, max_size=4).map(FDSet)
+# Mostly real FD sets, occasionally the bottom sentinel, so the law arms that
+# touch bottom are exercised without swamping the normal cases.
+_values = st.one_of(_fd_sets, st.just(ALL_FDS))
+
+_REL = SourceRef(SourceKind.MODEL, "model.shop.payments")
+
+
+def _fact(value: FDSet) -> Fact[FDSet, SourceRef]:
+    return Fact(scope=_REL, value=value, provenance=Declared(DeclaredSource.USER_ASSERTED))
+
+
+@given(_values, _values, _values)
+def test_fd_lattice_laws(a: FDSet, b: FDSet, c: FDSet) -> None:
+    assert_lattice_laws(FUNCTIONAL_DEPENDENCY_LATTICE, a, b, c)
+
+
+@given(_values, _values)
+def test_fd_consistency_laws(declared: FDSet, value: FDSet) -> None:
+    assert_consistency_laws(FUNCTIONAL_DEPENDENCY_LATTICE, declared, value)
+
+
+def test_top_is_no_fds() -> None:
+    assert FUNCTIONAL_DEPENDENCY_LATTICE.top == NO_FDS
+    assert NO_FDS.fds == frozenset()
+    assert not NO_FDS.is_bottom
+
+
+def test_meet_unions_fds() -> None:
+    """Resolving two declared dependencies keeps both."""
+    a = FDSet.of(FD(frozenset({"country"}), "currency"))
+    b = FDSet.of(FD(frozenset({"country"}), "region"))
+    assert FUNCTIONAL_DEPENDENCY_LATTICE.meet(a, b) == FDSet(a.fds | b.fds)
+
+
+def test_join_intersects_fds() -> None:
+    """A confluence keeps only the dependencies both branches carry."""
+    shared = FD(frozenset({"country"}), "currency")
+    a = FDSet.of(shared, FD(frozenset({"country"}), "region"))
+    b = FDSet.of(shared)
+    assert FUNCTIONAL_DEPENDENCY_LATTICE.join(a, b) == FDSet.of(shared)
+
+
+@given(st.lists(_fd_sets, max_size=6))
+def test_resolution_never_contradicts(values: list[FDSet]) -> None:
+    """FD declarations only ever union, so a bucket of real FD sets resolves to
+    their combined dependencies and never reports a contradiction."""
+    facts = tuple(_fact(v) for v in values)
+    value, is_contradiction = resolve(FUNCTIONAL_DEPENDENCY_LATTICE, facts)
+    assert not is_contradiction
+    expected: frozenset[FD] = frozenset()
+    for v in values:
+        expected = expected | v.fds
+    assert value == FDSet(expected)
+
+
+# --- entailment ----------------------------------------------------------------
+
+
+def _holds(rows: tuple[dict[str, int], ...], determinant: frozenset[str], dependent: str) -> bool:
+    return all(
+        r1[dependent] == r2[dependent]
+        for r1, r2 in combinations(rows, 2)
+        if all(r1[col] == r2[col] for col in determinant)
+    )
+
+
+def _semantically_entails(sigma: FDSet, given: frozenset[str], target: str) -> bool:
+    """Whether every two-row {0,1} relation satisfying ``sigma`` satisfies
+    ``given -> target``. Two-row models decide FD entailment, and only the per-column
+    agreement pattern matters, so a binary domain is exhaustive."""
+    all_rows: list[dict[str, int]] = [
+        dict(zip(_COLS, bits, strict=True)) for bits in product((0, 1), repeat=len(_COLS))
+    ]
+    for pair in combinations(all_rows, 2):
+        if all(_holds(pair, fd.determinant, fd.dependent) for fd in sigma.fds) and not _holds(
+            pair, given, target
+        ):
+            return False
+    return True
+
+
+@given(_fd_sets, _col_sets, st.sampled_from(_COLS))
+@settings(max_examples=1000)
+def test_determines_matches_two_row_semantics(
+    sigma: FDSet, given: frozenset[str], target: str
+) -> None:
+    """Order-sensitive closure bugs (a single non-fixpoint pass over the FD set) hide
+    in the small fraction of draws whose entailment needs a chained derivation, so
+    this runs deep enough to reach them reliably."""
+    assert determines(sigma, given, target) == _semantically_entails(sigma, given, target)
+
+
+def test_bottom_entails_everything() -> None:
+    assert determines(ALL_FDS, frozenset(), "currency")
+
+
+def test_empty_determinant_means_constant() -> None:
+    """``{} -> currency`` says the column is constant over the whole relation, so any
+    group key discharges it."""
+    constant = FDSet.of(FD(frozenset(), "currency"))
+    assert determines(constant, frozenset(), "currency")
+    assert determines(constant, frozenset({"country"}), "currency")
+
+
+def test_transitivity_chains_dependencies() -> None:
+    chain = FDSet.of(FD(frozenset({"a"}), "b"), FD(frozenset({"b"}), "c"))
+    assert determines(chain, frozenset({"a"}), "c")
+    assert not determines(chain, frozenset({"c"}), "a")

--- a/tests/lineage/test_functional_dependency_propagation.py
+++ b/tests/lineage/test_functional_dependency_propagation.py
@@ -1,0 +1,318 @@
+"""Relation-scoped functional-dependency propagation, end to end through the substrate.
+
+These pin the FD relation walk at the contract boundary: build a manifest of
+sources and models, ground declared dependencies from synthetic facts (the typed
+contract bridge is a later build), run the one propagator, and read each
+relation's FD set. The rules under test are the sound ones the walk can justify:
+a passthrough carries the source's dependencies, a projection renames them and
+drops what it cannot carry, a WHERE preserves them and pins filtered columns
+constant, a GROUP BY determines every other output from the group key, a key read
+from the uniqueness property determines the columns selected alongside it, and a
+join or UNION proves nothing.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from dblect.lineage.builder import build_relation_graph
+from dblect.lineage.facts.model import Annotation, Declared, DeclaredSource, Fact
+from dblect.lineage.facts.registry import AnnotationStore, PropertyRegistry
+from dblect.lineage.graph import SourceKind, SourceRef
+from dblect.lineage.properties.functional_dependency import (
+    FD,
+    NO_FDS,
+    FDSet,
+    functional_dependency_grounding,
+    functional_dependency_property,
+)
+from dblect.lineage.properties.uniqueness import uniqueness_property
+from dblect.lineage.property import propagate
+from dblect.manifest import DbtTestMetadata, Manifest, Node, ResourceType
+
+_FdFacts = Mapping[SourceRef, tuple[Fact[FDSet, SourceRef], ...]]
+
+
+def _model(uid: str, sql: str) -> Node:
+    return Node(
+        unique_id=uid,
+        name=uid.split(".")[-1],
+        resource_type=ResourceType.MODEL,
+        fqn=(uid,),
+        package_name="shop",
+        schema="analytics",
+        raw_code=None,
+        compiled_code=sql,
+        original_file_path=None,
+        columns={},
+    )
+
+
+def _source(uid: str) -> Node:
+    return Node(
+        unique_id=uid,
+        name=uid.split(".")[-1],
+        resource_type=ResourceType.SOURCE,
+        fqn=(uid,),
+        package_name="shop",
+        schema="raw",
+        raw_code=None,
+        compiled_code=None,
+        original_file_path=None,
+        columns={},
+    )
+
+
+def _unique(uid: str, *, column: str, target: str) -> Node:
+    return Node(
+        unique_id=uid,
+        name=uid.split(".")[-1],
+        resource_type=ResourceType.OTHER,
+        fqn=(uid,),
+        package_name="shop",
+        schema=None,
+        raw_code=None,
+        compiled_code=None,
+        original_file_path=None,
+        columns={},
+        depends_on=frozenset({target}),
+        test_metadata=DbtTestMetadata(name="unique", kwargs={"column_name": column}),
+        attached_node=target,
+    )
+
+
+_PAYMENTS = SourceRef(SourceKind.SOURCE, "source.shop.raw.payments")
+
+
+def _declared(*fds: FD, scope: SourceRef = _PAYMENTS) -> _FdFacts:
+    fact = Fact(
+        scope=scope, value=FDSet.of(*fds), provenance=Declared(DeclaredSource.USER_ASSERTED)
+    )
+    return {scope: (fact,)}
+
+
+def _fd(dependent: str, *determinant: str) -> FD:
+    return FD(frozenset(determinant), dependent)
+
+
+def _fds(facts: _FdFacts, *nodes: Node, read_keys: bool = False) -> dict[str, FDSet]:
+    """Build a manifest from the nodes, propagate the FD property (after uniqueness
+    when ``read_keys`` is set, so the key-derived source is live), and return each
+    model's FD set keyed by unique_id."""
+    manifest = Manifest(
+        schema_version="v12",
+        adapter_type="duckdb",
+        nodes={n.unique_id: n for n in nodes},
+    )
+    graph = build_relation_graph(manifest).graph
+    ground = functional_dependency_grounding(facts)
+    if read_keys:
+        uniq = uniqueness_property(manifest)
+        store = AnnotationStore()
+        for scope, ann in propagate(graph, uniq).items():
+            store.record(uniq.name, scope, ann)
+        prop = functional_dependency_property(ground, uniqueness=uniq.ref)
+        ctx = PropertyRegistry((uniq, prop)).dep_context(store)
+        anns: Mapping[SourceRef, Annotation[FDSet]] = propagate(graph, prop, dep_context=ctx)
+    else:
+        anns = propagate(graph, functional_dependency_property(ground))
+    return {ref.unique_id: ann.value for ref, ann in anns.items() if ref.kind is SourceKind.MODEL}
+
+
+# --- carrying and renaming -----------------------------------------------------
+
+
+def test_passthrough_carries_the_declared_fd() -> None:
+    out = _fds(
+        _declared(_fd("currency", "country")),
+        _source(_PAYMENTS.unique_id),
+        _model("model.shop.stg", "SELECT country, currency, amount FROM payments"),
+    )
+    assert out["model.shop.stg"] == FDSet.of(_fd("currency", "country"))
+
+
+def test_projection_renames_both_sides() -> None:
+    out = _fds(
+        _declared(_fd("currency", "country")),
+        _source(_PAYMENTS.unique_id),
+        _model("model.shop.stg", "SELECT country AS nation, currency AS curr FROM payments"),
+    )
+    assert out["model.shop.stg"] == FDSet.of(_fd("curr", "nation"))
+
+
+def test_dropping_a_dependency_column_drops_the_fd() -> None:
+    out = _fds(
+        _declared(_fd("currency", "country")),
+        _source(_PAYMENTS.unique_id),
+        _model("model.shop.stg", "SELECT country, amount FROM payments"),
+    )
+    assert out["model.shop.stg"] == NO_FDS
+
+
+def test_star_carries_everything() -> None:
+    out = _fds(
+        _declared(_fd("currency", "country")),
+        _source(_PAYMENTS.unique_id),
+        _model("model.shop.stg", "SELECT * FROM payments"),
+    )
+    assert out["model.shop.stg"] == FDSet.of(_fd("currency", "country"))
+
+
+# --- WHERE ----------------------------------------------------------------------
+
+
+def test_where_preserves_fds() -> None:
+    """A filter removes rows, and a dependency that holds on all rows holds on any
+    subset, so the FD survives."""
+    out = _fds(
+        _declared(_fd("currency", "country")),
+        _source(_PAYMENTS.unique_id),
+        _model("model.shop.stg", "SELECT country, currency FROM payments WHERE amount > 0"),
+    )
+    assert out["model.shop.stg"] == FDSet.of(_fd("currency", "country"))
+
+
+def test_where_equality_pins_a_column_constant() -> None:
+    """``WHERE currency = 'usd'`` makes ``currency`` single-valued over the result,
+    which is the empty-determinant dependency."""
+    out = _fds(
+        _declared(),
+        _source(_PAYMENTS.unique_id),
+        _model("model.shop.usd", "SELECT country, currency FROM payments WHERE currency = 'usd'"),
+    )
+    assert out["model.shop.usd"] == FDSet.of(_fd("currency"))
+
+
+def test_constancy_flows_through_a_cte_and_a_downstream_model() -> None:
+    out = _fds(
+        _declared(),
+        _source(_PAYMENTS.unique_id),
+        _model(
+            "model.shop.usd",
+            "WITH f AS (SELECT country, currency FROM payments WHERE currency = 'usd') "
+            "SELECT country, currency FROM f",
+        ),
+        _model("model.shop.downstream", "SELECT country, currency FROM usd"),
+    )
+    assert out["model.shop.usd"] == FDSet.of(_fd("currency"))
+    assert out["model.shop.downstream"] == FDSet.of(_fd("currency"))
+
+
+# --- GROUP BY --------------------------------------------------------------------
+
+
+def test_group_by_determines_the_aggregates() -> None:
+    out = _fds(
+        _declared(),
+        _source(_PAYMENTS.unique_id),
+        _model(
+            "model.shop.by_country",
+            "SELECT country, SUM(amount) AS total FROM payments GROUP BY country",
+        ),
+    )
+    assert out["model.shop.by_country"] == FDSet.of(_fd("total", "country"))
+
+
+def test_group_by_keeps_fds_among_the_group_columns() -> None:
+    out = _fds(
+        _declared(_fd("currency", "country")),
+        _source(_PAYMENTS.unique_id),
+        _model(
+            "model.shop.by_cc",
+            "SELECT country, currency, SUM(amount) AS total FROM payments "
+            "GROUP BY country, currency",
+        ),
+    )
+    assert out["model.shop.by_cc"] == FDSet.of(
+        _fd("currency", "country"),
+        _fd("total", "country", "currency"),
+    )
+
+
+def test_group_by_drops_fds_reaching_outside_the_group_key() -> None:
+    """``currency`` is aggregated away, so ``country -> currency`` says nothing about
+    the output rows and must not survive."""
+    out = _fds(
+        _declared(_fd("region", "country")),
+        _source(_PAYMENTS.unique_id),
+        _model(
+            "model.shop.by_country",
+            "SELECT country, SUM(amount) AS total FROM payments GROUP BY country",
+        ),
+    )
+    assert out["model.shop.by_country"] == FDSet.of(_fd("total", "country"))
+
+
+def test_star_over_a_group_by_keeps_only_within_group_fds() -> None:
+    """``SELECT * ... GROUP BY`` parses even where engines reject it, and the star
+    bypasses the projection remap, so the grouping step itself must drop any
+    dependency reaching outside the group key: in a permissive dialect each group
+    surfaces one arbitrary row, and two groups sharing a determinant value can
+    surface different dependents."""
+    out = _fds(
+        _declared(_fd("region", "country"), _fd("currency", "region")),
+        _source(_PAYMENTS.unique_id),
+        _model("model.shop.g", "SELECT * FROM payments GROUP BY country"),
+    )
+    assert out["model.shop.g"] == NO_FDS
+
+
+# --- shapes the walk does not model ----------------------------------------------
+
+
+def test_join_proves_nothing() -> None:
+    customers = _source("source.shop.raw.customers")
+    out = _fds(
+        _declared(_fd("currency", "country")),
+        _source(_PAYMENTS.unique_id),
+        customers,
+        _model(
+            "model.shop.joined",
+            "SELECT p.country, p.currency FROM payments p JOIN customers c ON p.customer_id = c.id",
+        ),
+    )
+    assert out["model.shop.joined"] == NO_FDS
+
+
+def test_union_all_proves_nothing() -> None:
+    """Two arms can each satisfy a dependency while their union violates it (the same
+    determinant value mapping to different dependents per arm)."""
+    out = _fds(
+        _declared(_fd("currency", "country")),
+        _source(_PAYMENTS.unique_id),
+        _model(
+            "model.shop.u",
+            "SELECT country, currency FROM payments "
+            "UNION ALL SELECT country, currency FROM payments",
+        ),
+    )
+    assert out["model.shop.u"] == NO_FDS
+
+
+# --- the key-derived source -------------------------------------------------------
+
+
+def test_a_key_determines_the_columns_selected_alongside_it() -> None:
+    """A relation unique on ``id`` admits one row per ``id``, so ``id`` determines
+    every column drawn from it. Read from the uniqueness property through the
+    declared dependency edge."""
+    orders = _source("source.shop.raw.orders")
+    out = _fds(
+        _declared(),
+        orders,
+        _unique("test.shop.u", column="id", target=orders.unique_id),
+        _model("model.shop.stg", "SELECT id, customer_id FROM orders"),
+        read_keys=True,
+    )
+    assert out["model.shop.stg"] == FDSet.of(_fd("customer_id", "id"))
+
+
+def test_without_the_uniqueness_edge_no_key_fd_is_minted() -> None:
+    orders = _source("source.shop.raw.orders")
+    out = _fds(
+        _declared(),
+        orders,
+        _unique("test.shop.u", column="id", target=orders.unique_id),
+        _model("model.shop.stg", "SELECT id, customer_id FROM orders"),
+    )
+    assert out["model.shop.stg"] == NO_FDS

--- a/tests/lineage/test_pbt_domain_type_soundness.py
+++ b/tests/lineage/test_pbt_domain_type_soundness.py
@@ -1,0 +1,170 @@
+"""Empirical soundness PBT for the domain-type property: the oracle is unit rescaling.
+
+The dimensional algebra rests on one theorem (Kennedy, *Dimension Types*, ESOP 1994):
+a well-typed expression is invariant under the group action that rescales each unit
+independently. Concretely, if the analyzer assigns an expression the dimension
+``{usd: i, eur: j}``, then multiplying every ``usd``-tagged input by a scale ``a`` and
+every ``eur``-tagged input by ``b`` must multiply the result by ``a^i * b^j``. That is
+a property real data can witness: materialize the expression twice, once on the raw
+inputs and once on the rescaled inputs, and the two outputs must differ by exactly the
+factor the analyzer's dimension predicts.
+
+So this test generates a small arithmetic expression over currency-tagged columns, asks
+the analyzer for the output dimension, then materializes both datasets in duckdb and
+checks the rescaling law. The data is the judge: an over-claimed dimension (calling a
+cancelled ratio ``usd^1``, or a money-times-money product ``usd^1``) breaks the law and
+the test catches it, with no rule restated. A mixed-currency expression the analyzer
+reports as a conflict carries no dimension to predict a factor, so it is skipped here;
+that the analyzer flags it is pinned in the propagation tests.
+
+Only ``+``, ``*``, ``/`` over strictly positive inputs are generated, so every
+subexpression is positive and division never hits a zero. Every leaf carries a known
+currency, keeping the test on the dimensional algebra rather than the naked-composition
+choice, which the propagation tests pin separately.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+import duckdb
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from dblect.lineage import propagate
+from dblect.lineage.builder import build_model_graph
+from dblect.lineage.facts.model import Declared, DeclaredSource, Fact
+from dblect.lineage.graph import ColumnRef, SourceKind, SourceRef
+from dblect.lineage.properties.domain_type import (
+    Concrete,
+    Dimension,
+    DomainTag,
+    Tagged,
+    domain_type_grounding,
+    domain_type_property,
+    tagged,
+)
+
+_SRC = SourceRef(SourceKind.SOURCE, "source.test.raw.t")
+_MODEL = SourceRef(SourceKind.MODEL, "model.test.m")
+_CURRENCIES = ("usd", "eur")
+_SCALES: Mapping[str, float] = {"usd": 2.0, "eur": 3.0}
+
+
+@dataclass(frozen=True)
+class Expr:
+    sql: str
+    leaves: frozenset[str]  # the column names referenced
+
+
+@dataclass(frozen=True)
+class Scenario:
+    columns: tuple[str, ...]
+    currency_of: Mapping[str, str]  # column -> currency
+    expr: Expr
+    rows: tuple[tuple[float, ...], ...]  # one tuple per row, in `columns` order
+
+
+@st.composite
+def _expr(draw: st.DrawFn, columns: Sequence[str], depth: int) -> Expr:
+    if depth == 0 or draw(st.booleans()):
+        col = draw(st.sampled_from(columns))
+        return Expr(sql=f"d.{col}", leaves=frozenset({col}))
+    op = draw(st.sampled_from(("+", "*", "/")))
+    left = draw(_expr(columns, depth - 1))
+    right = draw(_expr(columns, depth - 1))
+    return Expr(sql=f"({left.sql} {op} {right.sql})", leaves=left.leaves | right.leaves)
+
+
+@st.composite
+def _scenario(draw: st.DrawFn) -> Scenario:
+    n = draw(st.integers(min_value=2, max_value=3))
+    columns = tuple(f"c{i}" for i in range(n))
+    currency_of = {c: draw(st.sampled_from(_CURRENCIES)) for c in columns}
+    expr = draw(_expr(columns, depth=2))
+    n_rows = draw(st.integers(min_value=1, max_value=5))
+    rows = tuple(
+        tuple(float(draw(st.integers(min_value=1, max_value=9))) for _ in columns)
+        for _ in range(n_rows)
+    )
+    return Scenario(columns=columns, currency_of=currency_of, expr=expr, rows=rows)
+
+
+def _model_sql(s: Scenario) -> str:
+    return f"SELECT d.rid AS rid, {s.expr.sql} AS r FROM t AS d"
+
+
+def _analyzer_dimension(s: Scenario) -> DomainTag:
+    """The output column's domain tag, exactly as the column property derives it."""
+    facts: dict[ColumnRef, tuple[Fact[DomainTag, ColumnRef], ...]] = {}
+    for col, currency in s.currency_of.items():
+        ref = ColumnRef(_SRC, col)
+        value = tagged(dimension=Dimension.of(Concrete(currency)))
+        facts[ref] = (
+            Fact(scope=ref, value=value, provenance=Declared(DeclaredSource.USER_ASSERTED)),
+        )
+    schema = {"t": {"rid": "INT", **dict.fromkeys(s.columns, "DOUBLE")}}
+    graph = build_model_graph(
+        model_uid=_MODEL.unique_id, sql=_model_sql(s), name_to_source={"t": _SRC}, schema=schema
+    )
+    anns = propagate(graph, domain_type_property(domain_type_grounding(facts)))
+    return anns[ColumnRef(_MODEL, "r")].value
+
+
+def _predicted_factor(dimension: Dimension) -> float:
+    factor = 1.0
+    for unit, power in dimension.exponents:
+        assert isinstance(unit, Concrete)
+        factor *= _SCALES[unit.name] ** power
+    return factor
+
+
+def _materialize(s: Scenario, *, scaled: bool) -> list[float]:
+    con = duckdb.connect(":memory:")
+    try:
+        cols_ddl = ", ".join(f"{c} DOUBLE" for c in s.columns)
+        con.execute(f"CREATE TABLE t (rid INTEGER, {cols_ddl})")
+        placeholders = ", ".join(["?"] * (len(s.columns) + 1))
+        payload = [
+            [
+                rid,
+                *(
+                    _scale_value(v, s.currency_of[col], scaled)
+                    for col, v in zip(s.columns, row, strict=True)
+                ),
+            ]
+            for rid, row in enumerate(s.rows)
+        ]
+        con.executemany(f"INSERT INTO t VALUES ({placeholders})", payload)
+        result = con.execute(f"SELECT r FROM ({_model_sql(s)}) sub ORDER BY rid").fetchall()
+        return [float(r[0]) for r in result]
+    finally:
+        con.close()
+
+
+def _scale_value(value: float, currency: str, scaled: bool) -> float:
+    return value * _SCALES[currency] if scaled else value
+
+
+@given(_scenario())
+@settings(max_examples=400, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+def test_dimension_claim_predicts_unit_rescaling(s: Scenario) -> None:
+    """The analyzer's output dimension predicts exactly how the materialized result
+    transforms under independent unit rescaling. A conflict or naked output carries no
+    dimension to predict, so it is skipped; a known dimension must match the data."""
+    value = _analyzer_dimension(s)
+    if not isinstance(value, Tagged) or value.dimension is None:
+        return  # conflict (mixed currency) or naked: no dimension to witness
+    factor = _predicted_factor(value.dimension)
+    raw = _materialize(s, scaled=False)
+    rescaled = _materialize(s, scaled=True)
+    assert len(raw) == len(rescaled)
+    for original, scaled_result in zip(raw, rescaled, strict=True):
+        expected = original * factor
+        tolerance = 1e-6 * max(1.0, abs(expected))
+        assert abs(scaled_result - expected) <= tolerance, (
+            f"rescaling law broken: dimension {value.dimension} predicts factor {factor}, "
+            f"but {original} -> {scaled_result} (expected {expected}) for sql={s.expr.sql!r} "
+            f"currencies={dict(s.currency_of)}"
+        )

--- a/tests/lineage/test_pbt_domain_type_soundness.py
+++ b/tests/lineage/test_pbt_domain_type_soundness.py
@@ -9,18 +9,25 @@ a property real data can witness: materialize the expression twice, once on the 
 inputs and once on the rescaled inputs, and the two outputs must differ by exactly the
 factor the analyzer's dimension predicts.
 
-So this test generates a small arithmetic expression over currency-tagged columns, asks
-the analyzer for the output dimension, then materializes both datasets in duckdb and
-checks the rescaling law. The data is the judge: an over-claimed dimension (calling a
-cancelled ratio ``usd^1``, or a money-times-money product ``usd^1``) breaks the law and
-the test catches it, with no rule restated. A mixed-currency expression the analyzer
-reports as a conflict carries no dimension to predict a factor, so it is skipped here;
-that the analyzer flags it is pinned in the propagation tests.
+So this test generates a small arithmetic expression over columns, asks the analyzer for
+the output dimension, then materializes both datasets in duckdb and checks the rescaling
+law. The data is the judge: an over-claimed dimension (calling a cancelled ratio
+``usd^1``, or a money-times-money product ``usd^1``) breaks the law and the test catches
+it, with no rule restated. A mixed-currency expression the analyzer reports as a conflict
+carries no dimension to predict a factor, so it is skipped here; that the analyzer flags
+it is pinned in the propagation tests.
+
+Some leaves are left undeclared (naked to the analyzer) while still carrying real values
+in the data. The rescaling action runs over declared units only, and a naked column is
+held fixed: the analyzer claimed nothing about its unit, so soundness must hold whatever
+that column turns out to be, and an unscaled column is one legitimate witness of "could
+be anything". This is what exercises the naked-composition rules. A naked factor under
+``*`` rides through cleanly (the result still scales by the declared unit), while a naked
+term under ``+`` does not (the result no longer scales by any single factor), so an
+additive rule that folds a naked operand into a dimensional claim is caught here.
 
 Only ``+``, ``*``, ``/`` over strictly positive inputs are generated, so every
-subexpression is positive and division never hits a zero. Every leaf carries a known
-currency, keeping the test on the dimensional algebra rather than the naked-composition
-choice, which the propagation tests pin separately.
+subexpression is positive and division never hits a zero.
 """
 
 from __future__ import annotations
@@ -62,6 +69,7 @@ class Expr:
 class Scenario:
     columns: tuple[str, ...]
     currency_of: Mapping[str, str]  # column -> currency
+    declared: frozenset[str]  # columns whose currency the analyzer is told (the rest are naked)
     expr: Expr
     rows: tuple[tuple[float, ...], ...]  # one tuple per row, in `columns` order
 
@@ -82,13 +90,16 @@ def _scenario(draw: st.DrawFn) -> Scenario:
     n = draw(st.integers(min_value=2, max_value=3))
     columns = tuple(f"c{i}" for i in range(n))
     currency_of = {c: draw(st.sampled_from(_CURRENCIES)) for c in columns}
+    declared = frozenset(c for c in columns if draw(st.booleans()))
     expr = draw(_expr(columns, depth=2))
     n_rows = draw(st.integers(min_value=1, max_value=5))
     rows = tuple(
         tuple(float(draw(st.integers(min_value=1, max_value=9))) for _ in columns)
         for _ in range(n_rows)
     )
-    return Scenario(columns=columns, currency_of=currency_of, expr=expr, rows=rows)
+    return Scenario(
+        columns=columns, currency_of=currency_of, declared=declared, expr=expr, rows=rows
+    )
 
 
 def _model_sql(s: Scenario) -> str:
@@ -98,9 +109,9 @@ def _model_sql(s: Scenario) -> str:
 def _analyzer_dimension(s: Scenario) -> DomainTag:
     """The output column's domain tag, exactly as the column property derives it."""
     facts: dict[ColumnRef, tuple[Fact[DomainTag, ColumnRef], ...]] = {}
-    for col, currency in s.currency_of.items():
+    for col in s.declared:
         ref = ColumnRef(_SRC, col)
-        value = tagged(dimension=Dimension.of(Concrete(currency)))
+        value = tagged(dimension=Dimension.of(Concrete(s.currency_of[col])))
         facts[ref] = (
             Fact(scope=ref, value=value, provenance=Declared(DeclaredSource.USER_ASSERTED)),
         )
@@ -130,7 +141,7 @@ def _materialize(s: Scenario, *, scaled: bool) -> list[float]:
             [
                 rid,
                 *(
-                    _scale_value(v, s.currency_of[col], scaled)
+                    _scale_value(v, s.currency_of[col], scaled and col in s.declared)
                     for col, v in zip(s.columns, row, strict=True)
                 ),
             ]
@@ -151,11 +162,12 @@ def _scale_value(value: float, currency: str, scaled: bool) -> float:
 @settings(max_examples=400, deadline=None, suppress_health_check=[HealthCheck.too_slow])
 def test_dimension_claim_predicts_unit_rescaling(s: Scenario) -> None:
     """The analyzer's output dimension predicts exactly how the materialized result
-    transforms under independent unit rescaling. A conflict or naked output carries no
+    transforms under independent rescaling of the declared units, with naked columns held
+    fixed (the analyzer claimed nothing about them). A conflict or naked output carries no
     dimension to predict, so it is skipped; a known dimension must match the data."""
     value = _analyzer_dimension(s)
-    if not isinstance(value, Tagged) or value.dimension is None:
-        return  # conflict (mixed currency) or naked: no dimension to witness
+    if not isinstance(value, Tagged) or not isinstance(value.dimension, Dimension):
+        return  # conflict (mixed currency), naked, or polymorphic: no monomial to witness
     factor = _predicted_factor(value.dimension)
     raw = _materialize(s, scaled=False)
     rescaled = _materialize(s, scaled=True)

--- a/tests/lineage/test_pbt_functional_dependency_soundness.py
+++ b/tests/lineage/test_pbt_functional_dependency_soundness.py
@@ -1,0 +1,183 @@
+"""Empirical soundness PBT for the functional-dependency property: the data judges.
+
+The FD walk claims dependencies on a model's output from three sources: a declared
+dependency carried through the relational algebra, a constancy minted by an
+equality filter, and the group key determining every other output of a GROUP BY.
+The soundness obligation is uniform: every claimed ``X -> y`` must hold on the
+materialized result, meaning no two result rows agree on ``X`` and differ on ``y``.
+
+So this test generates a small scenario (a base table whose data satisfies the
+declared dependency when one is declared, and a model built from a random
+projection/rename, an optional equality filter, and an optional GROUP BY), asks
+the analyzer for the model's FD set, materializes everything in duckdb, and checks
+each claimed dependency against the rows. Over-claims anywhere in the walk (a
+rename that blurs columns, a filter wrongly treated as pinning, a group key minted
+from the wrong columns) surface as a concrete two-row counterexample, with no walk
+rule restated in the test.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+import duckdb
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from dblect.lineage.builder import build_relation_graph
+from dblect.lineage.facts.model import Declared, DeclaredSource, Fact
+from dblect.lineage.graph import SourceKind, SourceRef
+from dblect.lineage.properties.functional_dependency import (
+    FD,
+    FDSet,
+    functional_dependency_grounding,
+    functional_dependency_property,
+)
+from dblect.lineage.property import propagate
+from dblect.manifest import Manifest, Node, ResourceType
+
+_SRC = SourceRef(SourceKind.SOURCE, "source.test.raw.t")
+_MODEL = SourceRef(SourceKind.MODEL, "model.test.m")
+_COLS = ("g", "x", "y")
+
+
+@dataclass(frozen=True)
+class Scenario:
+    rows: tuple[tuple[int, int, int], ...]  # (g, x, y) per row
+    declared: bool  # ``g -> x`` declared, and the data honours it
+    where: tuple[str, int] | None  # equality filter ``col = literal``
+    group_cols: tuple[str, ...]  # non-empty means GROUP BY these input columns
+    renames: Mapping[str, str]  # projected input column -> output name
+
+
+@st.composite
+def _scenario(draw: st.DrawFn) -> Scenario:
+    declared = draw(st.booleans())
+    # When ``g -> x`` is declared the generated data must satisfy it, so ``x`` is a
+    # drawn function of ``g`` rather than independent noise.
+    mapping = {g: draw(st.integers(min_value=0, max_value=2)) for g in range(3)}
+    rows: list[tuple[int, int, int]] = []
+    for _ in range(draw(st.integers(min_value=0, max_value=8))):
+        g = draw(st.integers(min_value=0, max_value=2))
+        x = mapping[g] if declared else draw(st.integers(min_value=0, max_value=2))
+        y = draw(st.integers(min_value=0, max_value=3))
+        rows.append((g, x, y))
+
+    where = None
+    if draw(st.booleans()):
+        where = (draw(st.sampled_from(_COLS)), draw(st.integers(min_value=0, max_value=3)))
+
+    if draw(st.booleans()):
+        group_cols = tuple(
+            sorted(draw(st.sets(st.sampled_from(("g", "x")), min_size=1, max_size=2)))
+        )
+        projected = group_cols
+    else:
+        group_cols = ()
+        projected = tuple(sorted(draw(st.sets(st.sampled_from(_COLS), min_size=1, max_size=3))))
+    names = draw(st.permutations(("a", "b", "c")))
+    renames = {col: names[i] for i, col in enumerate(projected)}
+    return Scenario(
+        rows=tuple(rows), declared=declared, where=where, group_cols=group_cols, renames=renames
+    )
+
+
+def _model_sql(s: Scenario) -> str:
+    projections = [f"{col} AS {name}" for col, name in s.renames.items()]
+    if s.group_cols:
+        projections.append("SUM(y) AS s")
+    sql = f"SELECT {', '.join(projections)} FROM t"
+    if s.where is not None:
+        sql += f" WHERE {s.where[0]} = {s.where[1]}"
+    if s.group_cols:
+        sql += f" GROUP BY {', '.join(s.group_cols)}"
+    return sql
+
+
+def _claimed(s: Scenario) -> FDSet:
+    """The model's FD set, exactly as the relation property derives it."""
+    nodes = {
+        _SRC.unique_id: Node(
+            unique_id=_SRC.unique_id,
+            name="t",
+            resource_type=ResourceType.SOURCE,
+            fqn=(_SRC.unique_id,),
+            package_name="test",
+            schema="raw",
+            raw_code=None,
+            compiled_code=None,
+            original_file_path=None,
+            columns={},
+        ),
+        _MODEL.unique_id: Node(
+            unique_id=_MODEL.unique_id,
+            name="m",
+            resource_type=ResourceType.MODEL,
+            fqn=(_MODEL.unique_id,),
+            package_name="test",
+            schema="analytics",
+            raw_code=None,
+            compiled_code=_model_sql(s),
+            original_file_path=None,
+            columns={},
+        ),
+    }
+    manifest = Manifest(schema_version="v12", adapter_type="duckdb", nodes=nodes)
+    value = FDSet.of(FD(frozenset({"g"}), "x")) if s.declared else FDSet(frozenset())
+    fact = Fact(scope=_SRC, value=value, provenance=Declared(DeclaredSource.USER_ASSERTED))
+    prop = functional_dependency_property(functional_dependency_grounding({_SRC: (fact,)}))
+    anns = propagate(build_relation_graph(manifest).graph, prop)
+    return anns[_MODEL].value
+
+
+def _materialize(s: Scenario) -> tuple[tuple[str, ...], list[tuple[object, ...]]]:
+    con = duckdb.connect(":memory:")
+    try:
+        con.execute("CREATE TABLE t (g INTEGER, x INTEGER, y INTEGER)")
+        if s.rows:
+            con.executemany("INSERT INTO t VALUES (?, ?, ?)", [list(r) for r in s.rows])
+        cursor = con.execute(_model_sql(s))
+        description = cursor.description
+        assert description is not None
+        names = tuple(str(d[0]).lower() for d in description)
+        return names, [tuple(r) for r in cursor.fetchall()]
+    finally:
+        con.close()
+
+
+def _fd_holds(
+    fd: FD, names: tuple[str, ...], rows: list[tuple[object, ...]]
+) -> tuple[object, ...] | None:
+    """``None`` when the dependency holds; otherwise a witness determinant value
+    whose rows disagree on the dependent."""
+    index = {name: i for i, name in enumerate(names)}
+    seen: dict[tuple[object, ...], object] = {}
+    for row in rows:
+        key = tuple(row[index[col]] for col in sorted(fd.determinant))
+        dep = row[index[fd.dependent]]
+        if key in seen and seen[key] != dep:
+            return key
+        seen[key] = dep
+    return None
+
+
+@given(_scenario())
+@settings(max_examples=300, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+def test_every_claimed_fd_holds_on_the_data(s: Scenario) -> None:
+    claimed = _claimed(s)
+    assert not claimed.is_bottom
+    if s.group_cols:
+        # Anti-vacuity: a GROUP BY always yields at least the group-key dependency,
+        # so a walk that silently claims nothing cannot pass on silence alone.
+        assert claimed.fds
+    names, rows = _materialize(s)
+    for fd in claimed.fds:
+        assert {fd.dependent, *fd.determinant} <= set(names), (
+            f"claimed FD names a column the result lacks: {fd} vs {names} for sql={_model_sql(s)!r}"
+        )
+        witness = _fd_holds(fd, names, rows)
+        assert witness is None, (
+            f"claimed FD {sorted(fd.determinant)} -> {fd.dependent} violated at "
+            f"determinant value {witness} for sql={_model_sql(s)!r} rows={rows}"
+        )


### PR DESCRIPTION
First domain-type property over the lineage engine (Phase 1 of the domain-type plan): a per-column tagged magnitude carrying a dimensional monomial (currency/units, with Kennedy multiply-divide exponent arithmetic) plus nominal categorical tags, each binding to a pinned literal or a per-row companion column. This is the multi-column companion binding the substrate-readiness notes call the first genuine build: the property value is structured, so the work is a lattice and transfer rules, not engine plumbing.

## What's here
- **`DomainTag` value type + lattice** — `NAKED` (no claim) top, `CONFLICT` bottom; `meet` composes agreeing tags and conflicts on disagreement (`MoneyUSD` meet `MoneyEUR`), `join` keeps only what both arms share. `Dimension` is a free-abelian-group monomial over `Concrete`/`PerRow` units.
- **Operators** — same-currency add stays typed, mixed-currency add conflicts; ratios cancel to dimensionless, `money*money` is `money^2`, scalar factors ride through; comparisons tag-free. Aggregates: `sum`/`avg`/`min`/`max` pass the tag through, `count` is tag-free.
- **Grounding** from typed synthetic facts (as the uniqueness/nullability tests ground), leaving the real typed source to the contract bridge. *Deviation:* no `schema.yml meta.dblect` reader — the manifest model carries no `meta` field, and adding a raw-dict reader would invite the stringy typing CLAUDE.md forbids.

## Tests
Lattice + dimensional-group laws, grounding/propagation contracts, and an empirical-soundness PBT grounded in Kennedy's rescaling theorem (the claimed dimension must predict how the materialized result transforms when each unit is independently rescaled in duckdb). Mutation-checked: deliberate over-claims in the multiply, divide, meet, and additive rules are each killed (several by the PBTs).

Full gate suite green: `ruff check`, `ruff format --check`, `pyright` (strict), `pytest` (451 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)