### PR TITLE
domain-type: join transfers (stage 3) — FD-through-join, outer-join taint, join-key & fan-out signals

### DIFF
--- a/src/dblect/lineage/properties/domain_type.py
+++ b/src/dblect/lineage/properties/domain_type.py
@@ -56,6 +56,7 @@ from dblect.lineage.facts.property import (
 from dblect.lineage.graph import ColumnRef, SourceRef
 from dblect.lineage.properties.functional_dependency import FDSet, determines
 from dblect.lineage.properties.nullability import OuterJoinNull
+from dblect.sql import _sqlglot as sg
 
 # --- unit and tag identities -------------------------------------------------
 
@@ -492,6 +493,34 @@ def companion_columns(tag: DomainTag) -> frozenset[ColumnRef]:
         out.update(unit.column for unit, _ in tag.dimension.exponents if isinstance(unit, PerRow))
     out.update(binding.column for _, binding in tag.nominal if isinstance(binding, PerRow))
     return frozenset(out)
+
+
+# --- join-key type compatibility (substrate signal) -----------------------------
+
+
+def join_key_conflicts(
+    on: Expr, tag_of: Callable[[exp.Column], DomainTag | None]
+) -> tuple[tuple[exp.Column, exp.Column], ...]:
+    """The join-key equalities in ``on`` whose two sides carry conflicting domain tags.
+
+    Joining a ``MoneyUSD`` column against a ``MoneyEUR`` one, or two incompatible nominal
+    tags (an ISO-2 ``Country`` against an ISO-3), equates values that cannot mean the same
+    thing. For each ``a.x = b.y`` the two tags are met; a ``CONFLICT`` meet is the signal.
+    A no-claim side (``tag_of`` returns ``None`` or ``NAKED``) never conflicts, the lenient
+    posture.
+
+    This is the substrate signal only: it returns the offending column pairs rather than
+    raising or producing a finding, because the user-facing finding surface (the seam
+    diagnostic) is a later build. ``tag_of`` resolves a column to its tag, since the
+    builder stamps projection columns but not ON-clause columns."""
+    out: list[tuple[exp.Column, exp.Column]] = []
+    for left, right in sg.equality_column_pairs(on):
+        tag_left, tag_right = tag_of(left), tag_of(right)
+        if tag_left is None or tag_right is None:
+            continue
+        if DOMAIN_TYPE_LATTICE.meet(tag_left, tag_right) is CONFLICT:
+            out.append((left, right))
+    return tuple(out)
 
 
 def _guarded_aggregates(

--- a/src/dblect/lineage/properties/domain_type.py
+++ b/src/dblect/lineage/properties/domain_type.py
@@ -55,6 +55,7 @@ from dblect.lineage.facts.property import (
 )
 from dblect.lineage.graph import ColumnRef, SourceRef
 from dblect.lineage.properties.functional_dependency import FDSet, determines
+from dblect.lineage.properties.nullability import OuterJoinNull
 
 # --- unit and tag identities -------------------------------------------------
 
@@ -420,8 +421,26 @@ def _literal_rule(
     return Annotation(NAKED, Opacity.IMPLICIT)
 
 
+def _outer_join_null_rule(
+    _expr: Expr, kids: tuple[Annotation[DomainTag], ...], _ctx: DepContext
+) -> Annotation[DomainTag]:
+    """A column drawn from an outer join's optional side is NULL on unmatched rows, and a
+    NULL pads the whole row: a per-row companion travelling with the magnitude (its unit)
+    is NULL too, so the unit is unknown there and the tag widens to ``NAKED``. A tag with
+    no per-row companion (a pinned currency, or none) is unaffected: a NULL amount is still
+    of its declared unit. Reads the same ``OuterJoinNull`` taint nullability inserts, so it
+    fires only when the domain-type property runs over the outer-join-tainted graph."""
+    if not kids:
+        return Annotation(NAKED, Opacity.IMPLICIT)
+    (child,) = kids
+    if companion_columns(child.value):
+        return Annotation(NAKED, Opacity.IMPLICIT, provisional=child.provisional)
+    return child
+
+
 DOMAIN_TYPE_OPERATORS: Mapping[type[Expr], OperatorTransfer[DomainTag]] = {
     exp.Literal: _literal_rule,
+    OuterJoinNull: _outer_join_null_rule,
     exp.Add: _additive_rule,
     exp.Sub: _additive_rule,
     exp.Mul: _multiplicative_rule(_multiply_tags),

--- a/src/dblect/lineage/properties/domain_type.py
+++ b/src/dblect/lineage/properties/domain_type.py
@@ -422,21 +422,37 @@ def _literal_rule(
     return Annotation(NAKED, Opacity.IMPLICIT)
 
 
+def _widen_per_row_coordinates(tag: DomainTag) -> DomainTag:
+    """The tag with every ``PerRow``-bound coordinate widened away: a dimension carrying
+    a per-row unit drops to no-claim, a per-row nominal binding is removed. Pinned
+    (``Concrete``) coordinates survive untouched."""
+    if isinstance(tag, _Conflict):
+        return tag
+    dim = tag.dimension
+    if isinstance(dim, Dimension) and any(isinstance(u, PerRow) for u, _ in dim.exponents):
+        dim = None
+    nominal = {n: b for n, b in tag.nominal_map().items() if not isinstance(b, PerRow)}
+    return Tagged(dim, _froze(nominal))
+
+
 def _outer_join_null_rule(
     _expr: Expr, kids: tuple[Annotation[DomainTag], ...], _ctx: DepContext
 ) -> Annotation[DomainTag]:
     """A column drawn from an outer join's optional side is NULL on unmatched rows, and a
     NULL pads the whole row: a per-row companion travelling with the magnitude (its unit)
-    is NULL too, so the unit is unknown there and the tag widens to ``NAKED``. A tag with
-    no per-row companion (a pinned currency, or none) is unaffected: a NULL amount is still
-    of its declared unit. Reads the same ``OuterJoinNull`` taint nullability inserts, so it
-    fires only when the domain-type property runs over the outer-join-tainted graph."""
+    is NULL too, so anything that companion vouched for is unknown there. The widening is
+    per coordinate: each ``PerRow``-bound piece of the tag drops while a pinned piece
+    survives (a NULL amount is still of its declared unit), so an all-pinned tag is
+    unaffected and an all-per-row tag widens to ``NAKED``. Reads the same
+    ``OuterJoinNull`` taint nullability inserts, so it fires only when the domain-type
+    property runs over the outer-join-tainted graph."""
     if not kids:
         return Annotation(NAKED, Opacity.IMPLICIT)
     (child,) = kids
-    if companion_columns(child.value):
-        return Annotation(NAKED, Opacity.IMPLICIT, provisional=child.provisional)
-    return child
+    widened = _widen_per_row_coordinates(child.value)
+    if widened == child.value:
+        return child
+    return _annotate(widened, kids)
 
 
 DOMAIN_TYPE_OPERATORS: Mapping[type[Expr], OperatorTransfer[DomainTag]] = {

--- a/src/dblect/lineage/properties/functional_dependency.py
+++ b/src/dblect/lineage/properties/functional_dependency.py
@@ -14,16 +14,17 @@ dependencies is more precise, so ``meet`` (resolution of declarations) unions th
 sets, ``join`` (confluence) intersects them, ``top`` is the empty set, and
 ``bottom`` is a formal universal element no real resolution reaches.
 
-Dependencies come from four places. A declaration grounds one directly (synthetic
+Dependencies come from five places. A declaration grounds one directly (synthetic
 facts until the authoring bridge lands; the ``determines(...)`` contract is its
 eventual source). An equality filter pins a column constant, the empty-determinant
 dependency. A GROUP BY makes its group key determine every output (the key of the
-grouped result). And a candidate key read from the uniqueness property determines
+grouped result). A candidate key read from the uniqueness property determines
 every column selected alongside it, since a relation unique on ``K`` admits one
-row per ``K`` value. Posture elsewhere is silent-when-unproven: a join can pair
-determinant values across sources and two UNION arms can each satisfy a dependency
-their union violates, so both prove nothing (the join transfer is a later build,
-alongside the rest of the join concerns).
+row per ``K`` value. And a join carries each kept side's dependencies (qualified
+by source alias) plus an inner join's ``ON`` equalities as mutual determinations.
+Posture elsewhere is silent-when-unproven: an outer join's NULL-padded side and
+two UNION arms that can each satisfy a dependency their union violates both prove
+nothing.
 """
 
 from __future__ import annotations
@@ -172,9 +173,10 @@ class _FdWalk:
     """Bottom-up dependency inference over one relational tree.
 
     ``base_resolve`` resolves a base table; CTEs and inline subqueries are
-    resolved structurally within the walk. Only single-source scopes carry:
-    a join or a UNION proves nothing, and an unmodellable group shape (positional
-    or computed group keys) drops the scope's dependencies entirely.
+    resolved structurally within the walk. Single-source scopes carry fully; a
+    join carries its kept sides (see :meth:`_join_select`); a UNION proves
+    nothing, and an unmodellable group shape (positional or computed group keys)
+    drops the scope's dependencies entirely.
     """
 
     def __init__(self, base_resolve: _BaseResolve) -> None:
@@ -268,23 +270,26 @@ class _FdWalk:
         *,
         cte_scope: Mapping[str, frozenset[FD]],
     ) -> frozenset[FD]:
-        """Dependencies an inner join carries to the projection.
+        """Dependencies a join carries to the projection.
 
-        An FD that holds on one joined relation holds on the inner join: two output
-        rows agreeing on its determinant come from that relation's rows agreeing on it,
-        and a join only filters or duplicates rows (a duplicate still agrees on the
-        dependent). So each source's dependencies carry, the ``ON`` equalities add a
-        mutual determination between the joined columns, and an equality filter pins its
-        column. Everything is tracked qualified by source alias (a join can expose two
-        ``country`` columns), then projected onto the output names.
+        An FD that holds on a joined relation holds on the join wherever that side's
+        rows come through un-padded: two output rows agreeing on its determinant come
+        from that relation's rows agreeing on it, and a join only filters or duplicates
+        such rows (a duplicate still agrees on the dependent). So each kept side's
+        dependencies carry, an inner join's ``ON`` equalities add a mutual determination
+        between the joined columns, and an equality filter pins its column. Everything
+        is tracked qualified by source alias (a join can expose two ``country``
+        columns), then projected onto the output names.
 
-        Only inner joins carry: an outer join pads its optional side with NULL and a
-        cross join multiplies rows, so both prove nothing here. Aggregation over a join
-        is deferred (the FD scope a downstream guard would read is not a single source),
-        and a candidate-key-derived dependency is not minted across a join (sound to omit;
-        the key path stays single-source for now)."""
-        if any(sg.join_side_of(j) is not sg.JoinSide.INNER for j in joins):
-            return frozenset()
+        Padding is what breaks an FD: an outer join fills its optional side with NULL
+        on unmatched rows, so a padded side's dependencies are dropped (until the NULL
+        semantics are worked through) and an ``ON`` equality is minted only while both
+        its columns stay on kept sides. The padded sides mirror nullability's taint:
+        LEFT pads the joined-in side, RIGHT pads the accumulated left, FULL pads both,
+        INNER and CROSS pad nothing (a cross join only duplicates rows). Aggregation
+        over a join is deferred (the FD scope a downstream guard would read is not a
+        single source), and a candidate-key-derived dependency is not minted across a
+        join (sound to omit; the key path stays single-source for now)."""
         group = sg.group_of(sel)
         if group is not None and group.expressions:
             return frozenset()
@@ -298,19 +303,36 @@ class _FdWalk:
                 return frozenset()
             sources.append((node.alias_or_name.lower(), base))
 
+        aliases = [alias for alias, _ in sources]
+        padded: set[str] = set()
+        for i, j in enumerate(joins, start=1):
+            side = sg.join_side_of(j)
+            if side is sg.JoinSide.LEFT:
+                padded.add(aliases[i])
+            elif side is sg.JoinSide.RIGHT:
+                padded.update(aliases[:i])
+            elif side is sg.JoinSide.FULL:
+                padded.add(aliases[i])
+                padded.update(aliases[:i])
+
         qfds: set[tuple[frozenset[_QCol], _QCol]] = set()
         for alias, base in sources:
+            if alias in padded:
+                continue
             for fd in base.fds:
                 qfds.add((frozenset((alias, d) for d in fd.determinant), (alias, fd.dependent)))
         for j in joins:
+            if sg.join_side_of(j) is not sg.JoinSide.INNER:
+                continue
             on = sg.on_of(j)
             if on is None:
                 continue
             for left, right in sg.equality_column_pairs(on):
                 ql, qr = _qcol(left), _qcol(right)
-                if ql is not None and qr is not None:
-                    qfds.add((frozenset({ql}), qr))
-                    qfds.add((frozenset({qr}), ql))
+                if ql is None or qr is None or ql[0] in padded or qr[0] in padded:
+                    continue
+                qfds.add((frozenset({ql}), qr))
+                qfds.add((frozenset({qr}), ql))
         where = sg.where_of(sel)
         if where is not None and isinstance(where.this, Expr):
             for col in sg.equality_literal_columns(where.this):

--- a/src/dblect/lineage/properties/functional_dependency.py
+++ b/src/dblect/lineage/properties/functional_dependency.py
@@ -196,8 +196,9 @@ class _FdWalk:
         from_ = sg.from_of(sel)
         if from_ is None or not isinstance(from_.this, Expr):
             return frozenset()
-        if sg.joins_of(sel):
-            return frozenset()  # a join can pair determinant values across sources
+        joins = sg.joins_of(sel)
+        if joins:
+            return self._join_select(sel, from_.this, joins, cte_scope=local)
         base = self._resolve_source(from_.this, cte_scope=local)
         if base is None:
             return frozenset()
@@ -259,6 +260,69 @@ class _FdWalk:
             return _Base(self.scope_fds(inner, cte_scope=cte_scope))
         return None
 
+    def _join_select(
+        self,
+        sel: exp.Select,
+        from_node: Expr,
+        joins: list[exp.Join],
+        *,
+        cte_scope: Mapping[str, frozenset[FD]],
+    ) -> frozenset[FD]:
+        """Dependencies an inner join carries to the projection.
+
+        An FD that holds on one joined relation holds on the inner join: two output
+        rows agreeing on its determinant come from that relation's rows agreeing on it,
+        and a join only filters or duplicates rows (a duplicate still agrees on the
+        dependent). So each source's dependencies carry, the ``ON`` equalities add a
+        mutual determination between the joined columns, and an equality filter pins its
+        column. Everything is tracked qualified by source alias (a join can expose two
+        ``country`` columns), then projected onto the output names.
+
+        Only inner joins carry: an outer join pads its optional side with NULL and a
+        cross join multiplies rows, so both prove nothing here. Aggregation over a join
+        is deferred (the FD scope a downstream guard would read is not a single source),
+        and a candidate-key-derived dependency is not minted across a join (sound to omit;
+        the key path stays single-source for now)."""
+        if any(sg.join_side_of(j) is not sg.JoinSide.INNER for j in joins):
+            return frozenset()
+        group = sg.group_of(sel)
+        if group is not None and group.expressions:
+            return frozenset()
+
+        sources: list[tuple[str, _Base]] = []
+        for node in (from_node, *(j.this for j in joins)):
+            if not isinstance(node, Expr):
+                return frozenset()
+            base = self._resolve_source(node, cte_scope=cte_scope)
+            if base is None:
+                return frozenset()
+            sources.append((node.alias_or_name.lower(), base))
+
+        qfds: set[tuple[frozenset[_QCol], _QCol]] = set()
+        for alias, base in sources:
+            for fd in base.fds:
+                qfds.add((frozenset((alias, d) for d in fd.determinant), (alias, fd.dependent)))
+        for j in joins:
+            on = sg.on_of(j)
+            if on is None:
+                continue
+            for left, right in sg.equality_column_pairs(on):
+                ql, qr = _qcol(left), _qcol(right)
+                if ql is not None and qr is not None:
+                    qfds.add((frozenset({ql}), qr))
+                    qfds.add((frozenset({qr}), ql))
+        where = sg.where_of(sel)
+        if where is not None and isinstance(where.this, Expr):
+            for col in sg.equality_literal_columns(where.this):
+                qc = _qcol(col)
+                if qc is not None:
+                    qfds.add((frozenset(), qc))
+
+        qrename, star = _qualified_rename(sel)
+        if star:
+            return frozenset()  # a star over a join leaves the output universe ambiguous
+        return _project_qualified(qfds, qrename)
+
 
 def _group_columns(group: exp.Group) -> frozenset[str] | None:
     """The group key as case-folded input column names, or ``None`` for a shape we
@@ -308,6 +372,64 @@ def _named_outputs(sel: exp.Select) -> frozenset[str]:
         elif isinstance(proj, exp.Column) and not isinstance(proj.this, exp.Star):
             names.add(sg.column_name(proj).lower())
     return frozenset(names)
+
+
+# --- qualified projection (the join case) ----------------------------------------
+#
+# A join can expose two columns of the same name (``payments.country`` and
+# ``customers.country``), so dependencies under a join are tracked qualified by source
+# alias, ``(alias, column)``, and projected onto bare output names only at the end.
+
+_QCol = tuple[str, str]
+
+
+def _qcol(col: exp.Column) -> _QCol | None:
+    """A column as ``(alias, name)``, or ``None`` when it carries no table qualifier
+    (ambiguous under a join, so not attributable to a side)."""
+    table = sg.column_table(col)
+    if not table:
+        return None
+    return (table.lower(), sg.column_name(col).lower())
+
+
+def _qualified_rename(sel: exp.Select) -> tuple[dict[_QCol, tuple[str, ...]], bool]:
+    """Map each qualified input column to the output names it appears under, plus a flag
+    for a star (which leaves the output universe ambiguous over a join). Computed
+    projections carry no source column through and contribute nothing."""
+    out: dict[_QCol, list[str]] = {}
+    star = False
+    for proj in sel.expressions:
+        if isinstance(proj, exp.Star):
+            star = True
+            continue
+        inner = proj.this if isinstance(proj, exp.Alias) else proj
+        if isinstance(inner, exp.Column):
+            if isinstance(inner.this, exp.Star):  # ``alias.*``
+                star = True
+                continue
+            qc = _qcol(inner)
+            if qc is not None:
+                out.setdefault(qc, []).append(proj.alias_or_name.lower())
+    return {qc: tuple(names) for qc, names in out.items()}, star
+
+
+def _project_qualified(
+    qfds: set[tuple[frozenset[_QCol], _QCol]], rename: Mapping[_QCol, tuple[str, ...]]
+) -> frozenset[FD]:
+    """Rename each qualified dependency onto the projection's output names, dropping any
+    whose columns do not all survive. One output name per column suffices (copies carry
+    equal values), picked stably."""
+    out: set[FD] = set()
+    for determinant, dependent in qfds:
+        dep_names = rename.get(dependent)
+        if not dep_names:
+            continue
+        det_names = [rename.get(d) for d in determinant]
+        if any(names is None for names in det_names):
+            continue
+        determinant_out = frozenset(min(names) for names in det_names if names is not None)
+        out.add(FD(determinant_out, min(dep_names)))
+    return frozenset(out)
 
 
 # --- the property ------------------------------------------------------------

--- a/src/dblect/lineage/properties/nullability.py
+++ b/src/dblect/lineage/properties/nullability.py
@@ -161,9 +161,9 @@ def _null_literal_rule(
     return Annotation(Nullability.NULLABLE)
 
 
-class _OuterJoinNull(exp.Expression):  # pyright: ignore[reportPrivateImportUsage]
+class OuterJoinNull(exp.Expression):  # pyright: ignore[reportPrivateImportUsage]
     """A synthetic marker wrapping a column reference drawn from an outer join's optional
-    side. The taint rewrite (:func:`_taint_outer_joins`) inserts it into the nullability
+    side. The taint rewrite (:func:`taint_outer_joins`) inserts it into the nullability
     graph only; the rule below reads it to taint the value NULLABLE. Other properties
     never see it, since they run over the untainted graph. It subclasses ``Expression``
     (the concrete base) rather than ``Func`` so the standard node constructor works."""
@@ -195,7 +195,7 @@ NULLABILITY_OPERATORS: Mapping[type[Expr], OperatorTransfer[Nullability]] = {
     exp.Is: _is_not_null_rule,
     exp.Nullif: _nullif_rule,
     exp.Null: _null_literal_rule,
-    _OuterJoinNull: _outer_join_null_rule,
+    OuterJoinNull: _outer_join_null_rule,
 }
 NULLABILITY_AGGREGATES: Mapping[type[exp.AggFunc], AggregateRule[Nullability]] = {
     exp.Count: AggregateRule(core=_count_core),
@@ -421,7 +421,7 @@ def _conditional_columns_by_relation(
 # taint is a fact about the join, not the column expression, so it cannot be grounded
 # (a more precise NON_NULL inference would win the reconcile) and has to enter
 # inference. We do that by rewriting the nullability graph: each optional-side column
-# reference is wrapped in an :class:`_OuterJoinNull` marker whose rule taints NULLABLE.
+# reference is wrapped in an :class:`OuterJoinNull` marker whose rule taints NULLABLE.
 # Because the marker sits in the expression the propagator walks, the taint rides
 # downstream through every consumer and a guard (COALESCE, IS NOT NULL) still clears it.
 
@@ -468,16 +468,16 @@ def _optional_join_aliases(select: exp.Select) -> set[str]:
 
 def _wrap_optional_columns(expr: Expr, optional: set[str]) -> Expr:
     """A copy of ``expr`` with every column qualified by an optional-side alias wrapped in
-    :class:`_OuterJoinNull`. Unqualified columns are left alone (the side is unknown), the
+    :class:`OuterJoinNull`. Unqualified columns are left alone (the side is unknown), the
     silent-when-unsure posture that keeps the taint from over-firing."""
     rewritten = expr.copy()
     targets = [c for c in rewritten.find_all(exp.Column) if c.table and c.table.lower() in optional]
     for col in targets:
-        col.replace(_OuterJoinNull(this=col.copy()))
+        col.replace(OuterJoinNull(this=col.copy()))
     return rewritten
 
 
-def _taint_outer_joins(
+def taint_outer_joins(
     graph: ColumnLineageGraph,
     manifest: Manifest,
     *,
@@ -529,7 +529,7 @@ def activated_nullability(
     column folds NON_NULL into its annotation. ``parsed`` shares the audit's already-parsed
     trees so the whole pass re-parses nothing; the nullability detectors are its consumer.
     """
-    tainted = _taint_outer_joins(
+    tainted = taint_outer_joins(
         build_manifest_graph(manifest, parsed=parsed).graph, manifest, parsed=parsed
     )
     base = dict(propagate(tainted, nullability_property(manifest, name_to_source={})))

--- a/src/dblect/lineage/properties/uniqueness.py
+++ b/src/dblect/lineage/properties/uniqueness.py
@@ -154,6 +154,21 @@ UNIQUENESS_LATTICE: Lattice[CandidateKeySet] = Lattice(
 )
 
 
+def grain_preserved(keys: CandidateKeySet, origin_key: Key) -> bool:
+    """Whether a relation is still keyed finely enough that each ``origin_key`` row appears
+    once, so a magnitude produced at that grain is summed without double counting.
+
+    True when some surviving candidate key refines ``origin_key`` (is a subset of it): a
+    relation unique on ``K <= origin_key`` is unique on ``origin_key`` too. A relation left
+    keyed only on a different key (the fan trap, where a join to a many-side replicates the
+    magnitude), or with no key known, is not provably single-counted: the fan-out signal a
+    downstream ``sum`` rests on. The user-facing finding is the finding pipeline's job; this
+    is the substrate predicate."""
+    if keys.is_bottom:
+        return True
+    return any(key <= origin_key for key in keys.keys)
+
+
 # --- discoverers -------------------------------------------------------------
 
 # Uniqueness grounds on relations a downstream model can ref by name: models and

--- a/src/dblect/sql/_sqlglot.py
+++ b/src/dblect/sql/_sqlglot.py
@@ -179,6 +179,29 @@ def equality_literal_columns(predicate: Expr) -> tuple[exp.Column, ...]:
     return tuple(out)
 
 
+def equality_column_pairs(predicate: Expr) -> tuple[tuple[exp.Column, exp.Column], ...]:
+    """Column-to-column equalities in `predicate` (``a.x = b.y``), as ordered pairs.
+
+    Walks the AND-conjunction; a leaf contributes a pair only when it is an ``exp.EQ``
+    between two bare columns. This is the join-key extraction a join ON predicate needs
+    (each equated pair, both sides resolved), companion to :func:`equality_literal_columns`
+    for the literal-pin case. Non-equality and non-column leaves are skipped, each pair
+    standing on its own conjunct."""
+    out: list[tuple[exp.Column, exp.Column]] = []
+    for leaf in _conjunctive_leaves(predicate):
+        if not isinstance(leaf, exp.EQ):
+            continue
+        left, right = leaf.this, leaf.expression
+        if (
+            isinstance(left, exp.Column)
+            and isinstance(right, exp.Column)
+            and not isinstance(left.this, exp.Star)
+            and not isinstance(right.this, exp.Star)
+        ):
+            out.append((left, right))
+    return tuple(out)
+
+
 def _conjunctive_leaves(predicate: Expr) -> list[Expr]:
     """Flatten an ``AND``-only conjunction into its leaves; non-AND nodes are leaves."""
     if isinstance(predicate, exp.And):

--- a/tests/lineage/test_domain_type_join_keys.py
+++ b/tests/lineage/test_domain_type_join_keys.py
@@ -1,0 +1,80 @@
+"""Join-key type compatibility, the substrate signal (the C2 join concern).
+
+Equating two columns in a join ``ON`` asserts their values mean the same thing, so
+joining a ``MoneyUSD`` column against a ``MoneyEUR`` one (or an ISO-2 ``Country`` against
+an ISO-3) is a contradiction. :func:`join_key_conflicts` computes that signal: the ON
+equalities whose two sides' domain tags meet to ``CONFLICT``. It returns the offending
+column pairs rather than a finding, because the user-facing seam diagnostic is a later
+build; these tests pin the signal by reading tags through a supplied resolver.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import sqlglot
+
+from dblect.lineage.properties.domain_type import (
+    Concrete,
+    Dimension,
+    DomainTag,
+    join_key_conflicts,
+    tagged,
+)
+from dblect.sql import _sqlglot as sg
+
+_USD = tagged(dimension=Dimension.of(Concrete("usd")))
+_EUR = tagged(dimension=Dimension.of(Concrete("eur")))
+_ISO2 = tagged(nominal={"country": Concrete("iso2")})
+_ISO3 = tagged(nominal={"country": Concrete("iso3")})
+
+
+def _on(sql: str) -> sqlglot.Expr:
+    sel = sqlglot.parse_one(sql, dialect="duckdb")
+    assert isinstance(sel, sqlglot.exp.Select)
+    on = sg.on_of(sg.joins_of(sel)[0])
+    assert on is not None
+    return on
+
+
+def _resolver(by_qcol: Mapping[tuple[str, str], DomainTag]):
+    def tag_of(col: sqlglot.exp.Column) -> DomainTag | None:
+        return by_qcol.get((col.table.lower(), col.name.lower()))
+
+    return tag_of
+
+
+def test_mixed_currency_join_key_is_a_conflict() -> None:
+    on = _on("SELECT 1 FROM a JOIN b ON a.amt = b.amt")
+    conflicts = join_key_conflicts(on, _resolver({("a", "amt"): _USD, ("b", "amt"): _EUR}))
+    assert len(conflicts) == 1
+
+
+def test_matching_currency_join_key_is_clean() -> None:
+    on = _on("SELECT 1 FROM a JOIN b ON a.amt = b.amt")
+    assert join_key_conflicts(on, _resolver({("a", "amt"): _USD, ("b", "amt"): _USD})) == ()
+
+
+def test_incompatible_nominal_join_key_is_a_conflict() -> None:
+    on = _on("SELECT 1 FROM a JOIN b ON a.country = b.country")
+    conflicts = join_key_conflicts(
+        on, _resolver({("a", "country"): _ISO2, ("b", "country"): _ISO3})
+    )
+    assert len(conflicts) == 1
+
+
+def test_an_untagged_join_key_does_not_conflict() -> None:
+    """A no-claim side is the lenient posture: nothing is asserted about it, so no finding."""
+    on = _on("SELECT 1 FROM a JOIN b ON a.amt = b.amt")
+    assert join_key_conflicts(on, _resolver({("a", "amt"): _USD})) == ()
+
+
+def test_only_the_conflicting_conjunct_is_flagged() -> None:
+    """A compound ON pins each equality on its own conjunct: the currency mismatch is
+    flagged while a matching key alongside it is not."""
+    on = _on("SELECT 1 FROM a JOIN b ON a.amt = b.amt AND a.k = b.k")
+    tags = {("a", "amt"): _USD, ("b", "amt"): _EUR, ("a", "k"): _USD, ("b", "k"): _USD}
+    conflicts = join_key_conflicts(on, _resolver(tags))
+    assert len(conflicts) == 1
+    left, right = conflicts[0]
+    assert (left.name.lower(), right.name.lower()) == ("amt", "amt")

--- a/tests/lineage/test_domain_type_join_keys.py
+++ b/tests/lineage/test_domain_type_join_keys.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 
 import sqlglot
+from sqlglot import expressions as exp
 
 from dblect.lineage.properties.domain_type import (
     Concrete,
@@ -31,14 +32,14 @@ _ISO3 = tagged(nominal={"country": Concrete("iso3")})
 
 def _on(sql: str) -> sqlglot.Expr:
     sel = sqlglot.parse_one(sql, dialect="duckdb")
-    assert isinstance(sel, sqlglot.exp.Select)
+    assert isinstance(sel, exp.Select)
     on = sg.on_of(sg.joins_of(sel)[0])
     assert on is not None
     return on
 
 
 def _resolver(by_qcol: Mapping[tuple[str, str], DomainTag]):
-    def tag_of(col: sqlglot.exp.Column) -> DomainTag | None:
+    def tag_of(col: exp.Column) -> DomainTag | None:
         return by_qcol.get((col.table.lower(), col.name.lower()))
 
     return tag_of

--- a/tests/lineage/test_domain_type_outer_join.py
+++ b/tests/lineage/test_domain_type_outer_join.py
@@ -1,0 +1,114 @@
+"""Outer-join NULL companion widens the tag (the C1 join concern).
+
+An outer join pads its optional side with NULL on unmatched rows, and a NULL pads the
+whole row: a per-row companion travelling with the magnitude (a ``Money`` whose unit is
+a companion ``currency`` column) is NULL too, so the unit is unknown there and the tag
+can no longer be claimed. It widens to ``NAKED``. A pinned-unit magnitude is unaffected
+(a NULL amount is still of its declared currency), and an inner join, or the kept side of
+an outer join, pads nothing.
+
+The domain-type property reads the same ``OuterJoinNull`` taint the nullability property
+inserts, by running over the outer-join-tainted graph. The taint marks exactly the
+optional-side columns, so no separate join analysis lives here. A companion bound to a
+column of a relation the magnitude no longer travels with (rebinding across projections)
+is the deferred gap noted in the coherence story, not exercised here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from dblect.lineage.builder import build_model_graph
+from dblect.lineage.facts.model import Declared, DeclaredSource, Fact
+from dblect.lineage.graph import ColumnRef, SourceKind, SourceRef
+from dblect.lineage.properties.domain_type import (
+    NAKED,
+    Concrete,
+    Dimension,
+    DomainTag,
+    PerRow,
+    domain_type_grounding,
+    domain_type_property,
+    tagged,
+)
+from dblect.lineage.properties.nullability import taint_outer_joins
+from dblect.lineage.property import propagate
+from dblect.manifest import Manifest, Node, ResourceType
+
+_PAYMENTS = SourceRef(SourceKind.SOURCE, "source.shop.raw.payments")
+_ANCHOR = SourceRef(SourceKind.SOURCE, "source.shop.raw.anchor")
+_MODEL = SourceRef(SourceKind.MODEL, "model.shop.m")
+
+_PER_ROW = tagged(dimension=Dimension.of(PerRow(ColumnRef(_PAYMENTS, "currency"))))
+_USD = tagged(dimension=Dimension.of(Concrete("usd")))
+
+_NAME_TO_SOURCE: Mapping[str, SourceRef] = {"payments": _PAYMENTS, "anchor": _ANCHOR}
+_SCHEMA: Mapping[str, Mapping[str, str]] = {
+    "payments": {"amount": "DECIMAL", "currency": "VARCHAR", "cust_id": "INT"},
+    "anchor": {"id": "INT"},
+}
+
+# ``payments`` is the joined-in (optional) side of a LEFT join, so ``p.amount`` is tainted.
+_OPTIONAL = "SELECT p.amount AS amount FROM anchor a LEFT JOIN payments p ON a.id = p.cust_id"
+# ``payments`` is the kept side; the optional side is ``anchor``, so ``p.amount`` is not.
+_KEPT = "SELECT p.amount AS amount FROM payments p LEFT JOIN anchor a ON p.cust_id = a.id"
+# Inner join pads nothing.
+_INNER = "SELECT p.amount AS amount FROM anchor a JOIN payments p ON a.id = p.cust_id"
+
+
+def _node(ref: SourceRef, sql: str | None) -> Node:
+    kind = ResourceType.MODEL if ref.kind is SourceKind.MODEL else ResourceType.SOURCE
+    return Node(
+        unique_id=ref.unique_id,
+        name=ref.unique_id.split(".")[-1],
+        resource_type=kind,
+        fqn=(ref.unique_id,),
+        package_name="shop",
+        schema="analytics",
+        raw_code=None,
+        compiled_code=sql,
+        original_file_path=None,
+        columns={},
+    )
+
+
+def _run(sql: str, *, amount: DomainTag = _PER_ROW, out: str = "amount") -> DomainTag:
+    """Propagate domain type over the outer-join-tainted column graph and read ``out``."""
+    manifest = Manifest(
+        schema_version="v12",
+        adapter_type="duckdb",
+        nodes={
+            n.unique_id: n
+            for n in (_node(_PAYMENTS, None), _node(_ANCHOR, None), _node(_MODEL, sql))
+        },
+    )
+    graph = build_model_graph(
+        model_uid=_MODEL.unique_id, sql=sql, name_to_source=_NAME_TO_SOURCE, schema=_SCHEMA
+    )
+    tainted = taint_outer_joins(graph, manifest)
+    amount_ref = ColumnRef(_PAYMENTS, "amount")
+    facts = {
+        amount_ref: (
+            Fact(scope=amount_ref, value=amount, provenance=Declared(DeclaredSource.USER_ASSERTED)),
+        )
+    }
+    anns = propagate(tainted, domain_type_property(domain_type_grounding(facts)))
+    return anns[ColumnRef(_MODEL, out)].value
+
+
+def test_per_row_companion_on_optional_side_widens_to_naked() -> None:
+    assert _run(_OPTIONAL) == NAKED
+
+
+def test_pinned_currency_on_optional_side_is_unaffected() -> None:
+    """A NULL-padded amount is still of its declared currency; only a per-row companion,
+    which is itself NULL on the padded row, makes the unit unknown."""
+    assert _run(_OPTIONAL, amount=_USD) == _USD
+
+
+def test_per_row_companion_on_kept_side_is_preserved() -> None:
+    assert _run(_KEPT) == _PER_ROW
+
+
+def test_inner_join_does_not_widen() -> None:
+    assert _run(_INNER) == _PER_ROW

--- a/tests/lineage/test_domain_type_outer_join.py
+++ b/tests/lineage/test_domain_type_outer_join.py
@@ -2,10 +2,12 @@
 
 An outer join pads its optional side with NULL on unmatched rows, and a NULL pads the
 whole row: a per-row companion travelling with the magnitude (a ``Money`` whose unit is
-a companion ``currency`` column) is NULL too, so the unit is unknown there and the tag
-can no longer be claimed. It widens to ``NAKED``. A pinned-unit magnitude is unaffected
-(a NULL amount is still of its declared currency), and an inner join, or the kept side of
-an outer join, pads nothing.
+a companion ``currency`` column) is NULL too, so the unit is unknown there and that
+claim can no longer be made. The widening is per coordinate: each ``PerRow``-bound
+piece of the tag (a dimension unit, a nominal binding) is dropped, while a pinned
+``Concrete`` piece survives (a NULL amount is still of its declared currency). A tag
+that was all per-row widens to ``NAKED``; an inner join, or the kept side of an outer
+join, pads nothing.
 
 The domain-type property reads the same ``OuterJoinNull`` taint the nullability property
 inserts, by running over the outer-join-tainted graph. The taint marks exactly the
@@ -112,3 +114,24 @@ def test_per_row_companion_on_kept_side_is_preserved() -> None:
 
 def test_inner_join_does_not_widen() -> None:
     assert _run(_INNER) == _PER_ROW
+
+
+def test_widening_is_per_coordinate_pinned_dimension_survives() -> None:
+    """A tag mixing a pinned dimension with a per-row nominal binding loses only the
+    per-row piece: the amount is still USD on a padded row, while whether it contains
+    tax (read from a NULL-padded neighbour) is unknown there."""
+    mixed = tagged(
+        dimension=Dimension.of(Concrete("usd")),
+        nominal={"contains_tax": PerRow(ColumnRef(_PAYMENTS, "tax_flag"))},
+    )
+    assert _run(_OPTIONAL, amount=mixed) == _USD
+
+
+def test_widening_is_per_coordinate_pinned_nominal_survives() -> None:
+    """The converse mix: a per-row currency unit is dropped while a pinned nominal
+    binding rides through."""
+    mixed = tagged(
+        dimension=Dimension.of(PerRow(ColumnRef(_PAYMENTS, "currency"))),
+        nominal={"country": Concrete("us")},
+    )
+    assert _run(_OPTIONAL, amount=mixed) == tagged(nominal={"country": Concrete("us")})

--- a/tests/lineage/test_fanout_grain.py
+++ b/tests/lineage/test_fanout_grain.py
@@ -1,0 +1,49 @@
+"""Fan-out grain signal at a sum (the C3 join concern, substrate level).
+
+A magnitude is summable only when the rows being folded are distinct at the grain that
+produced it: each underlying value counted once. A join to a many-side replicates the
+magnitude (the fan trap), so a downstream ``sum`` double counts. The substrate reads this
+from the uniqueness property: :func:`grain_preserved` asks whether the relation being
+aggregated is still keyed at least as finely as the magnitude's origin key, so each origin
+row appears once.
+
+This is the signal only. The user-facing ``order_revenue``-style finding (fired where the
+grain is *not* preserved through a join) belongs to the finding pipeline, a later build;
+here the predicate is pinned directly. Uniqueness's own join handling, which drops a key a
+fan-out breaks, is tested in the uniqueness suite, so this pins the grain predicate over
+constructed key sets.
+"""
+
+from __future__ import annotations
+
+from dblect.lineage.properties.uniqueness import NO_KEYS, CandidateKeySet, grain_preserved
+
+
+def _keys(*key_sets: set[str]) -> CandidateKeySet:
+    return CandidateKeySet(frozenset(frozenset(k) for k in key_sets))
+
+
+def test_grain_preserved_when_the_origin_key_is_a_key() -> None:
+    assert grain_preserved(_keys({"order_id"}), frozenset({"order_id"}))
+
+
+def test_grain_preserved_when_a_finer_key_survives() -> None:
+    """A relation keyed on a subset of the origin is even finer, so each origin row still
+    appears once."""
+    assert grain_preserved(_keys({"order_id"}), frozenset({"order_id", "line_no"}))
+
+
+def test_grain_not_preserved_when_only_a_different_key_survives() -> None:
+    """The fan trap: joining orders to line items leaves the result keyed on the line
+    grain, not the order grain, so ``sum(order_total)`` would double count."""
+    assert not grain_preserved(_keys({"line_item_id"}), frozenset({"order_id"}))
+
+
+def test_grain_not_preserved_when_no_key_is_known() -> None:
+    """No surviving key proves the grain, so the sum is not provably single-counted."""
+    assert not grain_preserved(NO_KEYS, frozenset({"order_id"}))
+
+
+def test_any_surviving_subset_key_preserves_the_grain() -> None:
+    """Several candidate keys: one that refines the origin is enough."""
+    assert grain_preserved(_keys({"x"}, {"order_id"}), frozenset({"order_id"}))

--- a/tests/lineage/test_functional_dependency_propagation.py
+++ b/tests/lineage/test_functional_dependency_propagation.py
@@ -7,8 +7,9 @@ relation's FD set. The rules under test are the sound ones the walk can justify:
 a passthrough carries the source's dependencies, a projection renames them and
 drops what it cannot carry, a WHERE preserves them and pins filtered columns
 constant, a GROUP BY determines every other output from the group key, a key read
-from the uniqueness property determines the columns selected alongside it, and a
-join or UNION proves nothing.
+from the uniqueness property determines the columns selected alongside it, a join
+carries its kept sides' dependencies plus an inner join's ON equalities, and a
+UNION proves nothing.
 """
 
 from __future__ import annotations
@@ -378,10 +379,10 @@ def test_inner_join_qualifies_under_a_name_collision() -> None:
     assert out["model.shop.m"] == FDSet.of(_fd("currency", "country"))
 
 
-def test_left_join_proves_nothing() -> None:
+def test_left_join_drops_the_optional_sides_fds() -> None:
     """An outer join pads the optional side with NULL on unmatched rows, so a
-    dependency on that side need not survive; the conservative posture proves
-    nothing until the NULL semantics are worked through."""
+    dependency on that side need not survive; the conservative posture drops it
+    until the NULL semantics are worked through."""
     out = _fds(
         _declared_on({_CUSTOMERS: (_fd("currency", "country"),)}),
         _source(_PAYMENTS.unique_id),
@@ -395,7 +396,83 @@ def test_left_join_proves_nothing() -> None:
     assert out["model.shop.m"] == NO_FDS
 
 
-def test_cross_join_proves_nothing() -> None:
+def test_left_join_carries_the_kept_sides_fds() -> None:
+    """The kept side's rows come through un-padded, at worst duplicated, and a
+    duplicate still agrees on the dependent: its dependencies survive the outer join."""
+    out = _fds(
+        _declared_on({_PAYMENTS: (_fd("amount", "ref"),)}),
+        _source(_PAYMENTS.unique_id),
+        _source(_CUSTOMERS.unique_id),
+        _model(
+            "model.shop.m",
+            "SELECT p.ref, p.amount, c.country FROM payments p "
+            "LEFT JOIN customers c ON p.customer_id = c.id",
+        ),
+    )
+    assert out["model.shop.m"] == FDSet.of(_fd("amount", "ref"))
+
+
+def test_left_join_does_not_mint_the_on_equality() -> None:
+    """The ON equality holds only on matched rows; a padded row carries NULL on the
+    optional side, so no mutual determination is minted for an outer join's keys."""
+    out = _fds(
+        _declared_on({}),
+        _source(_PAYMENTS.unique_id),
+        _source(_CUSTOMERS.unique_id),
+        _model(
+            "model.shop.m",
+            "SELECT p.customer_id, c.id FROM payments p "
+            "LEFT JOIN customers c ON p.customer_id = c.id",
+        ),
+    )
+    assert out["model.shop.m"] == NO_FDS
+
+
+def test_right_join_keeps_the_joined_in_side() -> None:
+    """A RIGHT join pads the accumulated left side and keeps the joined-in one, the
+    mirror of LEFT: the joined-in relation's dependencies survive, the left's drop."""
+    out = _fds(
+        _declared_on(
+            {
+                _PAYMENTS: (_fd("amount", "ref"),),
+                _CUSTOMERS: (_fd("currency", "country"),),
+            }
+        ),
+        _source(_PAYMENTS.unique_id),
+        _source(_CUSTOMERS.unique_id),
+        _model(
+            "model.shop.m",
+            "SELECT p.ref, p.amount, c.country, c.currency FROM payments p "
+            "RIGHT JOIN customers c ON p.customer_id = c.id",
+        ),
+    )
+    assert out["model.shop.m"] == FDSet.of(_fd("currency", "country"))
+
+
+def test_full_join_proves_nothing() -> None:
+    """A FULL join can pad either side, so neither side's dependencies survive."""
+    out = _fds(
+        _declared_on(
+            {
+                _PAYMENTS: (_fd("amount", "ref"),),
+                _CUSTOMERS: (_fd("currency", "country"),),
+            }
+        ),
+        _source(_PAYMENTS.unique_id),
+        _source(_CUSTOMERS.unique_id),
+        _model(
+            "model.shop.m",
+            "SELECT p.ref, p.amount, c.country, c.currency FROM payments p "
+            "FULL JOIN customers c ON p.customer_id = c.id",
+        ),
+    )
+    assert out["model.shop.m"] == NO_FDS
+
+
+def test_cross_join_carries_side_fds() -> None:
+    """A cross join pads nothing: it only duplicates rows, and duplicates still agree
+    on the dependent, so each side's dependencies survive (there is just no ON to
+    mint an equality from)."""
     out = _fds(
         _declared_on({_CUSTOMERS: (_fd("currency", "country"),)}),
         _source(_PAYMENTS.unique_id),
@@ -405,7 +482,27 @@ def test_cross_join_proves_nothing() -> None:
             "SELECT p.amount, c.country, c.currency FROM payments p CROSS JOIN customers c",
         ),
     )
-    assert out["model.shop.m"] == NO_FDS
+    assert out["model.shop.m"] == FDSet.of(_fd("currency", "country"))
+
+
+def test_a_later_outer_join_pads_an_earlier_inner_joins_equality() -> None:
+    """An inner join's ON equality is minted only while both its columns stay on kept
+    sides: a later RIGHT join pads the whole accumulated left, taking the earlier
+    equality's columns with it."""
+    extra = SourceRef(SourceKind.SOURCE, "source.shop.raw.extra")
+    out = _fds(
+        _declared_on({extra: (_fd("v", "g"),)}),
+        _source(_PAYMENTS.unique_id),
+        _source(_CUSTOMERS.unique_id),
+        _source(extra.unique_id),
+        _model(
+            "model.shop.m",
+            "SELECT p.customer_id, c.id, e.g, e.v FROM payments p "
+            "JOIN customers c ON p.customer_id = c.id "
+            "RIGHT JOIN extra e ON c.id = e.k",
+        ),
+    )
+    assert out["model.shop.m"] == FDSet.of(_fd("v", "g"))
 
 
 def test_inner_join_carries_a_where_pin_on_either_side() -> None:

--- a/tests/lineage/test_functional_dependency_propagation.py
+++ b/tests/lineage/test_functional_dependency_propagation.py
@@ -260,20 +260,6 @@ def test_star_over_a_group_by_keeps_only_within_group_fds() -> None:
 # --- shapes the walk does not model ----------------------------------------------
 
 
-def test_join_proves_nothing() -> None:
-    customers = _source("source.shop.raw.customers")
-    out = _fds(
-        _declared(_fd("currency", "country")),
-        _source(_PAYMENTS.unique_id),
-        customers,
-        _model(
-            "model.shop.joined",
-            "SELECT p.country, p.currency FROM payments p JOIN customers c ON p.customer_id = c.id",
-        ),
-    )
-    assert out["model.shop.joined"] == NO_FDS
-
-
 def test_union_all_proves_nothing() -> None:
     """Two arms can each satisfy a dependency while their union violates it (the same
     determinant value mapping to different dependents per arm)."""
@@ -316,3 +302,122 @@ def test_without_the_uniqueness_edge_no_key_fd_is_minted() -> None:
         _model("model.shop.stg", "SELECT id, customer_id FROM orders"),
     )
     assert out["model.shop.stg"] == NO_FDS
+
+
+# --- dependency through joins (C4) ----------------------------------------------
+
+_CUSTOMERS = SourceRef(SourceKind.SOURCE, "source.shop.raw.customers")
+
+
+def _declared_on(by_scope: Mapping[SourceRef, tuple[FD, ...]]) -> _FdFacts:
+    """Declared FD facts on several sources at once (a join needs each side grounded)."""
+    return {
+        scope: (
+            Fact(
+                scope=scope,
+                value=FDSet.of(*fds),
+                provenance=Declared(DeclaredSource.USER_ASSERTED),
+            ),
+        )
+        for scope, fds in by_scope.items()
+    }
+
+
+def test_inner_join_carries_a_joined_relations_fd() -> None:
+    """An FD that holds on one joined relation holds on the inner join: two output
+    rows agreeing on the determinant come from that relation's rows agreeing on it,
+    and a join only filters or duplicates rows. So ``country -> currency`` declared on
+    ``customers`` survives the join."""
+    out = _fds(
+        _declared_on({_CUSTOMERS: (_fd("currency", "country"),)}),
+        _source(_PAYMENTS.unique_id),
+        _source(_CUSTOMERS.unique_id),
+        _model(
+            "model.shop.m",
+            "SELECT p.amount, c.country, c.currency FROM payments p "
+            "JOIN customers c ON p.customer_id = c.id",
+        ),
+    )
+    assert out["model.shop.m"] == FDSet.of(_fd("currency", "country"))
+
+
+def test_inner_join_carries_both_sides_fds() -> None:
+    out = _fds(
+        _declared_on(
+            {
+                _PAYMENTS: (_fd("amount", "ref"),),
+                _CUSTOMERS: (_fd("currency", "country"),),
+            }
+        ),
+        _source(_PAYMENTS.unique_id),
+        _source(_CUSTOMERS.unique_id),
+        _model(
+            "model.shop.m",
+            "SELECT p.ref, p.amount, c.country, c.currency FROM payments p "
+            "JOIN customers c ON p.customer_id = c.id",
+        ),
+    )
+    assert out["model.shop.m"] == FDSet.of(_fd("amount", "ref"), _fd("currency", "country"))
+
+
+def test_inner_join_qualifies_under_a_name_collision() -> None:
+    """Both sides expose a ``country`` column, but the dependency is the joined
+    relation's. The walk must track which side each column came from (qualified by
+    alias) rather than blurring the two ``country`` columns, or it would mint a
+    dependency off the wrong column."""
+    out = _fds(
+        _declared_on({_CUSTOMERS: (_fd("currency", "country"),)}),
+        _source(_PAYMENTS.unique_id),
+        _source(_CUSTOMERS.unique_id),
+        _model(
+            "model.shop.m",
+            "SELECT c.country AS country, c.currency AS currency, p.country AS p_country "
+            "FROM payments p JOIN customers c ON p.customer_id = c.id",
+        ),
+    )
+    assert out["model.shop.m"] == FDSet.of(_fd("currency", "country"))
+
+
+def test_left_join_proves_nothing() -> None:
+    """An outer join pads the optional side with NULL on unmatched rows, so a
+    dependency on that side need not survive; the conservative posture proves
+    nothing until the NULL semantics are worked through."""
+    out = _fds(
+        _declared_on({_CUSTOMERS: (_fd("currency", "country"),)}),
+        _source(_PAYMENTS.unique_id),
+        _source(_CUSTOMERS.unique_id),
+        _model(
+            "model.shop.m",
+            "SELECT p.amount, c.country, c.currency FROM payments p "
+            "LEFT JOIN customers c ON p.customer_id = c.id",
+        ),
+    )
+    assert out["model.shop.m"] == NO_FDS
+
+
+def test_cross_join_proves_nothing() -> None:
+    out = _fds(
+        _declared_on({_CUSTOMERS: (_fd("currency", "country"),)}),
+        _source(_PAYMENTS.unique_id),
+        _source(_CUSTOMERS.unique_id),
+        _model(
+            "model.shop.m",
+            "SELECT p.amount, c.country, c.currency FROM payments p CROSS JOIN customers c",
+        ),
+    )
+    assert out["model.shop.m"] == NO_FDS
+
+
+def test_inner_join_carries_a_where_pin_on_either_side() -> None:
+    """An equality filter pins its column constant whichever side it sits on."""
+    out = _fds(
+        _declared_on({}),
+        _source(_PAYMENTS.unique_id),
+        _source(_CUSTOMERS.unique_id),
+        _model(
+            "model.shop.m",
+            "SELECT p.amount, c.currency FROM payments p "
+            "JOIN customers c ON p.customer_id = c.id WHERE c.currency = 'usd'",
+        ),
+    )
+    assert out["model.shop.m"] == FDSet.of(_fd("currency"))

--- a/tests/lineage/test_pbt_functional_dependency_soundness.py
+++ b/tests/lineage/test_pbt_functional_dependency_soundness.py
@@ -181,3 +181,131 @@ def test_every_claimed_fd_holds_on_the_data(s: Scenario) -> None:
             f"claimed FD {sorted(fd.determinant)} -> {fd.dependent} violated at "
             f"determinant value {witness} for sql={_model_sql(s)!r} rows={rows}"
         )
+
+
+# --- dependency through an inner join (C4) --------------------------------------
+#
+# A second base table is joined in. An FD declared on the joined-in relation (its data
+# honouring it) must still hold on the inner join, whatever the join's fan-out does:
+# duplicated rows still agree on the dependent. The data is again the judge, so a
+# qualified-projection bug that minted the dependency off the wrong same-named column
+# would surface as a two-row counterexample.
+
+_PAY = SourceRef(SourceKind.SOURCE, "source.test.raw.pay")
+_DIM = SourceRef(SourceKind.SOURCE, "source.test.raw.dim")
+_JOIN_MODEL = SourceRef(SourceKind.MODEL, "model.test.j")
+_QCOLS: tuple[tuple[str, str], ...] = (("p", "k"), ("p", "a"), ("d", "k"), ("d", "g"), ("d", "v"))
+
+
+@dataclass(frozen=True)
+class JoinScenario:
+    rows_pay: tuple[tuple[int, int], ...]  # (k, a)
+    rows_dim: tuple[tuple[int, int, int], ...]  # (k, g, v), with v a function of g (g -> v holds)
+    projection: tuple[tuple[tuple[str, str], str], ...]  # ((alias, column), output name)
+
+
+@st.composite
+def _join_scenario(draw: st.DrawFn) -> JoinScenario:
+    vmap = {g: draw(st.integers(min_value=0, max_value=2)) for g in range(3)}
+    rows_pay = tuple(
+        (draw(st.integers(min_value=0, max_value=2)), draw(st.integers(min_value=0, max_value=9)))
+        for _ in range(draw(st.integers(min_value=0, max_value=6)))
+    )
+    rows_dim: list[tuple[int, int, int]] = []
+    for _ in range(draw(st.integers(min_value=0, max_value=6))):
+        k = draw(st.integers(min_value=0, max_value=2))
+        g = draw(st.integers(min_value=0, max_value=2))
+        rows_dim.append((k, g, vmap[g]))  # v determined by g, so g -> v holds in the data
+    chosen = draw(st.lists(st.sampled_from(_QCOLS), min_size=1, max_size=5, unique=True))
+    projection = tuple((qc, f"o{i}") for i, qc in enumerate(chosen))
+    return JoinScenario(rows_pay=rows_pay, rows_dim=tuple(rows_dim), projection=projection)
+
+
+def _join_sql(s: JoinScenario) -> str:
+    cols = ", ".join(f"{alias}.{col} AS {name}" for (alias, col), name in s.projection)
+    return f"SELECT {cols} FROM pay p JOIN dim d ON p.k = d.k"
+
+
+def _source_node(ref: SourceRef, name: str) -> Node:
+    return Node(
+        unique_id=ref.unique_id,
+        name=name,
+        resource_type=ResourceType.SOURCE,
+        fqn=(ref.unique_id,),
+        package_name="test",
+        schema="raw",
+        raw_code=None,
+        compiled_code=None,
+        original_file_path=None,
+        columns={},
+    )
+
+
+def _join_claimed(s: JoinScenario) -> FDSet:
+    """The join model's FD set, exactly as the relation property derives it, with
+    ``g -> v`` declared on the joined-in ``dim``."""
+    nodes = {
+        _PAY.unique_id: _source_node(_PAY, "pay"),
+        _DIM.unique_id: _source_node(_DIM, "dim"),
+        _JOIN_MODEL.unique_id: Node(
+            unique_id=_JOIN_MODEL.unique_id,
+            name="j",
+            resource_type=ResourceType.MODEL,
+            fqn=(_JOIN_MODEL.unique_id,),
+            package_name="test",
+            schema="analytics",
+            raw_code=None,
+            compiled_code=_join_sql(s),
+            original_file_path=None,
+            columns={},
+        ),
+    }
+    manifest = Manifest(schema_version="v12", adapter_type="duckdb", nodes=nodes)
+    fact = Fact(
+        scope=_DIM,
+        value=FDSet.of(FD(frozenset({"g"}), "v")),
+        provenance=Declared(DeclaredSource.USER_ASSERTED),
+    )
+    prop = functional_dependency_property(functional_dependency_grounding({_DIM: (fact,)}))
+    anns = propagate(build_relation_graph(manifest).graph, prop)
+    return anns[_JOIN_MODEL].value
+
+
+def _join_materialize(s: JoinScenario) -> tuple[tuple[str, ...], list[tuple[object, ...]]]:
+    con = duckdb.connect(":memory:")
+    try:
+        con.execute("CREATE TABLE pay (k INTEGER, a INTEGER)")
+        con.execute("CREATE TABLE dim (k INTEGER, g INTEGER, v INTEGER)")
+        if s.rows_pay:
+            con.executemany("INSERT INTO pay VALUES (?, ?)", [list(r) for r in s.rows_pay])
+        if s.rows_dim:
+            con.executemany("INSERT INTO dim VALUES (?, ?, ?)", [list(r) for r in s.rows_dim])
+        cursor = con.execute(_join_sql(s))
+        description = cursor.description
+        assert description is not None
+        names = tuple(str(d[0]).lower() for d in description)
+        return names, [tuple(r) for r in cursor.fetchall()]
+    finally:
+        con.close()
+
+
+@given(_join_scenario())
+@settings(max_examples=300, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+def test_every_claimed_join_fd_holds_on_the_data(s: JoinScenario) -> None:
+    claimed = _join_claimed(s)
+    assert not claimed.is_bottom
+    selected = dict(s.projection)
+    # Anti-vacuity: when both columns of the joined-in dependency are projected, the
+    # walk must carry it through the join (a silent walk cannot pass on silence alone).
+    if ("d", "g") in selected and ("d", "v") in selected:
+        assert FD(frozenset({selected[("d", "g")]}), selected[("d", "v")]) in claimed.fds
+    names, rows = _join_materialize(s)
+    for fd in claimed.fds:
+        assert {fd.dependent, *fd.determinant} <= set(names), (
+            f"claimed FD names a column the result lacks: {fd} vs {names} for sql={_join_sql(s)!r}"
+        )
+        witness = _fd_holds(fd, names, rows)
+        assert witness is None, (
+            f"claimed FD {sorted(fd.determinant)} -> {fd.dependent} violated at "
+            f"determinant value {witness} for sql={_join_sql(s)!r} rows={rows}"
+        )

--- a/tests/lineage/test_pbt_functional_dependency_soundness.py
+++ b/tests/lineage/test_pbt_functional_dependency_soundness.py
@@ -183,34 +183,55 @@ def test_every_claimed_fd_holds_on_the_data(s: Scenario) -> None:
         )
 
 
-# --- dependency through an inner join (C4) --------------------------------------
+# --- dependency through a join (C4) ----------------------------------------------
 #
-# A second base table is joined in. An FD declared on the joined-in relation (its data
-# honouring it) must still hold on the inner join, whatever the join's fan-out does:
-# duplicated rows still agree on the dependent. The data is again the judge, so a
-# qualified-projection bug that minted the dependency off the wrong same-named column
-# would surface as a two-row counterexample.
+# A second base table is joined in, with the join side drawn alongside the data. An FD
+# declared on a relation (its data honouring it) must still hold on the join wherever
+# that relation is a kept side, whatever the join's fan-out does: duplicated rows still
+# agree on the dependent. The data is again the judge, so a qualified-projection bug
+# that minted the dependency off the wrong same-named column, or a kept/padded mixup,
+# would surface as a two-row counterexample. The padded side's drop is pinned as the
+# contract too: the walk must stay silent about a NULL-padded relation.
 
 _PAY = SourceRef(SourceKind.SOURCE, "source.test.raw.pay")
 _DIM = SourceRef(SourceKind.SOURCE, "source.test.raw.dim")
 _JOIN_MODEL = SourceRef(SourceKind.MODEL, "model.test.j")
 _QCOLS: tuple[tuple[str, str], ...] = (("p", "k"), ("p", "a"), ("d", "k"), ("d", "g"), ("d", "v"))
+_JOIN_KINDS: Mapping[str, str] = {
+    "inner": "JOIN dim d ON p.k = d.k",
+    "left": "LEFT JOIN dim d ON p.k = d.k",
+    "right": "RIGHT JOIN dim d ON p.k = d.k",
+    "full": "FULL JOIN dim d ON p.k = d.k",
+    "cross": "CROSS JOIN dim d",
+}
+# The sides whose rows come through un-padded, per join kind: their declared FDs
+# must be claimed (anti-vacuity) and every claim must hold on the data.
+_KEPT: Mapping[str, frozenset[str]] = {
+    "inner": frozenset({"p", "d"}),
+    "left": frozenset({"p"}),
+    "right": frozenset({"d"}),
+    "full": frozenset(),
+    "cross": frozenset({"p", "d"}),
+}
 
 
 @dataclass(frozen=True)
 class JoinScenario:
-    rows_pay: tuple[tuple[int, int], ...]  # (k, a)
+    side: str  # key into _JOIN_KINDS
+    rows_pay: tuple[tuple[int, int], ...]  # (k, a), with a a function of k (k -> a holds)
     rows_dim: tuple[tuple[int, int, int], ...]  # (k, g, v), with v a function of g (g -> v holds)
     projection: tuple[tuple[tuple[str, str], str], ...]  # ((alias, column), output name)
 
 
 @st.composite
 def _join_scenario(draw: st.DrawFn) -> JoinScenario:
+    side = draw(st.sampled_from(sorted(_JOIN_KINDS)))
+    amap = {k: draw(st.integers(min_value=0, max_value=9)) for k in range(3)}
     vmap = {g: draw(st.integers(min_value=0, max_value=2)) for g in range(3)}
-    rows_pay = tuple(
-        (draw(st.integers(min_value=0, max_value=2)), draw(st.integers(min_value=0, max_value=9)))
-        for _ in range(draw(st.integers(min_value=0, max_value=6)))
-    )
+    rows_pay: list[tuple[int, int]] = []
+    for _ in range(draw(st.integers(min_value=0, max_value=6))):
+        k = draw(st.integers(min_value=0, max_value=2))
+        rows_pay.append((k, amap[k]))  # a determined by k, so k -> a holds in the data
     rows_dim: list[tuple[int, int, int]] = []
     for _ in range(draw(st.integers(min_value=0, max_value=6))):
         k = draw(st.integers(min_value=0, max_value=2))
@@ -218,12 +239,14 @@ def _join_scenario(draw: st.DrawFn) -> JoinScenario:
         rows_dim.append((k, g, vmap[g]))  # v determined by g, so g -> v holds in the data
     chosen = draw(st.lists(st.sampled_from(_QCOLS), min_size=1, max_size=5, unique=True))
     projection = tuple((qc, f"o{i}") for i, qc in enumerate(chosen))
-    return JoinScenario(rows_pay=rows_pay, rows_dim=tuple(rows_dim), projection=projection)
+    return JoinScenario(
+        side=side, rows_pay=tuple(rows_pay), rows_dim=tuple(rows_dim), projection=projection
+    )
 
 
 def _join_sql(s: JoinScenario) -> str:
     cols = ", ".join(f"{alias}.{col} AS {name}" for (alias, col), name in s.projection)
-    return f"SELECT {cols} FROM pay p JOIN dim d ON p.k = d.k"
+    return f"SELECT {cols} FROM pay p {_JOIN_KINDS[s.side]}"
 
 
 def _source_node(ref: SourceRef, name: str) -> Node:
@@ -243,7 +266,7 @@ def _source_node(ref: SourceRef, name: str) -> Node:
 
 def _join_claimed(s: JoinScenario) -> FDSet:
     """The join model's FD set, exactly as the relation property derives it, with
-    ``g -> v`` declared on the joined-in ``dim``."""
+    ``k -> a`` declared on ``pay`` and ``g -> v`` on ``dim``."""
     nodes = {
         _PAY.unique_id: _source_node(_PAY, "pay"),
         _DIM.unique_id: _source_node(_DIM, "dim"),
@@ -261,12 +284,23 @@ def _join_claimed(s: JoinScenario) -> FDSet:
         ),
     }
     manifest = Manifest(schema_version="v12", adapter_type="duckdb", nodes=nodes)
-    fact = Fact(
-        scope=_DIM,
-        value=FDSet.of(FD(frozenset({"g"}), "v")),
-        provenance=Declared(DeclaredSource.USER_ASSERTED),
-    )
-    prop = functional_dependency_property(functional_dependency_grounding({_DIM: (fact,)}))
+    facts = {
+        _PAY: (
+            Fact(
+                scope=_PAY,
+                value=FDSet.of(FD(frozenset({"k"}), "a")),
+                provenance=Declared(DeclaredSource.USER_ASSERTED),
+            ),
+        ),
+        _DIM: (
+            Fact(
+                scope=_DIM,
+                value=FDSet.of(FD(frozenset({"g"}), "v")),
+                provenance=Declared(DeclaredSource.USER_ASSERTED),
+            ),
+        ),
+    }
+    prop = functional_dependency_property(functional_dependency_grounding(facts))
     anns = propagate(build_relation_graph(manifest).graph, prop)
     return anns[_JOIN_MODEL].value
 
@@ -295,10 +329,19 @@ def test_every_claimed_join_fd_holds_on_the_data(s: JoinScenario) -> None:
     claimed = _join_claimed(s)
     assert not claimed.is_bottom
     selected = dict(s.projection)
-    # Anti-vacuity: when both columns of the joined-in dependency are projected, the
-    # walk must carry it through the join (a silent walk cannot pass on silence alone).
-    if ("d", "g") in selected and ("d", "v") in selected:
-        assert FD(frozenset({selected[("d", "g")]}), selected[("d", "v")]) in claimed.fds
+    declared = {"p": (("p", "k"), ("p", "a")), "d": (("d", "g"), ("d", "v"))}
+    for alias, (det, dep) in declared.items():
+        if det not in selected or dep not in selected:
+            continue
+        out_fd = FD(frozenset({selected[det]}), selected[dep])
+        if alias in _KEPT[s.side]:
+            # Anti-vacuity: a kept side's declared dependency must be carried through
+            # the join (a silent walk cannot pass on silence alone).
+            assert out_fd in claimed.fds, f"kept-side FD dropped for sql={_join_sql(s)!r}"
+        else:
+            # The padded side's drop is the contract: NULL padding can break the
+            # dependency, so the walk must stay silent about it.
+            assert out_fd not in claimed.fds, f"padded-side FD claimed for sql={_join_sql(s)!r}"
     names, rows = _join_materialize(s)
     for fd in claimed.fds:
         assert {fd.dependent, *fd.determinant} <= set(names), (


### PR DESCRIPTION
**Stacked on #69** (`domain-type-property`). Phase 3 of the domain-type plan: the four join concerns from the substrate-readiness table, in cost order. Two land fully (substrate-complete, PBT-validated); two land as substrate signals only, deferring the user-facing `Finding` to the seam/reporter pipeline (Phases 4-6) so this PR does not pull the authoring layer forward.

Exploration corrected the plan's "all reuse existing join logic" optimism in two specific ways, recorded in commits.

## C4 — dependency-through-join (fully)
The FD relation walk carried nothing across a join; now a join carries each **kept** side's dependencies, an inner join's `ON`-equality mutual determination, and a WHERE pin on either side. Padding is what breaks an FD, so the kept/padded split mirrors nullability's outer-join taint: LEFT pads the joined-in side, RIGHT the accumulated left, FULL both, INNER and CROSS nothing (a cross join only duplicates rows, and duplicates still agree on the dependent). A padded side's dependencies, and any `ON` equality touching a padded column, are dropped. Because a join can expose two `country` columns, dependencies are tracked **qualified by source alias** `(alias, column)` and projected at the end (mirroring uniqueness's `_QKey`), not a bare-name union. New `sg.equality_column_pairs` helper (reused by C2). Validated by a join soundness PBT that draws the join side alongside the data, materializes the join in duckdb, checks every claimed dependency on the data, and pins both postures: a kept side's declared dependency must be claimed, a padded side's must not.

## C1 — outer-join NULL companion widens (fully)
A magnitude from an outer join's optional side is NULL-padded, so a **per-row companion** (its unit) is NULL there and whatever it vouched for is unknown. The widening is **per coordinate**: each `PerRow`-bound piece of the tag drops while pinned (`Concrete`) pieces survive — a NULL amount is still of its declared currency — so an all-per-row tag widens to `NAKED` and a pinned unit and the kept side are unaffected. Reuses the `OuterJoinNull` taint nullability already inserts (the marker + `taint_outer_joins` are now public — graph-level, shared), with a domain-type rule for the marker. Catches the co-located `Money(amount, currency)` case; a companion split across relations stays the deferred Phase-2 rebinding gap.

## C2 — join-key type compatibility (substrate signal)
`join_key_conflicts(on, tag_of)` returns the `ON` equalities whose two sides' tags meet to `CONFLICT` (MoneyUSD joined against MoneyEUR; incompatible nominal tags). Returns offending pairs rather than a finding.

## C3 — fan-out grain (substrate signal)
`grain_preserved(keys, origin_key)` asks whether a relation is still keyed finely enough that each origin row appears once (so a `sum` doesn't double count), reading the uniqueness property's keys. Negation gated by fan-out evidence becomes the `order_revenue` finding later.

Plan (`hidden-hugging-bee.md`) updated to record the scoping and the qualified-name / taint-reuse corrections.

Full gate green: ruff, ruff format, pyright (strict), pytest (523 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

