### PR TITLE
feat(check): coverage reporting (resolution vs grounding) (#49)

### DIFF
--- a/src/dblect/check/coverage.py
+++ b/src/dblect/check/coverage.py
@@ -1,0 +1,100 @@
+"""Coverage as a first-class output of a check, kept as two metrics that mean
+opposite things.
+
+**Resolution coverage** is the fraction of projection column references whose
+lineage the propagator could follow against the fraction it fell blind on (a
+reference qualify could not attach a source to, an unexpanded ``SELECT *``, a
+macro that escaped rendering). Blindness is a capability gap, so a configurable
+floor turns sustained blindness into a finding, and the floor keys on resolution
+only.
+
+**Grounding coverage** is, among resolved columns, how many a fact grounded,
+reported per property. An ungrounded column is the expected case under "absence
+is silence", not a defect, so grounding never trips a floor on its own. Where it
+earns attention is scoped to declared intent: of the columns a contract names,
+how many resolved to a checkable annotation, which tells a partial adopter
+whether their declarations are actually being checked.
+
+See ``docs/design/lineage-facts.md`` ("Coverage and degradation").
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from dblect.lineage.builder import ModelResolution
+
+
+@dataclass(frozen=True, slots=True)
+class ResolutionCoverage:
+    """Aggregate resolution coverage across every model that built, plus the
+    lowest-covered models for a message that can name where the blindness is."""
+
+    resolved_refs: int
+    blind_refs: int
+    unexpanded_stars: int
+    worst_models: tuple[ModelResolution, ...]
+
+    @property
+    def sites(self) -> int:
+        """Every resolution site across the project: column references attempted
+        plus unexpanded ``SELECT *``. The denominator of the resolved share."""
+        return self.resolved_refs + self.blind_refs + self.unexpanded_stars
+
+    @property
+    def fraction(self) -> float | None:
+        """Resolved share of sites, or ``None`` when there were none (a project of
+        literal-only models has no lineage to follow, which is full coverage
+        rather than blindness, so the floor skips it). An unexpanded ``SELECT *``
+        is one blind site of unknown width: it lowers the share rather than being
+        ignored, so a fully ``SELECT *`` model reads as fully blind."""
+        return self.resolved_refs / self.sites if self.sites else None
+
+    def below(self, floor: float) -> bool:
+        """Whether resolution sits under ``floor``. A project with nothing to
+        resolve is never below a floor; the floor is about blindness, and there
+        is none."""
+        frac = self.fraction
+        return frac is not None and frac < floor
+
+    @staticmethod
+    def from_models(models: tuple[ModelResolution, ...], *, worst_n: int = 5) -> ResolutionCoverage:
+        resolved = sum(m.resolved_refs for m in models)
+        blind = sum(m.blind_refs for m in models)
+        stars = sum(m.unexpanded_stars for m in models)
+        # Worst-first by resolved share, then by absolute blindness, so the
+        # message names the models a reader should look at. Models with no sites
+        # have no blindness and sort last.
+        ranked = sorted(
+            (m for m in models if m.sites),
+            key=lambda m: (
+                m.resolved_refs / m.sites,
+                -(m.blind_refs + m.unexpanded_stars),
+            ),
+        )
+        return ResolutionCoverage(
+            resolved_refs=resolved,
+            blind_refs=blind,
+            unexpanded_stars=stars,
+            worst_models=tuple(ranked[:worst_n]),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class PropertyGrounding:
+    """How many of a property's resolved subjects a fact grounded."""
+
+    property_name: str
+    grounded: int
+    resolved: int
+
+
+@dataclass(frozen=True, slots=True)
+class GroundingCoverage:
+    """Per-property grounding, plus the contract-scoped slice that is the one
+    grounding number worth acting on: of the columns contracts name, how many
+    resolved to a checkable annotation."""
+
+    by_property: tuple[PropertyGrounding, ...]
+    contract_columns: int
+    contract_columns_checkable: int

--- a/src/dblect/check/coverage.py
+++ b/src/dblect/check/coverage.py
@@ -1,12 +1,13 @@
 """Coverage as a first-class output of a check, kept as two metrics that mean
 opposite things.
 
-**Resolution coverage** is the fraction of projection column references whose
-lineage the propagator could follow against the fraction it fell blind on (a
+**Resolution coverage** is the fraction of model output columns whose lineage the
+propagator could follow against the fraction it fell blind on (a column reading a
 reference qualify could not attach a source to, an unexpanded ``SELECT *``, a
-macro that escaped rendering). Blindness is a capability gap, so a configurable
-floor turns sustained blindness into a finding, and the floor keys on resolution
-only.
+macro that escaped rendering). Counting model output columns rather than every
+reference in every nested scope keeps a deep CTE chain from inflating the
+denominator. Blindness is a capability gap, so a configurable floor turns
+sustained blindness into a finding, and the floor keys on resolution only.
 
 **Grounding coverage** is, among resolved columns, how many a fact grounded,
 reported per property. An ungrounded column is the expected case under "absence
@@ -30,16 +31,17 @@ class ResolutionCoverage:
     """Aggregate resolution coverage across every model that built, plus the
     lowest-covered models for a message that can name where the blindness is."""
 
-    resolved_refs: int
-    blind_refs: int
+    resolved_columns: int
+    blind_columns: int
     unexpanded_stars: int
     worst_models: tuple[ModelResolution, ...]
 
     @property
     def sites(self) -> int:
-        """Every resolution site across the project: column references attempted
-        plus unexpanded ``SELECT *``. The denominator of the resolved share."""
-        return self.resolved_refs + self.blind_refs + self.unexpanded_stars
+        """Every resolution site across the project: model output columns whose
+        lineage was attempted plus unexpanded ``SELECT *``. The denominator of the
+        resolved share."""
+        return self.resolved_columns + self.blind_columns + self.unexpanded_stars
 
     @property
     def fraction(self) -> float | None:
@@ -48,7 +50,7 @@ class ResolutionCoverage:
         rather than blindness, so the floor skips it). An unexpanded ``SELECT *``
         is one blind site of unknown width: it lowers the share rather than being
         ignored, so a fully ``SELECT *`` model reads as fully blind."""
-        return self.resolved_refs / self.sites if self.sites else None
+        return self.resolved_columns / self.sites if self.sites else None
 
     def below(self, floor: float) -> bool:
         """Whether resolution sits under ``floor``. A project with nothing to
@@ -59,8 +61,8 @@ class ResolutionCoverage:
 
     @staticmethod
     def from_models(models: tuple[ModelResolution, ...], *, worst_n: int = 5) -> ResolutionCoverage:
-        resolved = sum(m.resolved_refs for m in models)
-        blind = sum(m.blind_refs for m in models)
+        resolved = sum(m.resolved_columns for m in models)
+        blind = sum(m.blind_columns for m in models)
         stars = sum(m.unexpanded_stars for m in models)
         # Worst-first by resolved share, then by absolute blindness, so the
         # message names the models a reader should look at. Models with no sites
@@ -68,13 +70,13 @@ class ResolutionCoverage:
         ranked = sorted(
             (m for m in models if m.sites),
             key=lambda m: (
-                m.resolved_refs / m.sites,
-                -(m.blind_refs + m.unexpanded_stars),
+                m.resolved_columns / m.sites,
+                -(m.blind_columns + m.unexpanded_stars),
             ),
         )
         return ResolutionCoverage(
-            resolved_refs=resolved,
-            blind_refs=blind,
+            resolved_columns=resolved,
+            blind_columns=blind,
             unexpanded_stars=stars,
             worst_models=tuple(ranked[:worst_n]),
         )

--- a/src/dblect/check/findings.py
+++ b/src/dblect/check/findings.py
@@ -11,9 +11,10 @@ one statement). See ``docs/design/declaration-dsl.md`` and
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import StrEnum, auto
 
+from dblect.check.coverage import GroundingCoverage, ResolutionCoverage
 from dblect.loader import LoadIssue
 
 
@@ -31,6 +32,11 @@ class CheckFindingKind(StrEnum):
     AGGREGATION_NOT_WELL_TYPED = auto()
     """A reduction over one field of a multi-field type whose other fields are not
     provably constant across the group (the mixed-currency sum)."""
+
+    RESOLUTION_BELOW_FLOOR = auto()
+    """Lineage resolution across the project sits below the configured floor, so
+    the analysis covers only a fraction of columns and a clean report would
+    overstate what was checked. A capability gap, not a project defect."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -66,6 +72,8 @@ class CheckReport:
     contracts_resolved: int
     models_propagated: int
     predicates_collected: int
+    resolution: ResolutionCoverage = field(default_factory=lambda: ResolutionCoverage(0, 0, 0, ()))
+    grounding: GroundingCoverage = field(default_factory=lambda: GroundingCoverage((), 0, 0))
 
     @property
     def has_findings(self) -> bool:

--- a/src/dblect/check/report.py
+++ b/src/dblect/check/report.py
@@ -34,8 +34,8 @@ class JsonPropertyGrounding(TypedDict):
 
 
 class JsonResolutionCoverage(TypedDict):
-    resolved_refs: int
-    blind_refs: int
+    resolved_columns: int
+    blind_columns: int
     sites: int
     unexpanded_stars: int
     fraction: float | None
@@ -104,11 +104,11 @@ def _coverage_block(report: CheckReport) -> str:
     grounding is, among that, how many columns a fact actually checks."""
     res = report.resolution
     frac = res.fraction
-    res_pct = "n/a" if frac is None else f"{frac:.0%}"
+    res_pct = "n/a" if frac is None else f"{frac:.1%}"
     star = f"; {res.unexpanded_stars} unexpanded SELECT *" if res.unexpanded_stars else ""
     lines = [
         "coverage:",
-        f"  resolution: {res_pct} of lineage sites ({res.resolved_refs}/{res.sites}){star}",
+        f"  resolution: {res_pct} of columns ({res.resolved_columns}/{res.sites}){star}",
     ]
     g = report.grounding
     per_prop = "; ".join(f"{p.property_name} {p.grounded}/{p.resolved}" for p in g.by_property)
@@ -157,8 +157,8 @@ def render_json(report: CheckReport) -> str:
         },
         "coverage": {
             "resolution": {
-                "resolved_refs": report.resolution.resolved_refs,
-                "blind_refs": report.resolution.blind_refs,
+                "resolved_columns": report.resolution.resolved_columns,
+                "blind_columns": report.resolution.blind_columns,
                 "sites": report.resolution.sites,
                 "unexpanded_stars": report.resolution.unexpanded_stars,
                 "fraction": report.resolution.fraction,

--- a/src/dblect/check/report.py
+++ b/src/dblect/check/report.py
@@ -13,7 +13,8 @@ from typing import TypedDict
 
 from dblect.check.findings import CheckFinding, CheckReport
 
-JSON_SCHEMA_VERSION = "1"
+# Bumped to 2 with the coverage block (resolution + grounding) added to the JSON.
+JSON_SCHEMA_VERSION = "2"
 
 
 class JsonSummary(TypedDict):
@@ -24,6 +25,31 @@ class JsonSummary(TypedDict):
     findings: int
     load_issues: int
     unbuilt: int
+
+
+class JsonPropertyGrounding(TypedDict):
+    property: str
+    grounded: int
+    resolved: int
+
+
+class JsonResolutionCoverage(TypedDict):
+    resolved_refs: int
+    blind_refs: int
+    sites: int
+    unexpanded_stars: int
+    fraction: float | None
+
+
+class JsonGroundingCoverage(TypedDict):
+    by_property: list[JsonPropertyGrounding]
+    contract_columns: int
+    contract_columns_checkable: int
+
+
+class JsonCoverage(TypedDict):
+    resolution: JsonResolutionCoverage
+    grounding: JsonGroundingCoverage
 
 
 class JsonFinding(TypedDict):
@@ -48,13 +74,14 @@ class JsonUnbuilt(TypedDict):
 class JsonReport(TypedDict):
     schema_version: str
     summary: JsonSummary
+    coverage: JsonCoverage
     findings: list[JsonFinding]
     load_issues: list[JsonLoadIssue]
     unbuilt: list[JsonUnbuilt]
 
 
 def render_text(report: CheckReport) -> str:
-    sections: list[str] = [_summary_line(report)]
+    sections: list[str] = [_summary_line(report), _coverage_block(report)]
     if report.load_issues:
         lines = [
             f"  could not load {issue.module}: {issue.message}" for issue in report.load_issues
@@ -69,6 +96,28 @@ def render_text(report: CheckReport) -> str:
         lines = [f"  {m.unique_id}: {m.reason}" for m in report.unbuilt]
         sections.append("could not analyze (no findings reported for these):\n" + "\n".join(lines))
     return "\n\n".join(sections) + "\n"
+
+
+def _coverage_block(report: CheckReport) -> str:
+    """The two coverage metrics, rendered so thin coverage cannot hide behind a
+    short finding list. Resolution is the lineage the propagator could follow;
+    grounding is, among that, how many columns a fact actually checks."""
+    res = report.resolution
+    frac = res.fraction
+    res_pct = "n/a" if frac is None else f"{frac:.0%}"
+    star = f"; {res.unexpanded_stars} unexpanded SELECT *" if res.unexpanded_stars else ""
+    lines = [
+        "coverage:",
+        f"  resolution: {res_pct} of lineage sites ({res.resolved_refs}/{res.sites}){star}",
+    ]
+    g = report.grounding
+    per_prop = "; ".join(f"{p.property_name} {p.grounded}/{p.resolved}" for p in g.by_property)
+    if per_prop:
+        lines.append(f"  grounding: {per_prop}")
+    lines.append(
+        f"  contract columns checkable: {g.contract_columns_checkable}/{g.contract_columns}"
+    )
+    return "\n".join(lines)
 
 
 def _summary_line(report: CheckReport) -> str:
@@ -105,6 +154,23 @@ def render_json(report: CheckReport) -> str:
             "findings": len(report.findings),
             "load_issues": len(report.load_issues),
             "unbuilt": len(report.unbuilt),
+        },
+        "coverage": {
+            "resolution": {
+                "resolved_refs": report.resolution.resolved_refs,
+                "blind_refs": report.resolution.blind_refs,
+                "sites": report.resolution.sites,
+                "unexpanded_stars": report.resolution.unexpanded_stars,
+                "fraction": report.resolution.fraction,
+            },
+            "grounding": {
+                "by_property": [
+                    {"property": p.property_name, "grounded": p.grounded, "resolved": p.resolved}
+                    for p in report.grounding.by_property
+                ],
+                "contract_columns": report.grounding.contract_columns,
+                "contract_columns_checkable": report.grounding.contract_columns_checkable,
+            },
         },
         "findings": [
             {

--- a/src/dblect/check/run.py
+++ b/src/dblect/check/run.py
@@ -19,15 +19,21 @@ data, which belongs to the fixture/PBT loop, so the static check stays static.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from typing import TypeVar
 
 import sqlglot.expressions as exp
 from sqlglot import Expr
 
 from dblect.adapters import AdapterProfile
+from dblect.check.coverage import GroundingCoverage, PropertyGrounding, ResolutionCoverage
 from dblect.check.findings import CheckFinding, CheckFindingKind, CheckReport, UnbuiltModel
-from dblect.lineage.builder import BuildIssue, build_manifest_graph, build_relation_graph
+from dblect.lineage.builder import (
+    BuildIssue,
+    RelationBuildResult,
+    build_manifest_graph,
+    build_relation_graph,
+)
 from dblect.lineage.facts.model import Annotation, Fact
 from dblect.lineage.facts.registry import AnnotationStore, PropertyRegistry
 from dblect.lineage.graph import (
@@ -35,6 +41,7 @@ from dblect.lineage.graph import (
     ColumnLineageGraph,
     ColumnRef,
     RelationLineageGraph,
+    SourceKind,
     SourceRef,
     aggregation_site_meta,
 )
@@ -58,11 +65,17 @@ def run_check(
     profile: AdapterProfile,
     *,
     registry: ContractRegistry | None = None,
+    resolution_floor: float | None = None,
 ) -> CheckReport:
     """Resolve the registered contracts against ``manifest``, propagate, and return
     the declaration-level findings. ``profile`` is the run's resolved target, whose
     dialect parses every model. ``registry`` defaults to the active one (the loader
-    populates a fresh registry the CLI passes in)."""
+    populates a fresh registry the CLI passes in).
+
+    ``resolution_floor`` is the minimum share of column references the propagator
+    must resolve before a clean report is trustworthy; when set and the project
+    falls under it, a ``RESOLUTION_BELOW_FLOOR`` finding fires. It keys on
+    resolution only, never on grounding."""
     reg = registry if registry is not None else active_registry()
     resolved = resolve_contracts(manifest, registry=reg)
 
@@ -70,10 +83,14 @@ def run_check(
     column_build = build_manifest_graph(manifest, dialect=profile.sqlglot_dialect)
     annotations = _propagate(resolved, relation_build.graph, column_build.graph)
 
+    resolution = ResolutionCoverage.from_models(column_build.resolution)
+    grounding = _grounding_coverage(resolved, relation_build, annotations)
+
     findings: list[CheckFinding] = []
     findings.extend(_issue_findings(resolved))
     findings.extend(_contradiction_findings(manifest, annotations))
     findings.extend(_aggregation_findings(manifest, annotations, column_build.graph))
+    findings.extend(_resolution_floor_findings(resolution, resolution_floor))
 
     return CheckReport(
         findings=tuple(findings),
@@ -82,6 +99,8 @@ def run_check(
         contracts_resolved=len(reg.contracts),
         models_propagated=len(manifest.models),
         predicates_collected=len(resolved.predicates),
+        resolution=resolution,
+        grounding=grounding,
     )
 
 
@@ -129,6 +148,96 @@ def _by_scope(facts: tuple[Fact[_V, _S], ...]) -> dict[_S, tuple[Fact[_V, _S], .
     for fact in facts:
         grouped.setdefault(fact.scope, []).append(fact)
     return {scope: tuple(items) for scope, items in grouped.items()}
+
+
+# --- coverage --------------------------------------------------------------------
+
+
+def _grounding_coverage(
+    resolved: ResolvedContracts,
+    relation_build: RelationBuildResult,
+    annotations: Mapping[ColumnRef, Annotation[DomainTag]],
+) -> GroundingCoverage:
+    """Per-property grounding over the property's resolved subjects, plus the
+    contract-scoped slice.
+
+    "Resolved" is the set of columns the propagator actually reached: the keys of
+    the domain-type annotation map, which includes source leaves the lineage flows
+    from (these are absent from ``graph.subjects()``, yet a contract on a source
+    column is genuinely checkable). A scope counts as grounded only when an
+    unconditional fact lands on it (a purely conditional fact grounds nothing
+    unconditionally, matching ``grounding``). The per-property denominator keeps
+    only model-kind columns, since the synthetic CTE and UNION scaffolding is
+    internal, not a column a fact would ever ground."""
+    resolved_columns = set(annotations)
+    model_columns = _model_scopes(resolved_columns)
+    relation_subjects = _model_scopes(relation_build.graph.subjects())
+
+    tag_scopes = _grounded_scopes(resolved.tag_facts)
+    fd_scopes = _grounded_scopes(resolved.fd_facts)
+
+    by_property = (
+        PropertyGrounding(
+            property_name="domain_type",
+            grounded=len(tag_scopes & model_columns),
+            resolved=len(model_columns),
+        ),
+        PropertyGrounding(
+            property_name="functional_dependency",
+            grounded=len(fd_scopes & relation_subjects),
+            resolved=len(relation_subjects),
+        ),
+    )
+    # The columns contracts name are the column scopes a contract fact lands on;
+    # "checkable" means lineage reached them, so a declared type is actually
+    # propagated rather than silently uncheckable on a model that did not build.
+    return GroundingCoverage(
+        by_property=by_property,
+        contract_columns=len(tag_scopes),
+        contract_columns_checkable=len(tag_scopes & resolved_columns),
+    )
+
+
+def _model_scopes(subjects: Iterable[ColumnRef | SourceRef]) -> set[ColumnRef | SourceRef]:
+    """The model-kind subjects among ``subjects``; synthetic scaffolding dropped."""
+    out: set[ColumnRef | SourceRef] = set()
+    for s in subjects:
+        ref = s.source if isinstance(s, ColumnRef) else s
+        if ref.kind is SourceKind.MODEL:
+            out.add(s)
+    return out
+
+
+def _grounded_scopes(facts: tuple[Fact[_V, _S], ...]) -> set[_S]:
+    """Scopes carrying at least one unconditional fact, the ones that ground."""
+    return {f.scope for f in facts if f.condition is None}
+
+
+def _resolution_floor_findings(
+    resolution: ResolutionCoverage, floor: float | None
+) -> list[CheckFinding]:
+    if floor is None or not resolution.below(floor):
+        return []
+    frac = resolution.fraction or 0.0
+    # Only models that actually fell blind are worth naming; a fully-resolved
+    # model is not "lowest" however the ranking sorted it.
+    worst = ", ".join(
+        f"{m.unique_id} ({m.resolved_refs}/{m.sites})"
+        for m in resolution.worst_models
+        if m.resolved_refs < m.sites
+    )
+    tail = f"; lowest: {worst}" if worst else ""
+    return [
+        CheckFinding(
+            kind=CheckFindingKind.RESOLUTION_BELOW_FLOOR,
+            message=(
+                f"resolved {frac:.0%} of lineage sites "
+                f"({resolution.resolved_refs}/{resolution.sites}), below the "
+                f"{floor:.0%} floor; analysis covers only what was resolved{tail}"
+            ),
+            model_unique_id=None,
+        )
+    ]
 
 
 # --- finding derivation ---------------------------------------------------------

--- a/src/dblect/check/run.py
+++ b/src/dblect/check/run.py
@@ -48,10 +48,12 @@ from dblect.lineage.graph import (
 from dblect.lineage.properties.domain_type import (
     NAKED,
     DomainTag,
+    domain_type_grounded_scopes,
     domain_type_grounding,
     domain_type_property,
 )
 from dblect.lineage.properties.functional_dependency import (
+    functional_dependency_grounded_scopes,
     functional_dependency_grounding,
     functional_dependency_property,
 )
@@ -164,17 +166,17 @@ def _grounding_coverage(
     "Resolved" is the set of columns the propagator actually reached: the keys of
     the domain-type annotation map, which includes source leaves the lineage flows
     from (these are absent from ``graph.subjects()``, yet a contract on a source
-    column is genuinely checkable). A scope counts as grounded only when an
-    unconditional fact lands on it (a purely conditional fact grounds nothing
-    unconditionally, matching ``grounding``). The per-property denominator keeps
-    only model-kind columns, since the synthetic CTE and UNION scaffolding is
-    internal, not a column a fact would ever ground."""
+    column is genuinely checkable). "Grounded" reads the property's own grounding
+    fold (``*_grounded_scopes``), the very fold ``_propagate`` grounds from, so the
+    coverage number cannot drift from what was actually grounded. The per-property
+    denominator keeps only model-kind columns, since the synthetic CTE and UNION
+    scaffolding is internal, not a column a fact would ever ground."""
     resolved_columns = set(annotations)
     model_columns = _model_scopes(resolved_columns)
     relation_subjects = _model_scopes(relation_build.graph.subjects())
 
-    tag_scopes = _grounded_scopes(resolved.tag_facts)
-    fd_scopes = _grounded_scopes(resolved.fd_facts)
+    tag_scopes = domain_type_grounded_scopes(_by_scope(resolved.tag_facts))
+    fd_scopes = functional_dependency_grounded_scopes(_by_scope(resolved.fd_facts))
 
     by_property = (
         PropertyGrounding(
@@ -208,11 +210,6 @@ def _model_scopes(subjects: Iterable[ColumnRef | SourceRef]) -> set[ColumnRef | 
     return out
 
 
-def _grounded_scopes(facts: tuple[Fact[_V, _S], ...]) -> set[_S]:
-    """Scopes carrying at least one unconditional fact, the ones that ground."""
-    return {f.scope for f in facts if f.condition is None}
-
-
 def _resolution_floor_findings(
     resolution: ResolutionCoverage, floor: float | None
 ) -> list[CheckFinding]:
@@ -222,18 +219,18 @@ def _resolution_floor_findings(
     # Only models that actually fell blind are worth naming; a fully-resolved
     # model is not "lowest" however the ranking sorted it.
     worst = ", ".join(
-        f"{m.unique_id} ({m.resolved_refs}/{m.sites})"
+        f"{m.unique_id} ({m.resolved_columns}/{m.sites})"
         for m in resolution.worst_models
-        if m.resolved_refs < m.sites
+        if m.resolved_columns < m.sites
     )
     tail = f"; lowest: {worst}" if worst else ""
     return [
         CheckFinding(
             kind=CheckFindingKind.RESOLUTION_BELOW_FLOOR,
             message=(
-                f"resolved {frac:.0%} of lineage sites "
-                f"({resolution.resolved_refs}/{resolution.sites}), below the "
-                f"{floor:.0%} floor; analysis covers only what was resolved{tail}"
+                f"resolved {resolution.resolved_columns}/{resolution.sites} columns "
+                f"({frac:.1%}), below the {floor:.1%} floor; "
+                f"analysis covers only what was resolved{tail}"
             ),
             model_unique_id=None,
         )

--- a/src/dblect/cli/__init__.py
+++ b/src/dblect/cli/__init__.py
@@ -142,6 +142,19 @@ def check(
         bool,
         typer.Option("--no-fail", help="Always exit 0, even when findings exist."),  # pyright: ignore[reportUnknownMemberType]
     ] = False,
+    resolution_floor: Annotated[
+        float | None,
+        typer.Option(  # pyright: ignore[reportUnknownMemberType]
+            "--resolution-floor",
+            min=0.0,
+            max=1.0,
+            help=(
+                "Minimum share (0..1) of column references lineage must resolve; "
+                "below it a RESOLUTION_BELOW_FLOOR finding fires so thin coverage "
+                "is not read as a clean bill."
+            ),
+        ),
+    ] = None,
 ) -> None:
     """Load a project's contracts, propagate, and report declaration-level findings."""
     from dataclasses import replace
@@ -159,7 +172,9 @@ def check(
 
     load_result = load_declarations(project_dir)
     report = replace(
-        run_check(loaded, profile, registry=load_result.registry),
+        run_check(
+            loaded, profile, registry=load_result.registry, resolution_floor=resolution_floor
+        ),
         load_issues=load_result.issues,
     )
     rendered = render_json(report) if output_format is OutputFormat.JSON else render_text(report)

--- a/src/dblect/lineage/builder.py
+++ b/src/dblect/lineage/builder.py
@@ -67,22 +67,22 @@ class BuildIssue:
 
 @dataclass(frozen=True, slots=True)
 class ModelResolution:
-    """Per-model resolution coverage: how many projection column references the
-    builder could follow against how many it fell blind on, plus the count of
-    ``SELECT *`` it could not expand. A model that failed to build at all carries
-    no entry here; it is reported in ``issues`` instead."""
+    """Per-model resolution coverage: how many of the model's output columns the
+    builder could follow the lineage of against how many it fell blind on, plus the
+    count of ``SELECT *`` it could not expand. A model that failed to build at all
+    carries no entry here; it is reported in ``issues`` instead."""
 
     unique_id: str
-    resolved_refs: int
-    blind_refs: int
+    resolved_columns: int
+    blind_columns: int
     unexpanded_stars: int
 
     @property
     def sites(self) -> int:
-        """Resolution sites the builder met: every column reference it tried to
-        resolve, plus every ``SELECT *`` it could not expand. The denominator the
-        resolved share is taken over."""
-        return self.resolved_refs + self.blind_refs + self.unexpanded_stars
+        """Resolution sites the builder met: every output column whose lineage it
+        tried to follow, plus every ``SELECT *`` it could not expand. The
+        denominator the resolved share is taken over."""
+        return self.resolved_columns + self.blind_columns + self.unexpanded_stars
 
 
 @dataclass(frozen=True, slots=True)
@@ -209,8 +209,8 @@ def build_manifest_graph(
         resolution.append(
             ModelResolution(
                 unique_id=uid,
-                resolved_refs=walker.resolved_refs,
-                blind_refs=walker.blind_refs,
+                resolved_columns=walker.resolved_columns,
+                blind_columns=walker.blind_columns,
                 unexpanded_stars=walker.unexpanded_stars,
             )
         )
@@ -294,6 +294,18 @@ def _walk_model(
     return walker
 
 
+@dataclass(frozen=True, slots=True)
+class _Stamped:
+    """A projection's resolved upstream refs (its ``edges`` entry) alongside the
+    leaf tally coverage reads: how many column references attached upstream and how
+    many fell blind. ``refs`` deduplicates; the counts do not, so a column reading
+    one upstream twice still reports two resolved leaves."""
+
+    refs: frozenset[ColumnRef]
+    resolved: int
+    blind: int
+
+
 class _Walker:
     """Per-model scope walker that builds graph entries as it descends."""
 
@@ -323,13 +335,17 @@ class _Walker:
         # One AggregationSite per SELECT scope, resolved lazily and shared by every
         # aggregate stamped in that scope.
         self._site_by_scope: dict[int, AggregationSite | None] = {}
-        # Resolution coverage: every projection column reference the walker meets
-        # is either resolved to an upstream ColumnRef (lineage the propagator can
-        # follow) or fell blind (qualify could not attach a source: a macro that
-        # escaped rendering, an unqualifiable reference, a misparse). An
-        # unexpanded ``SELECT *`` is a blind site of unknown width, counted apart.
-        self.resolved_refs = 0
-        self.blind_refs = 0
+        # Resolution coverage, counted over the model's own output columns (the
+        # top-level projection, the columns the model exposes) rather than every
+        # reference in every nested scope, so a deep CTE chain does not inflate the
+        # denominator. An output column is resolved when every column it reads
+        # attached to an upstream ColumnRef (lineage the propagator can follow) and
+        # blind when any reference fell blind (qualify could not attach a source: a
+        # macro that escaped rendering, an unqualifiable reference, a misparse). A
+        # pure-literal column reads nothing, so it is no resolution site at all. An
+        # unexpanded ``SELECT *`` is one blind column of unknown width, counted apart.
+        self.resolved_columns = 0
+        self.blind_columns = 0
         self.unexpanded_stars = 0
 
     def walk(
@@ -406,21 +422,34 @@ class _Walker:
     ) -> None:
         # A surviving ``Star`` means qualify couldn't expand ``SELECT *`` (no
         # schema for the source). Registering it would surface a phantom
-        # ``"*"`` column on the scope's source. It is a blind site of unknown
-        # width: the propagator follows none of the columns it stands for.
+        # ``"*"`` column on the scope's source. Only the model's own unexpanded
+        # star is an output blind site of unknown width; a star deeper in the tree
+        # surfaces as blind leaves wherever an output column reads through it.
         if isinstance(select, exp.Star):
-            self.unexpanded_stars += 1
+            if scope_source == self._self_ref:
+                self.unexpanded_stars += 1
             return
         out_name = self._alias_or_name(select)
         if not out_name:
             return
         col_ref = ColumnRef(source=scope_source, column=out_name.lower())
-        immediate = self._stamp_columns(select, scope=scope)
+        stamped = self._stamp_columns(select, scope=scope)
         self._stamp_aggregates(select, scope=scope)
         self.expressions[col_ref] = select
-        self.edges[col_ref] = immediate
+        self.edges[col_ref] = stamped.refs
+        if scope_source == self._self_ref:
+            self._count_output_column(stamped)
 
-    def _stamp_columns(self, expr: Expr, *, scope: Scope) -> frozenset[ColumnRef]:
+    def _count_output_column(self, stamped: _Stamped) -> None:
+        """Tally one model output column: blind if any reference fell blind,
+        resolved if it read at least one reference and none fell blind. A column
+        that reads nothing (a pure literal) is no resolution site."""
+        if stamped.blind:
+            self.blind_columns += 1
+        elif stamped.resolved:
+            self.resolved_columns += 1
+
+    def _stamp_columns(self, expr: Expr, *, scope: Scope) -> _Stamped:
         """Stamp the columns that supply ``expr``'s value with their upstream ``ColumnRef``.
 
         Columns lying directly in ``expr`` resolve against ``scope``. A scalar
@@ -428,19 +457,22 @@ class _Walker:
         recurse into its projection against the subquery's own scope and never
         touch its WHERE/FROM, so a correlated predicate column (which filters rows
         rather than supplying the value) does not leak in even though it may
-        resolve against the outer scope. Returns the deduped set of refs as this
-        projection's ``edges`` entry. An unresolved Column is silently skipped:
-        the propagator reads an unstamped Column as "unknown" via the property
-        default.
+        resolve against the outer scope. Returns the deduped set of refs (this
+        projection's ``edges`` entry) with the resolved/blind leaf tally coverage
+        reads. An unresolved Column is silently skipped from ``edges`` (the
+        propagator reads an unstamped Column as "unknown" via the property default)
+        and counted blind.
         """
         direct, subqueries = _projection_leaves(expr)
         immediate: set[ColumnRef] = set()
+        resolved = 0
+        blind = 0
         for col in direct:
             ref = self._resolve_column(col, scope=scope)
             if ref is None:
-                self.blind_refs += 1
+                blind += 1
                 continue
-            self.resolved_refs += 1
+            resolved += 1
             attach_column_ref(col, ref)
             immediate.add(ref)
         for subq in subqueries:
@@ -451,8 +483,11 @@ class _Walker:
             for sel in inner.selects:
                 if isinstance(sel, exp.Star):
                     continue
-                immediate |= self._stamp_columns(sel, scope=sub_scope)
-        return frozenset(immediate)
+                sub = self._stamp_columns(sel, scope=sub_scope)
+                immediate |= sub.refs
+                resolved += sub.resolved
+                blind += sub.blind
+        return _Stamped(refs=frozenset(immediate), resolved=resolved, blind=blind)
 
     def _resolve_column(self, col: exp.Column, *, scope: Scope) -> ColumnRef | None:
         table = col.table
@@ -625,6 +660,9 @@ class _Walker:
             )
 
         arm_refs_per_col: list[list[ColumnRef]] = [[] for _ in output_names]
+        # Leaf tally per output column, summed across arms, so a top-level union
+        # output column counts once with the resolution of everything its arms read.
+        leaves_per_col: list[list[int]] = [[0, 0] for _ in output_names]
         for arm_idx, arm_scope in enumerate(arm_scopes):
             arm_path = (*scope_path, f"arm{arm_idx}")
             arm_ref = SourceRef(
@@ -640,10 +678,12 @@ class _Walker:
                 arm_select = arm_selects[col_idx]
                 arm_col_ref = ColumnRef(source=arm_ref, column=out_name.lower())
                 arm_refs_per_col[col_idx].append(arm_col_ref)
-                immediate = self._stamp_columns(arm_select, scope=arm_scope)
+                stamped = self._stamp_columns(arm_select, scope=arm_scope)
+                leaves_per_col[col_idx][0] += stamped.resolved
+                leaves_per_col[col_idx][1] += stamped.blind
                 self._stamp_aggregates(arm_select, scope=arm_scope)
                 self.expressions[arm_col_ref] = arm_select
-                self.edges[arm_col_ref] = immediate
+                self.edges[arm_col_ref] = stamped.refs
 
         for col_idx, out_name in enumerate(output_names):
             if not out_name or not arm_refs_per_col[col_idx]:
@@ -655,6 +695,10 @@ class _Walker:
             arm_refs = tuple(arm_refs_per_col[col_idx])
             self.expressions[output_col_ref] = UnionConfluence(arm_refs)
             self.edges[output_col_ref] = frozenset(arm_refs)
+            # A top-level union output column is a model output column; count it.
+            if output_src == self._self_ref:
+                resolved, blind = leaves_per_col[col_idx]
+                self._count_output_column(_Stamped(frozenset(arm_refs), resolved, blind))
 
     def _source_ref_for_scope(self, scope: Scope) -> SourceRef:
         ref = self._scope_source_ref.get(id(scope))

--- a/src/dblect/lineage/builder.py
+++ b/src/dblect/lineage/builder.py
@@ -66,9 +66,30 @@ class BuildIssue:
 
 
 @dataclass(frozen=True, slots=True)
+class ModelResolution:
+    """Per-model resolution coverage: how many projection column references the
+    builder could follow against how many it fell blind on, plus the count of
+    ``SELECT *`` it could not expand. A model that failed to build at all carries
+    no entry here; it is reported in ``issues`` instead."""
+
+    unique_id: str
+    resolved_refs: int
+    blind_refs: int
+    unexpanded_stars: int
+
+    @property
+    def sites(self) -> int:
+        """Resolution sites the builder met: every column reference it tried to
+        resolve, plus every ``SELECT *`` it could not expand. The denominator the
+        resolved share is taken over."""
+        return self.resolved_refs + self.blind_refs + self.unexpanded_stars
+
+
+@dataclass(frozen=True, slots=True)
 class BuildResult:
     graph: ColumnLineageGraph
     issues: tuple[BuildIssue, ...]
+    resolution: tuple[ModelResolution, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -153,6 +174,7 @@ def build_manifest_graph(
     # reference resolves against an upstream model the project never documented.
     schema: dict[str, dict[str, str]] = {k: dict(v) for k, v in _build_schema(manifest).items()}
     issues: list[BuildIssue] = []
+    resolution: list[ModelResolution] = []
     graph = ColumnLineageGraph.empty()
     for uid in manifest.dag.topological_order():
         if uid not in manifest.models:
@@ -163,7 +185,7 @@ def build_manifest_graph(
             issues.append(BuildIssue(model_unique_id=uid, message="model has no compiled SQL"))
             continue
         try:
-            per_model = build_model_graph(
+            walker = _walk_model(
                 model_uid=uid,
                 sql=sql,
                 name_to_source=name_to_source,
@@ -183,9 +205,18 @@ def build_manifest_graph(
             # blank lineage for every downstream model.
             issues.append(BuildIssue(model_unique_id=uid, message=f"{type(e).__name__}: {e}"))
             continue
+        per_model = ColumnLineageGraph(edges=walker.edges, expressions=walker.expressions)
+        resolution.append(
+            ModelResolution(
+                unique_id=uid,
+                resolved_refs=walker.resolved_refs,
+                blind_refs=walker.blind_refs,
+                unexpanded_stars=walker.unexpanded_stars,
+            )
+        )
         graph = graph.merge(per_model)
         _record_output_columns(schema, model.name, uid, per_model)
-    return BuildResult(graph=graph, issues=tuple(issues))
+    return BuildResult(graph=graph, issues=tuple(issues), resolution=tuple(resolution))
 
 
 def _record_output_columns(
@@ -219,6 +250,32 @@ def build_model_graph(
     SQL is parsed once. It is copied before qualification, which mutates in place, so
     the caller's tree is left untouched.
     """
+    walker = _walk_model(
+        model_uid=model_uid,
+        sql=sql,
+        name_to_source=name_to_source,
+        schema=schema,
+        dialect=dialect,
+        tree=tree,
+    )
+    return ColumnLineageGraph(edges=walker.edges, expressions=walker.expressions)
+
+
+def _walk_model(
+    *,
+    model_uid: str,
+    sql: str,
+    name_to_source: Mapping[str, SourceRef],
+    schema: Mapping[str, Mapping[str, str]] | None = None,
+    dialect: str | None = "duckdb",
+    tree: Expr | None = None,
+) -> _Walker:
+    """Parse, qualify, and walk one model, returning the populated walker.
+
+    The walker carries both the graph entries (``edges``, ``expressions``) and the
+    resolution counts. ``build_model_graph`` keeps only the graph; the manifest
+    build also reads the counts. Splitting it here is what lets coverage ride
+    alongside the graph without changing ``build_model_graph``'s return type."""
     self_ref = SourceRef(kind=SourceKind.MODEL, unique_id=model_uid)
     expression: Expr = tree.copy() if tree is not None else sqlglot.parse_one(sql, dialect=dialect)
     expression = qualify(
@@ -234,7 +291,7 @@ def build_model_graph(
 
     walker = _Walker(model_uid=model_uid, self_ref=self_ref, name_to_source=name_to_source)
     walker.walk(root_scope, scope_path=())
-    return ColumnLineageGraph(edges=walker.edges, expressions=walker.expressions)
+    return walker
 
 
 class _Walker:
@@ -266,6 +323,14 @@ class _Walker:
         # One AggregationSite per SELECT scope, resolved lazily and shared by every
         # aggregate stamped in that scope.
         self._site_by_scope: dict[int, AggregationSite | None] = {}
+        # Resolution coverage: every projection column reference the walker meets
+        # is either resolved to an upstream ColumnRef (lineage the propagator can
+        # follow) or fell blind (qualify could not attach a source: a macro that
+        # escaped rendering, an unqualifiable reference, a misparse). An
+        # unexpanded ``SELECT *`` is a blind site of unknown width, counted apart.
+        self.resolved_refs = 0
+        self.blind_refs = 0
+        self.unexpanded_stars = 0
 
     def walk(
         self,
@@ -341,8 +406,10 @@ class _Walker:
     ) -> None:
         # A surviving ``Star`` means qualify couldn't expand ``SELECT *`` (no
         # schema for the source). Registering it would surface a phantom
-        # ``"*"`` column on the scope's source.
+        # ``"*"`` column on the scope's source. It is a blind site of unknown
+        # width: the propagator follows none of the columns it stands for.
         if isinstance(select, exp.Star):
+            self.unexpanded_stars += 1
             return
         out_name = self._alias_or_name(select)
         if not out_name:
@@ -371,7 +438,9 @@ class _Walker:
         for col in direct:
             ref = self._resolve_column(col, scope=scope)
             if ref is None:
+                self.blind_refs += 1
                 continue
+            self.resolved_refs += 1
             attach_column_ref(col, ref)
             immediate.add(ref)
         for subq in subqueries:

--- a/src/dblect/lineage/facts/grounding.py
+++ b/src/dblect/lineage/facts/grounding.py
@@ -90,23 +90,25 @@ def collect(
     return {scope: tuple(facts) for scope, facts in buckets.items()}
 
 
-def grounding(
+def _ground(
     facts: Mapping[S, tuple[Fact[K, S], ...]],
     opaque: Collection[S],
     lat: Lattice[K],
-) -> Callable[[S], Annotation[K]]:
-    """Fold each scope's bucket into its grounded annotation and return the lookup.
+) -> dict[S, Annotation[K]]:
+    """The fold itself: the explicit map from scope to grounded annotation, with
+    no IMPLICIT-top default applied. The single home for "what grounds", shared by
+    ``grounding`` (which wraps it in the default-filling lookup) and
+    ``grounded_scopes`` (which reads back which scopes a fact actually grounded).
 
     An opaque scope grounds ``Annotation(top, EXPLICIT)`` regardless of any facts
     present (an opt-out is consulted before facts). A scope whose bucket resolves
-    grounds ``Annotation(value, CONCRETE)``. Every other scope grounds
-    ``Annotation(top, IMPLICIT)``, the "nothing declared" default.
+    grounds ``Annotation(value, CONCRETE)``.
 
     Conditional facts (those carrying a ``condition``) are excluded from the fold:
     they hold only over a row filter, so grounding them unconditionally would
-    over-claim. A scope whose only facts are conditional grounds the IMPLICIT-top
-    default, exactly as if nothing were declared; the facts stay captured in the
-    bucket for an activation step to consume.
+    over-claim. A scope whose only facts are conditional is absent from the map,
+    so it falls to the IMPLICIT-top default exactly as if nothing were declared;
+    the facts stay captured in the bucket for an activation step to consume.
 
     A bucket that resolves to ``bottom`` is a contradiction and raises
     ``FactConflictError`` here, at build time, rather than swallowing it; recovery
@@ -126,13 +128,42 @@ def grounding(
         if is_contradiction:
             raise FactConflictError(scope, unconditional)
         grounded[scope] = Annotation(value, Opacity.CONCRETE)
+    return grounded
 
+
+def grounding(
+    facts: Mapping[S, tuple[Fact[K, S], ...]],
+    opaque: Collection[S],
+    lat: Lattice[K],
+) -> Callable[[S], Annotation[K]]:
+    """Fold each scope's bucket into its grounded annotation and return the lookup.
+
+    A scope absent from the fold grounds ``Annotation(top, IMPLICIT)``, the
+    "nothing declared" default. See ``_ground`` for the grounding rule itself.
+    """
+    grounded = _ground(facts, opaque, lat)
     implicit_top: Annotation[K] = Annotation(lat.top, Opacity.IMPLICIT)
 
     def ground(scope: S) -> Annotation[K]:
         return grounded.get(scope, implicit_top)
 
     return ground
+
+
+def grounded_scopes(
+    facts: Mapping[S, tuple[Fact[K, S], ...]],
+    opaque: Collection[S],
+    lat: Lattice[K],
+) -> set[S]:
+    """The scopes a fact actually grounded (``CONCRETE``), which coverage reports
+    as the grounded share. Reads the same fold ``grounding`` does, so the two can
+    never disagree on what grounds. An opaque opt-out grounds ``EXPLICIT`` top
+    rather than a value, so it is not a fact grounding and is excluded here."""
+    return {
+        scope
+        for scope, ann in _ground(facts, opaque, lat).items()
+        if ann.opacity is Opacity.CONCRETE
+    }
 
 
 def combine(lat: Lattice[K], a: Annotation[K], b: Annotation[K]) -> Annotation[K]:

--- a/src/dblect/lineage/properties/domain_type.py
+++ b/src/dblect/lineage/properties/domain_type.py
@@ -41,7 +41,7 @@ from typing import Final, final
 from sqlglot import Expr
 from sqlglot import expressions as exp
 
-from dblect.lineage.facts.grounding import grounding
+from dblect.lineage.facts.grounding import grounded_scopes, grounding
 from dblect.lineage.facts.lattice import Lattice
 from dblect.lineage.facts.model import Annotation, Fact, Opacity
 from dblect.lineage.facts.property import (
@@ -567,6 +567,16 @@ def domain_type_grounding(
     every property uses: an opt-out grounds EXPLICIT top, a resolved bucket grounds its
     value CONCRETE, everything else the IMPLICIT-top default."""
     return grounding(facts, opaque, DOMAIN_TYPE_LATTICE)
+
+
+def domain_type_grounded_scopes(
+    facts: Mapping[ColumnRef, tuple[Fact[DomainTag, ColumnRef], ...]],
+    *,
+    opaque: Collection[ColumnRef] = (),
+) -> set[ColumnRef]:
+    """The columns a domain-type fact grounded, for coverage. Reads the same fold
+    ``domain_type_grounding`` does."""
+    return grounded_scopes(facts, opaque, DOMAIN_TYPE_LATTICE)
 
 
 def domain_type_property(

--- a/src/dblect/lineage/properties/functional_dependency.py
+++ b/src/dblect/lineage/properties/functional_dependency.py
@@ -35,7 +35,7 @@ from dataclasses import dataclass
 import sqlglot.expressions as exp
 from sqlglot import Expr
 
-from dblect.lineage.facts.grounding import grounding
+from dblect.lineage.facts.grounding import grounded_scopes, grounding
 from dblect.lineage.facts.lattice import Lattice
 from dblect.lineage.facts.model import Annotation, Fact, Opacity
 from dblect.lineage.facts.property import DepContext, Property, PropertyRef, relation_property
@@ -142,6 +142,16 @@ def functional_dependency_grounding(
     fold every property uses: an opt-out grounds EXPLICIT top, a resolved bucket
     grounds its value CONCRETE, everything else the IMPLICIT-top default."""
     return grounding(facts, opaque, FUNCTIONAL_DEPENDENCY_LATTICE)
+
+
+def functional_dependency_grounded_scopes(
+    facts: Mapping[SourceRef, tuple[Fact[FDSet, SourceRef], ...]],
+    *,
+    opaque: Collection[SourceRef] = (),
+) -> set[SourceRef]:
+    """The relations a dependency fact grounded, for coverage. Reads the same fold
+    ``functional_dependency_grounding`` does."""
+    return grounded_scopes(facts, opaque, FUNCTIONAL_DEPENDENCY_LATTICE)
 
 
 # --- the relation reducer --------------------------------------------------------

--- a/tests/check/test_report.py
+++ b/tests/check/test_report.py
@@ -83,7 +83,7 @@ def test_json_is_a_stable_versioned_schema() -> None:
 
 def test_coverage_is_rendered_in_both_formats() -> None:
     resolution = ResolutionCoverage(
-        resolved_refs=8, blind_refs=2, unexpanded_stars=1, worst_models=()
+        resolved_columns=8, blind_columns=2, unexpanded_stars=1, worst_models=()
     )
     grounding = GroundingCoverage(
         by_property=(PropertyGrounding("domain_type", grounded=3, resolved=10),),
@@ -92,17 +92,17 @@ def test_coverage_is_rendered_in_both_formats() -> None:
     )
     report = _report(resolution=resolution, grounding=grounding)
 
-    # 8 resolved of 11 sites (8 resolved refs + 2 blind refs + 1 unexpanded star).
+    # 8 resolved of 11 sites (8 resolved columns + 2 blind columns + 1 unexpanded star).
     text = render_text(report)
-    assert "resolution: 73% of lineage sites (8/11)" in text
+    assert "resolution: 72.7% of columns (8/11)" in text
     assert "unexpanded SELECT *" in text
     assert "domain_type 3/10" in text
     assert "contract columns checkable: 3/4" in text
 
     cov = json.loads(render_json(report))["coverage"]
     assert cov["resolution"] == {
-        "resolved_refs": 8,
-        "blind_refs": 2,
+        "resolved_columns": 8,
+        "blind_columns": 2,
         "sites": 11,
         "unexpanded_stars": 1,
         "fraction": 8 / 11,

--- a/tests/check/test_report.py
+++ b/tests/check/test_report.py
@@ -17,6 +17,7 @@ from dblect.check import (
     render_json,
     render_text,
 )
+from dblect.check.coverage import GroundingCoverage, PropertyGrounding, ResolutionCoverage
 from dblect.loader import LoadIssue
 
 
@@ -24,6 +25,8 @@ def _report(
     *findings: CheckFinding,
     load_issues: tuple[LoadIssue, ...] = (),
     unbuilt: tuple[UnbuiltModel, ...] = (),
+    resolution: ResolutionCoverage | None = None,
+    grounding: GroundingCoverage | None = None,
 ) -> CheckReport:
     return CheckReport(
         findings=findings,
@@ -32,6 +35,8 @@ def _report(
         contracts_resolved=2,
         models_propagated=3,
         predicates_collected=1,
+        resolution=resolution or ResolutionCoverage(0, 0, 0, ()),
+        grounding=grounding or GroundingCoverage((), 0, 0),
     )
 
 
@@ -61,7 +66,7 @@ def test_json_is_a_stable_versioned_schema() -> None:
         column="amount",
     )
     payload = json.loads(render_json(_report(finding, load_issues=(LoadIssue("m", "boom"),))))
-    assert payload["schema_version"] == "1"
+    assert payload["schema_version"] == "2"
     assert payload["summary"] == {
         "contracts_resolved": 2,
         "models_propagated": 3,
@@ -74,6 +79,46 @@ def test_json_is_a_stable_versioned_schema() -> None:
     assert payload["findings"][0]["kind"] == "domain_type_contradiction"
     assert payload["findings"][0]["column"] == "amount"
     assert payload["load_issues"][0]["module"] == "m"
+
+
+def test_coverage_is_rendered_in_both_formats() -> None:
+    resolution = ResolutionCoverage(
+        resolved_refs=8, blind_refs=2, unexpanded_stars=1, worst_models=()
+    )
+    grounding = GroundingCoverage(
+        by_property=(PropertyGrounding("domain_type", grounded=3, resolved=10),),
+        contract_columns=4,
+        contract_columns_checkable=3,
+    )
+    report = _report(resolution=resolution, grounding=grounding)
+
+    # 8 resolved of 11 sites (8 resolved refs + 2 blind refs + 1 unexpanded star).
+    text = render_text(report)
+    assert "resolution: 73% of lineage sites (8/11)" in text
+    assert "unexpanded SELECT *" in text
+    assert "domain_type 3/10" in text
+    assert "contract columns checkable: 3/4" in text
+
+    cov = json.loads(render_json(report))["coverage"]
+    assert cov["resolution"] == {
+        "resolved_refs": 8,
+        "blind_refs": 2,
+        "sites": 11,
+        "unexpanded_stars": 1,
+        "fraction": 8 / 11,
+    }
+    assert cov["grounding"]["by_property"][0] == {
+        "property": "domain_type",
+        "grounded": 3,
+        "resolved": 10,
+    }
+    assert cov["grounding"]["contract_columns_checkable"] == 3
+
+
+def test_resolution_with_nothing_to_resolve_reads_as_not_applicable() -> None:
+    text = render_text(_report())
+    assert "resolution: n/a" in text
+    assert json.loads(render_json(_report()))["coverage"]["resolution"]["fraction"] is None
 
 
 def test_unbuilt_models_are_surfaced_not_silent() -> None:

--- a/tests/check/test_run_check.py
+++ b/tests/check/test_run_check.py
@@ -246,8 +246,8 @@ def test_resolution_and_grounding_coverage_are_reported() -> None:
     report = run_check(_creep_manifest(), _DUCKDB)
 
     res = report.resolution
-    assert res.resolved_refs > 0
-    assert res.fraction == 1.0  # every column reference resolves against an upstream
+    assert res.resolved_columns > 0
+    assert res.fraction == 1.0  # every output column's lineage resolves against an upstream
     assert res.unexpanded_stars == 0
 
     # Both contracts name a column whose lineage resolves, so every contract

--- a/tests/check/test_run_check.py
+++ b/tests/check/test_run_check.py
@@ -227,3 +227,68 @@ def test_declared_dependency_discharges_the_sum() -> None:
 
     report = run_check(_agg_manifest(), _DUCKDB)
     assert not [f for f in report.findings if f.kind is CheckFindingKind.AGGREGATION_NOT_WELL_TYPED]
+
+
+# --- coverage -------------------------------------------------------------------
+
+
+def test_resolution_and_grounding_coverage_are_reported() -> None:
+    # Consistent single-currency contracts keep the report quiet, so the coverage
+    # numbers are what is under test, not a side effect of findings.
+    class RawPayments(ModelContract):
+        dbt_model = "payments"
+        amount: MoneyUSD
+
+    class StgPayments(ModelContract):
+        dbt_model = "stg_payments"
+        amount: MoneyUSD
+
+    report = run_check(_creep_manifest(), _DUCKDB)
+
+    res = report.resolution
+    assert res.resolved_refs > 0
+    assert res.fraction == 1.0  # every column reference resolves against an upstream
+    assert res.unexpanded_stars == 0
+
+    # Both contracts name a column whose lineage resolves, so every contract
+    # column is checkable: a declared type that is actually propagated.
+    grounding = report.grounding
+    assert grounding.contract_columns >= 1
+    assert grounding.contract_columns_checkable == grounding.contract_columns
+    dt = next(p for p in grounding.by_property if p.property_name == "domain_type")
+    assert dt.grounded >= 1
+    assert dt.resolved >= dt.grounded
+
+
+def test_resolution_floor_fires_on_blindness_and_is_silent_when_clean() -> None:
+    # `SELECT *` over a source with no documented columns cannot be expanded, so
+    # the projection is an unexpanded-star blind site and resolution is 0%.
+    opaque = _node("source.shop.raw.opaque", kind=ResourceType.SOURCE, sql=None, columns=_cols())
+    passthru = _node(
+        "model.shop.passthru",
+        kind=ResourceType.MODEL,
+        sql="SELECT * FROM opaque",
+        columns=_cols(x="INT"),
+    )
+    manifest = Manifest(
+        schema_version="v12",
+        adapter_type="duckdb",
+        nodes={opaque.unique_id: opaque, passthru.unique_id: passthru},
+    )
+
+    assert passthru.unique_id not in {m.unique_id for m in run_check(manifest, _DUCKDB).unbuilt}
+    assert run_check(manifest, _DUCKDB).resolution.unexpanded_stars == 1
+
+    breached = run_check(manifest, _DUCKDB, resolution_floor=0.5)
+    assert CheckFindingKind.RESOLUTION_BELOW_FLOOR in _kinds(breached)
+    # The floor keys on resolution only and never fires without one set.
+    assert CheckFindingKind.RESOLUTION_BELOW_FLOOR not in _kinds(run_check(manifest, _DUCKDB))
+
+
+def test_resolution_floor_is_silent_when_coverage_clears_it() -> None:
+    class RawPayments(ModelContract):
+        dbt_model = "payments"
+        amount: MoneyUSD
+
+    report = run_check(_creep_manifest(), _DUCKDB, resolution_floor=0.99)
+    assert CheckFindingKind.RESOLUTION_BELOW_FLOOR not in _kinds(report)

--- a/tests/check/test_run_check.py
+++ b/tests/check/test_run_check.py
@@ -233,8 +233,6 @@ def test_declared_dependency_discharges_the_sum() -> None:
 
 
 def test_resolution_and_grounding_coverage_are_reported() -> None:
-    # Consistent single-currency contracts keep the report quiet, so the coverage
-    # numbers are what is under test, not a side effect of findings.
     class RawPayments(ModelContract):
         dbt_model = "payments"
         amount: MoneyUSD
@@ -247,22 +245,21 @@ def test_resolution_and_grounding_coverage_are_reported() -> None:
 
     res = report.resolution
     assert res.resolved_columns > 0
-    assert res.fraction == 1.0  # every output column's lineage resolves against an upstream
+    assert res.fraction == 1.0
     assert res.unexpanded_stars == 0
 
-    # Both contracts name a column whose lineage resolves, so every contract
-    # column is checkable: a declared type that is actually propagated.
+    # Both contracts name a column whose lineage resolves, so every named column is
+    # checkable: a declared type that actually reaches the propagator.
     grounding = report.grounding
     assert grounding.contract_columns >= 1
     assert grounding.contract_columns_checkable == grounding.contract_columns
     dt = next(p for p in grounding.by_property if p.property_name == "domain_type")
     assert dt.grounded >= 1
-    assert dt.resolved >= dt.grounded
 
 
 def test_resolution_floor_fires_on_blindness_and_is_silent_when_clean() -> None:
     # `SELECT *` over a source with no documented columns cannot be expanded, so
-    # the projection is an unexpanded-star blind site and resolution is 0%.
+    # the model's one output column is an unexpanded-star blind site: resolution 0%.
     opaque = _node("source.shop.raw.opaque", kind=ResourceType.SOURCE, sql=None, columns=_cols())
     passthru = _node(
         "model.shop.passthru",
@@ -276,19 +273,20 @@ def test_resolution_floor_fires_on_blindness_and_is_silent_when_clean() -> None:
         nodes={opaque.unique_id: opaque, passthru.unique_id: passthru},
     )
 
-    assert passthru.unique_id not in {m.unique_id for m in run_check(manifest, _DUCKDB).unbuilt}
-    assert run_check(manifest, _DUCKDB).resolution.unexpanded_stars == 1
+    clean = run_check(manifest, _DUCKDB)
+    # The star is a blind site, not a build failure, and nothing trips at 0%
+    # resolution until a floor is set.
+    assert passthru.unique_id not in {m.unique_id for m in clean.unbuilt}
+    assert clean.resolution.fraction == 0.0
+    assert CheckFindingKind.RESOLUTION_BELOW_FLOOR not in _kinds(clean)
 
     breached = run_check(manifest, _DUCKDB, resolution_floor=0.5)
     assert CheckFindingKind.RESOLUTION_BELOW_FLOOR in _kinds(breached)
-    # The floor keys on resolution only and never fires without one set.
-    assert CheckFindingKind.RESOLUTION_BELOW_FLOOR not in _kinds(run_check(manifest, _DUCKDB))
 
 
-def test_resolution_floor_is_silent_when_coverage_clears_it() -> None:
-    class RawPayments(ModelContract):
-        dbt_model = "payments"
-        amount: MoneyUSD
-
+def test_resolution_floor_is_silent_when_full_coverage_clears_it() -> None:
+    # No contracts: the floor keys on resolution alone, and every column in this
+    # manifest resolves, so even a near-1.0 floor stays silent.
     report = run_check(_creep_manifest(), _DUCKDB, resolution_floor=0.99)
+    assert report.resolution.fraction == 1.0
     assert CheckFindingKind.RESOLUTION_BELOW_FLOOR not in _kinds(report)

--- a/tests/cli/test_init_and_check.py
+++ b/tests/cli/test_init_and_check.py
@@ -128,5 +128,8 @@ def test_check_json_format(jaffle_manifest_path: Path, runner: CliRunner, tmp_pa
     )
     assert result.exit_code == 0, result.output
     payload = json.loads(result.stdout)
-    assert payload["schema_version"] == "1"
+    assert payload["schema_version"] == "2"
     assert payload["summary"]["contracts_resolved"] == 1
+    # The coverage block rides alongside the summary in the schema.
+    assert "resolution" in payload["coverage"]
+    assert "grounding" in payload["coverage"]

--- a/tests/lineage/test_resolution_coverage.py
+++ b/tests/lineage/test_resolution_coverage.py
@@ -50,7 +50,7 @@ def _resolution(manifest: Manifest, uid: str) -> tuple[int, int, int]:
     return model.resolved_columns, model.blind_columns, model.unexpanded_stars
 
 
-def test_every_column_reference_resolves_against_a_documented_upstream() -> None:
+def test_each_output_column_resolves_against_a_documented_upstream() -> None:
     src = _node(
         "source.shop.raw.payments",
         kind=ResourceType.SOURCE,
@@ -68,8 +68,6 @@ def test_every_column_reference_resolves_against_a_documented_upstream() -> None
 
 
 def test_unexpanded_select_star_is_a_blind_site() -> None:
-    # A source with no documented columns: qualify cannot expand `*`, so the
-    # projection is one unexpanded-star blind site and no reference resolves.
     src = _node("source.shop.raw.opaque", kind=ResourceType.SOURCE, sql=None, columns=_cols())
     model = _node(
         "model.shop.passthru",
@@ -93,8 +91,6 @@ def test_literal_only_model_has_no_resolution_sites() -> None:
 
 
 def test_a_column_built_from_many_references_counts_once() -> None:
-    # ``amount + tax`` reads two upstream columns but is one output column:
-    # coverage counts the column, not the references that supply it.
     src = _node(
         "source.shop.raw.payments",
         kind=ResourceType.SOURCE,
@@ -111,9 +107,6 @@ def test_a_column_built_from_many_references_counts_once() -> None:
 
 
 def test_cte_depth_does_not_inflate_the_denominator() -> None:
-    # The model exposes one output column however many CTE hops its lineage takes.
-    # Intermediate CTE columns are not output columns, so deepening the chain
-    # leaves coverage at one resolved column rather than one per hop.
     src = _node(
         "source.shop.raw.payments",
         kind=ResourceType.SOURCE,

--- a/tests/lineage/test_resolution_coverage.py
+++ b/tests/lineage/test_resolution_coverage.py
@@ -1,8 +1,11 @@
 """Resolution coverage counted as the lineage graph is built.
 
-Every projection column reference the builder meets is resolved (lineage the
-propagator can follow) or blind (qualify could not attach a source); an
-unexpanded ``SELECT *`` is a blind site of unknown width. These pin the counts
+Coverage is measured over the model's output columns: a column is resolved when
+the builder could follow the lineage of every reference it reads, blind when any
+reference fell blind (qualify could not attach a source), and no site at all when
+it reads nothing (a literal). An unexpanded ``SELECT *`` is one blind column of
+unknown width. Counting output columns rather than every reference in every nested
+scope keeps a deep CTE chain from inflating the denominator. These pin the counts
 so coverage reporting rests on a measured number rather than an inferred one.
 See ``docs/design/lineage-facts.md`` ("Coverage and degradation").
 """
@@ -44,7 +47,7 @@ def _manifest(*nodes: Node) -> Manifest:
 def _resolution(manifest: Manifest, uid: str) -> tuple[int, int, int]:
     build = build_manifest_graph(manifest)
     [model] = [m for m in build.resolution if m.unique_id == uid]
-    return model.resolved_refs, model.blind_refs, model.unexpanded_stars
+    return model.resolved_columns, model.blind_columns, model.unexpanded_stars
 
 
 def test_every_column_reference_resolves_against_a_documented_upstream() -> None:
@@ -87,3 +90,44 @@ def test_literal_only_model_has_no_resolution_sites() -> None:
         columns=_cols(one="INT", label="VARCHAR"),
     )
     assert _resolution(_manifest(model), "model.shop.k") == (0, 0, 0)
+
+
+def test_a_column_built_from_many_references_counts_once() -> None:
+    # ``amount + tax`` reads two upstream columns but is one output column:
+    # coverage counts the column, not the references that supply it.
+    src = _node(
+        "source.shop.raw.payments",
+        kind=ResourceType.SOURCE,
+        sql=None,
+        columns=_cols(amount="DECIMAL", tax="DECIMAL"),
+    )
+    model = _node(
+        "model.shop.totalled",
+        kind=ResourceType.MODEL,
+        sql="SELECT amount + tax AS total FROM payments",
+        columns=_cols(total="DECIMAL"),
+    )
+    assert _resolution(_manifest(src, model), "model.shop.totalled") == (1, 0, 0)
+
+
+def test_cte_depth_does_not_inflate_the_denominator() -> None:
+    # The model exposes one output column however many CTE hops its lineage takes.
+    # Intermediate CTE columns are not output columns, so deepening the chain
+    # leaves coverage at one resolved column rather than one per hop.
+    src = _node(
+        "source.shop.raw.payments",
+        kind=ResourceType.SOURCE,
+        sql=None,
+        columns=_cols(amount="DECIMAL"),
+    )
+    deep = _node(
+        "model.shop.deep",
+        kind=ResourceType.MODEL,
+        sql=(
+            "WITH a AS (SELECT amount FROM payments), "
+            "b AS (SELECT amount FROM a) "
+            "SELECT amount FROM b"
+        ),
+        columns=_cols(amount="DECIMAL"),
+    )
+    assert _resolution(_manifest(src, deep), "model.shop.deep") == (1, 0, 0)

--- a/tests/lineage/test_resolution_coverage.py
+++ b/tests/lineage/test_resolution_coverage.py
@@ -1,0 +1,89 @@
+"""Resolution coverage counted as the lineage graph is built.
+
+Every projection column reference the builder meets is resolved (lineage the
+propagator can follow) or blind (qualify could not attach a source); an
+unexpanded ``SELECT *`` is a blind site of unknown width. These pin the counts
+so coverage reporting rests on a measured number rather than an inferred one.
+See ``docs/design/lineage-facts.md`` ("Coverage and degradation").
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from dblect.lineage.builder import build_manifest_graph
+from dblect.manifest import Manifest, Node, ResourceType
+from dblect.manifest.parse import Column
+
+
+def _cols(**types: str) -> Mapping[str, Column]:
+    return {n: Column(name=n, data_type=t, description=None) for n, t in types.items()}
+
+
+def _node(uid: str, *, kind: ResourceType, sql: str | None, columns: Mapping[str, Column]) -> Node:
+    return Node(
+        unique_id=uid,
+        name=uid.split(".")[-1],
+        resource_type=kind,
+        fqn=tuple(uid.split(".")[1:]),
+        package_name="shop",
+        schema="analytics",
+        raw_code=None,
+        compiled_code=sql,
+        original_file_path=f"models/{uid.split('.')[-1]}.sql",
+        columns=columns,
+    )
+
+
+def _manifest(*nodes: Node) -> Manifest:
+    return Manifest(
+        schema_version="v12", adapter_type="duckdb", nodes={n.unique_id: n for n in nodes}
+    )
+
+
+def _resolution(manifest: Manifest, uid: str) -> tuple[int, int, int]:
+    build = build_manifest_graph(manifest)
+    [model] = [m for m in build.resolution if m.unique_id == uid]
+    return model.resolved_refs, model.blind_refs, model.unexpanded_stars
+
+
+def test_every_column_reference_resolves_against_a_documented_upstream() -> None:
+    src = _node(
+        "source.shop.raw.payments",
+        kind=ResourceType.SOURCE,
+        sql=None,
+        columns=_cols(amount="DECIMAL", currency="VARCHAR"),
+    )
+    model = _node(
+        "model.shop.stg",
+        kind=ResourceType.MODEL,
+        sql="SELECT amount, currency FROM payments",
+        columns=_cols(amount="DECIMAL", currency="VARCHAR"),
+    )
+    resolved, blind, stars = _resolution(_manifest(src, model), "model.shop.stg")
+    assert (resolved, blind, stars) == (2, 0, 0)
+
+
+def test_unexpanded_select_star_is_a_blind_site() -> None:
+    # A source with no documented columns: qualify cannot expand `*`, so the
+    # projection is one unexpanded-star blind site and no reference resolves.
+    src = _node("source.shop.raw.opaque", kind=ResourceType.SOURCE, sql=None, columns=_cols())
+    model = _node(
+        "model.shop.passthru",
+        kind=ResourceType.MODEL,
+        sql="SELECT * FROM opaque",
+        columns=_cols(x="INT"),
+    )
+    resolved, _blind, stars = _resolution(_manifest(src, model), "model.shop.passthru")
+    assert resolved == 0
+    assert stars == 1
+
+
+def test_literal_only_model_has_no_resolution_sites() -> None:
+    model = _node(
+        "model.shop.k",
+        kind=ResourceType.MODEL,
+        sql="SELECT 1 AS one, 'x' AS label",
+        columns=_cols(one="INT", label="VARCHAR"),
+    )
+    assert _resolution(_manifest(model), "model.shop.k") == (0, 0, 0)


### PR DESCRIPTION
Closes #49.

Surface coverage as a first-class output of `dblect check`, keeping two metrics that mean opposite things separate, so a thin run cannot read as a clean bill.

## What

- **Resolution coverage** — counted in the builder's `_Walker` as the column lineage graph is built. Every projection column reference is `resolved` (qualify attached an upstream `ColumnRef`, lineage the propagator can follow) or `blind` (it could not), and each unexpanded `SELECT *` is one blind site of unknown width. Per-model on `BuildResult.resolution`, aggregated into `ResolutionCoverage`.
- **Grounding coverage** — among the columns the propagator reached, how many a fact grounded, reported per property, plus the contract-scoped slice: of the columns contracts name, how many resolved to a checkable annotation.
- **Floor** — `run_check(..., resolution_floor=...)` and `dblect check --resolution-floor 0..1`. Below it, a new `RESOLUTION_BELOW_FLOOR` finding fires naming the lowest-covered models. Keys on resolution only; silent when there's nothing to resolve or no floor set. Grounding never trips it.
- Both render in the text report (a `coverage:` block) and JSON (schema bumped to `"2"` with a `coverage` object).

## Design notes

- An unexpanded `SELECT *` counts as one blind site folded into the resolution denominator, so a fully-`SELECT *` model reads as 0% rather than "N/A"; surfaced distinctly in the output too.
- "Resolved" for grounding is the propagation annotation universe, not `graph.subjects()`, because a contract on a source column is genuinely checkable yet source leaves aren't graph subjects.
- Scoped to the `dblect check` path (the facts substrate). Extending coverage to the `audit` reporter is a clean follow-up.

## Verification

709 tests pass, pyright 0 errors, ruff clean (on Python 3.12, matching CI; the local 3.11.7 has a slotted-generic-dataclass bug). New tests cover the builder counts, report rendering in both formats, and `run_check` coverage + floor behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)