### PR TITLE
feat(manifest): read catalog.json for leaf (seed/source) columns (#77)

### DIFF
--- a/src/dblect/cli/__init__.py
+++ b/src/dblect/cli/__init__.py
@@ -12,6 +12,7 @@ import typer
 
 if TYPE_CHECKING:
     from dblect.adapters import AdapterProfile
+    from dblect.manifest import Manifest
 
 app = typer.Typer(
     name="dblect",
@@ -79,6 +80,17 @@ def audit(
             ),
         ),
     ] = None,
+    catalog: Annotated[
+        Path | None,
+        typer.Option(  # pyright: ignore[reportUnknownMemberType]
+            "--catalog",
+            help=(
+                "Path to a catalog.json (`dbt docs generate`). Defaults to "
+                "catalog.json alongside the manifest. Supplies seed/source columns "
+                "so undocumented DAG leaves resolve; documented columns win on conflict."
+            ),
+        ),
+    ] = None,
     no_fail: Annotated[
         bool,
         typer.Option(  # pyright: ignore[reportUnknownMemberType]
@@ -93,7 +105,6 @@ def audit(
     """Run the static structural audit over a dbt project's models."""
     from dblect.audit import run_audit
     from dblect.audit.reporter import render_json, render_text
-    from dblect.manifest import Manifest
 
     manifest_path = _resolve_manifest_path(
         project_dir=project_dir,
@@ -101,8 +112,7 @@ def audit(
         dbt_executable=dbt_executable,
         command="audit",
     )
-    typer.echo(f"audit: reading manifest at {manifest_path}", err=True)
-    loaded = Manifest.from_file(manifest_path)
+    loaded = _load_manifest(manifest_path=manifest_path, explicit_catalog=catalog, command="audit")
     profile = _resolve_profile(loaded.adapter_type, dialect_override, command="audit")
     report = run_audit(loaded, profile)
     rendered = render_json(report) if output_format is OutputFormat.JSON else render_text(report)
@@ -138,6 +148,17 @@ def check(
         str | None,
         typer.Option("--dialect", help="Force a sqlglot dialect, overriding the manifest."),  # pyright: ignore[reportUnknownMemberType]
     ] = None,
+    catalog: Annotated[
+        Path | None,
+        typer.Option(  # pyright: ignore[reportUnknownMemberType]
+            "--catalog",
+            help=(
+                "Path to a catalog.json (`dbt docs generate`). Defaults to "
+                "catalog.json alongside the manifest. Supplies seed/source columns "
+                "so undocumented DAG leaves resolve; documented columns win on conflict."
+            ),
+        ),
+    ] = None,
     no_fail: Annotated[
         bool,
         typer.Option("--no-fail", help="Always exit 0, even when findings exist."),  # pyright: ignore[reportUnknownMemberType]
@@ -161,13 +182,11 @@ def check(
 
     from dblect.check import render_json, render_text, run_check
     from dblect.loader import load_declarations
-    from dblect.manifest import Manifest
 
     manifest_path = _resolve_manifest_path(
         project_dir=project_dir, explicit=manifest, dbt_executable=dbt_executable, command="check"
     )
-    typer.echo(f"check: reading manifest at {manifest_path}", err=True)
-    loaded = Manifest.from_file(manifest_path)
+    loaded = _load_manifest(manifest_path=manifest_path, explicit_catalog=catalog, command="check")
     profile = _resolve_profile(loaded.adapter_type, dialect_override, command="check")
 
     load_result = load_declarations(project_dir)
@@ -318,6 +337,43 @@ def _resolve_manifest_path(
             f"`dbt compile` succeeded but {default} is missing; check dbt's target-path config"
         )
     return default
+
+
+def _resolve_catalog_path(*, explicit: Path | None, manifest_path: Path) -> Path | None:
+    """The ``catalog.json`` to read, or ``None`` when there is none.
+
+    An explicit path must exist (a typo should fail loudly). Otherwise dblect
+    looks for ``catalog.json`` next to the manifest, where ``dbt docs generate``
+    writes it, and a miss is silent: the catalog is optional, the run proceeds on
+    documented and derived columns alone."""
+    if explicit is not None:
+        if not explicit.exists():
+            raise typer.BadParameter(f"catalog path does not exist: {explicit}")
+        return explicit
+    default = manifest_path.parent / "catalog.json"
+    return default if default.exists() else None
+
+
+def _load_manifest(*, manifest_path: Path, explicit_catalog: Path | None, command: str) -> Manifest:
+    """Load the manifest and, when a catalog is available, merge its
+    warehouse-introspected columns so seeds and sources resolve without manual
+    documentation. A missing catalog is noted, not an error: it is the difference
+    between full leaf coverage and resolving only what ``schema.yml`` documents."""
+    from dblect.manifest import Catalog, Manifest
+
+    typer.echo(f"{command}: reading manifest at {manifest_path}", err=True)
+    loaded = Manifest.from_file(manifest_path)
+    catalog_path = _resolve_catalog_path(explicit=explicit_catalog, manifest_path=manifest_path)
+    if catalog_path is not None:
+        typer.echo(f"{command}: reading catalog at {catalog_path}", err=True)
+        return loaded.merge_catalog(Catalog.from_file(catalog_path))
+    typer.echo(
+        f"{command}: no catalog.json alongside the manifest; seed/source columns come "
+        "only from schema.yml, so undocumented leaves may not resolve. Run "
+        "`dbt docs generate` or pass --catalog to cover them.",
+        err=True,
+    )
+    return loaded
 
 
 if __name__ == "__main__":

--- a/src/dblect/manifest/__init__.py
+++ b/src/dblect/manifest/__init__.py
@@ -1,5 +1,6 @@
 """dbt manifest ingestion: parse manifest.json into a typed DAG."""
 
+from dblect.manifest.catalog import Catalog
 from dblect.manifest.dag import CycleError, Dag
 from dblect.manifest.parse import (
     DATA_FLOW_UID_PREFIXES,
@@ -16,6 +17,7 @@ from dblect.manifest.parse import (
 
 __all__ = [
     "DATA_FLOW_UID_PREFIXES",
+    "Catalog",
     "Column",
     "ConstraintSpec",
     "ConstraintType",

--- a/src/dblect/manifest/catalog.py
+++ b/src/dblect/manifest/catalog.py
@@ -1,0 +1,63 @@
+"""dbt ``catalog.json`` ingestion: warehouse-introspected columns per node.
+
+``dbt docs generate`` writes a ``catalog.json`` next to the manifest, carrying
+the column universe of every node as the warehouse reports it, including the DAG
+leaves (seeds and sources) that have no SQL for dblect to derive columns from. A
+project that documents none of its leaves in ``schema.yml`` still resolves
+``select *`` and qualified references once the catalog supplies those columns.
+
+This module reads only what dblect needs from the catalog (per-node column names
+and their types) and leaves the merge into the manifest to
+:meth:`Manifest.merge_catalog`, which keeps documented columns authoritative.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Self, cast
+
+from dbt_artifacts_parser.parser import parse_catalog  # type: ignore[import-untyped]
+
+
+@dataclass(frozen=True, slots=True)
+class Catalog:
+    """The columns dbt introspected from the warehouse, keyed by node unique_id.
+
+    ``columns_by_uid[uid]`` maps a column name to its reported data type (or
+    ``None`` when the catalog omits one). Empty for a node the catalog did not
+    cover, which is silence, not an assertion of no columns.
+    """
+
+    columns_by_uid: Mapping[str, Mapping[str, str | None]]
+
+    @classmethod
+    def from_file(cls, path: Path) -> Self:
+        """Load and parse a ``catalog.json`` file at ``path``."""
+        return cls.from_raw(json.loads(path.read_text()))
+
+    @classmethod
+    def from_raw(cls, raw: dict[str, Any]) -> Self:
+        """Parse a raw catalog dict (already loaded as JSON).
+
+        Nodes and sources share the same per-node shape (a ``columns`` map of
+        name to a metadata object carrying ``type``), so both fold into one
+        index keyed by unique_id."""
+        parsed = parse_catalog(raw)
+        by_uid: dict[str, dict[str, str | None]] = {}
+        sections: tuple[Mapping[str, Any], ...] = (
+            cast("Mapping[str, Any]", getattr(parsed, "nodes", None) or {}),
+            cast("Mapping[str, Any]", getattr(parsed, "sources", None) or {}),
+        )
+        for section in sections:
+            for uid, entry in section.items():
+                columns = cast("Mapping[str, Any]", getattr(entry, "columns", None) or {})
+                cols: dict[str, str | None] = {}
+                for name, col in columns.items():
+                    data_type = getattr(col, "type", None)
+                    cols[name] = data_type if isinstance(data_type, str) else None
+                if cols:
+                    by_uid[uid] = cols
+        return cls(columns_by_uid=by_uid)

--- a/src/dblect/manifest/catalog.py
+++ b/src/dblect/manifest/catalog.py
@@ -48,8 +48,8 @@ class Catalog:
         parsed = parse_catalog(raw)
         by_uid: dict[str, dict[str, str | None]] = {}
         sections: tuple[Mapping[str, Any], ...] = (
-            cast("Mapping[str, Any]", getattr(parsed, "nodes", None) or {}),
-            cast("Mapping[str, Any]", getattr(parsed, "sources", None) or {}),
+            cast("Mapping[str, Any]", parsed.nodes or {}),
+            cast("Mapping[str, Any]", parsed.sources or {}),
         )
         for section in sections:
             for uid, entry in section.items():

--- a/src/dblect/manifest/parse.py
+++ b/src/dblect/manifest/parse.py
@@ -285,11 +285,16 @@ class Manifest:
                 merged[uid] = node
                 continue
             columns = dict(node.columns)
-            documented = {name.lower() for name in columns}
+            # Track present names case-insensitively, seeded from the documented
+            # columns and grown as catalog columns land, so two catalog entries
+            # that differ only in case (a warehouse reporting both) collapse to
+            # the first rather than duplicating.
+            present = {name.lower() for name in columns}
             for col_name, data_type in catalog_columns.items():
-                if col_name.lower() in documented:
+                if col_name.lower() in present:
                     continue
                 columns[col_name] = Column(name=col_name, data_type=data_type, description=None)
+                present.add(col_name.lower())
             merged[uid] = replace(node, columns=columns)
         return replace(self, nodes=merged)
 

--- a/src/dblect/manifest/parse.py
+++ b/src/dblect/manifest/parse.py
@@ -11,14 +11,17 @@ from __future__ import annotations
 
 import json
 from collections.abc import Iterable, Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from enum import StrEnum
 from pathlib import Path
-from typing import Any, Self, cast
+from typing import TYPE_CHECKING, Any, Self, cast
 
 from dbt_artifacts_parser.parser import parse_manifest  # type: ignore[import-untyped]
 
 from dblect.manifest.dag import Dag
+
+if TYPE_CHECKING:
+    from dblect.manifest.catalog import Catalog
 
 
 class ResourceType(StrEnum):
@@ -263,6 +266,32 @@ class Manifest:
             adapter_type=adapter_type,
             nodes=nodes,
         )
+
+    def merge_catalog(self, catalog: Catalog) -> Self:
+        """Return a copy whose node column sets are unioned with the catalog's
+        warehouse-introspected columns, so DAG leaves (seeds, sources) that no
+        ``schema.yml`` documents still carry a column universe.
+
+        Documented columns stay authoritative: a column the manifest already
+        carries keeps its declared :class:`Column` (matching by name
+        case-insensitively, since a warehouse may report a different case than
+        the project wrote), and the catalog adds only columns the node lacks.
+        Nodes the catalog does not cover pass through untouched.
+        """
+        merged: dict[str, Node] = {}
+        for uid, node in self.nodes.items():
+            catalog_columns = catalog.columns_by_uid.get(uid)
+            if not catalog_columns:
+                merged[uid] = node
+                continue
+            columns = dict(node.columns)
+            documented = {name.lower() for name in columns}
+            for col_name, data_type in catalog_columns.items():
+                if col_name.lower() in documented:
+                    continue
+                columns[col_name] = Column(name=col_name, data_type=data_type, description=None)
+            merged[uid] = replace(node, columns=columns)
+        return replace(self, nodes=merged)
 
     @property
     def models(self) -> Mapping[str, Node]:

--- a/tests/cli/test_init_and_check.py
+++ b/tests/cli/test_init_and_check.py
@@ -133,3 +133,68 @@ def test_check_json_format(jaffle_manifest_path: Path, runner: CliRunner, tmp_pa
     # The coverage block rides alongside the summary in the schema.
     assert "resolution" in payload["coverage"]
     assert "grounding" in payload["coverage"]
+
+
+# --- catalog wiring -------------------------------------------------------------
+
+_MINIMAL_CATALOG = """{
+  "metadata": {
+    "dbt_schema_version": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+    "dbt_version": "1.8.0",
+    "generated_at": "2024-01-01T00:00:00Z",
+    "invocation_id": "x",
+    "env": {}
+  },
+  "nodes": {},
+  "sources": {},
+  "errors": null
+}
+"""
+
+
+def test_check_reads_catalog_when_supplied(
+    jaffle_manifest_path: Path, runner: CliRunner, tmp_path: Path
+) -> None:
+    catalog = tmp_path / "catalog.json"
+    catalog.write_text(_MINIMAL_CATALOG)
+    result = runner.invoke(
+        app,
+        [
+            "check",
+            str(tmp_path),
+            "--manifest",
+            str(jaffle_manifest_path),
+            "--catalog",
+            str(catalog),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert f"reading catalog at {catalog}" in result.output
+
+
+def test_check_notes_when_no_catalog_is_available(
+    jaffle_manifest_path: Path, runner: CliRunner, tmp_path: Path
+) -> None:
+    # The jaffle manifest has no catalog.json beside it, so the run proceeds and
+    # says so rather than silently resolving leaves only from schema.yml.
+    result = runner.invoke(app, ["check", str(tmp_path), "--manifest", str(jaffle_manifest_path)])
+    assert result.exit_code == 0, result.output
+    assert "no catalog.json" in result.output
+
+
+def test_check_rejects_a_missing_catalog_path(
+    jaffle_manifest_path: Path, runner: CliRunner, tmp_path: Path
+) -> None:
+    result = runner.invoke(
+        app,
+        [
+            "check",
+            str(tmp_path),
+            "--manifest",
+            str(jaffle_manifest_path),
+            "--catalog",
+            str(tmp_path / "nope.json"),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "catalog path does not exist" in result.output

--- a/tests/manifest/test_catalog.py
+++ b/tests/manifest/test_catalog.py
@@ -216,3 +216,66 @@ def test_nodes_absent_from_catalog_pass_through_untouched() -> None:
     manifest = Manifest(schema_version="v12", adapter_type="duckdb", nodes={model.unique_id: model})
     merged = manifest.merge_catalog(Catalog.from_raw(_raw_catalog(nodes={}, sources={})))
     assert merged.nodes["model.shop.orders"] is manifest.nodes["model.shop.orders"]
+
+
+def test_catalog_internal_case_collision_collapses_to_first() -> None:
+    # A warehouse that reports a column under two cases (`amount` and `AMOUNT`)
+    # for an otherwise-undocumented leaf must not yield two columns: the first
+    # wins and the second case-folds into it.
+    source = _node("source.shop.raw.payments", kind=ResourceType.SOURCE, columns={})
+    manifest = Manifest(
+        schema_version="v12", adapter_type="duckdb", nodes={source.unique_id: source}
+    )
+    catalog = Catalog.from_raw(
+        _raw_catalog(
+            nodes={},
+            sources={
+                "source.shop.raw.payments": _catalog_entry(
+                    "source.shop.raw.payments", "raw", "payments", amount="DECIMAL", AMOUNT="FLOAT"
+                )
+            },
+        )
+    )
+    cols = manifest.merge_catalog(catalog).nodes["source.shop.raw.payments"].columns
+    assert set(cols) == {"amount"}
+    assert cols["amount"].data_type == "DECIMAL"
+
+
+def test_uppercase_catalog_columns_resolve_against_lowercase_sql() -> None:
+    # The motivating warehouse shape: a Snowflake-style catalog reports columns
+    # uppercased, while the model SQL writes them lowercase. sqlglot's qualifier
+    # normalizes identifier case against the schema, so `SELECT *` over the
+    # undocumented source still expands and the columns flow through.
+    source = _node("source.shop.raw.payments", kind=ResourceType.SOURCE, columns={})
+    model = _sql_node(
+        "model.shop.stg_payments",
+        kind=ResourceType.MODEL,
+        sql="SELECT * FROM payments",
+        columns={},
+    )
+    manifest = Manifest(
+        schema_version="v12",
+        adapter_type="snowflake",
+        nodes={source.unique_id: source, model.unique_id: model},
+    )
+    catalog = Catalog.from_raw(
+        _raw_catalog(
+            nodes={},
+            sources={
+                "source.shop.raw.payments": _catalog_entry(
+                    "source.shop.raw.payments",
+                    "raw",
+                    "payments",
+                    AMOUNT="DECIMAL",
+                    CURRENCY="VARCHAR",
+                )
+            },
+        )
+    )
+    graph = build_manifest_graph(manifest.merge_catalog(catalog)).graph
+    resolved = {
+        ref.column
+        for ref in graph.subjects()
+        if ref.source.kind is SourceKind.MODEL and ref.source.unique_id == "model.shop.stg_payments"
+    }
+    assert resolved == {"amount", "currency"}

--- a/tests/manifest/test_catalog.py
+++ b/tests/manifest/test_catalog.py
@@ -1,0 +1,218 @@
+"""Reading ``catalog.json`` and merging its columns into the manifest.
+
+The catalog carries the warehouse-introspected column universe of every node,
+including the DAG leaves (seeds, sources) that have no SQL to derive columns
+from. These pin the parse and the merge contract: documented columns stay
+authoritative, the catalog fills the rest, and a node the catalog never mentions
+passes through untouched. See issue #77.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from dblect.lineage.builder import build_manifest_graph
+from dblect.lineage.graph import SourceKind
+from dblect.manifest import Catalog, Column, Manifest, Node, ResourceType
+
+
+def _catalog_entry(uid: str, schema: str, name: str, **cols: str) -> dict[str, Any]:
+    return {
+        "metadata": {
+            "type": "BASE TABLE",
+            "schema": schema,
+            "name": name,
+            "database": "db",
+            "comment": None,
+            "owner": None,
+        },
+        "columns": {
+            c: {"type": t, "index": i + 1, "name": c, "comment": None}
+            for i, (c, t) in enumerate(cols.items())
+        },
+        "stats": {},
+        "unique_id": uid,
+    }
+
+
+def _raw_catalog(*, nodes: dict[str, Any], sources: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "metadata": {
+            "dbt_schema_version": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+            "dbt_version": "1.8.0",
+            "generated_at": "2024-01-01T00:00:00Z",
+            "invocation_id": "x",
+            "env": {},
+        },
+        "nodes": nodes,
+        "sources": sources,
+        "errors": None,
+    }
+
+
+def _node(uid: str, *, kind: ResourceType, columns: dict[str, Column]) -> Node:
+    return Node(
+        unique_id=uid,
+        name=uid.split(".")[-1],
+        resource_type=kind,
+        fqn=tuple(uid.split(".")[1:]),
+        package_name="shop",
+        schema="analytics",
+        raw_code=None,
+        compiled_code=None,
+        original_file_path=None,
+        columns=columns,
+    )
+
+
+def test_catalog_parses_node_and_source_columns() -> None:
+    catalog = Catalog.from_raw(
+        _raw_catalog(
+            nodes={
+                "seed.shop.codes": _catalog_entry(
+                    "seed.shop.codes", "analytics", "codes", code="VARCHAR"
+                )
+            },
+            sources={
+                "source.shop.raw.payments": _catalog_entry(
+                    "source.shop.raw.payments",
+                    "raw",
+                    "payments",
+                    amount="DECIMAL",
+                    currency="VARCHAR",
+                )
+            },
+        )
+    )
+    assert catalog.columns_by_uid["seed.shop.codes"] == {"code": "VARCHAR"}
+    assert catalog.columns_by_uid["source.shop.raw.payments"] == {
+        "amount": "DECIMAL",
+        "currency": "VARCHAR",
+    }
+
+
+def test_merge_fills_undocumented_leaf_columns() -> None:
+    source = _node("source.shop.raw.payments", kind=ResourceType.SOURCE, columns={})
+    manifest = Manifest(
+        schema_version="v12", adapter_type="duckdb", nodes={source.unique_id: source}
+    )
+    catalog = Catalog.from_raw(
+        _raw_catalog(
+            nodes={},
+            sources={
+                "source.shop.raw.payments": _catalog_entry(
+                    "source.shop.raw.payments", "raw", "payments", amount="DECIMAL"
+                )
+            },
+        )
+    )
+    merged = manifest.merge_catalog(catalog)
+    cols = merged.nodes["source.shop.raw.payments"].columns
+    assert set(cols) == {"amount"}
+    assert cols["amount"].data_type == "DECIMAL"
+
+
+def test_documented_columns_win_on_conflict() -> None:
+    # The human documented `amount` with a description; the catalog reports a
+    # different type for the same column. The documented Column is kept intact.
+    source = _node(
+        "source.shop.raw.payments",
+        kind=ResourceType.SOURCE,
+        columns={"amount": Column(name="amount", data_type="NUMERIC(38,9)", description="cents")},
+    )
+    manifest = Manifest(
+        schema_version="v12", adapter_type="duckdb", nodes={source.unique_id: source}
+    )
+    catalog = Catalog.from_raw(
+        _raw_catalog(
+            nodes={},
+            sources={
+                "source.shop.raw.payments": _catalog_entry(
+                    "source.shop.raw.payments",
+                    "raw",
+                    "payments",
+                    AMOUNT="FLOAT",
+                    currency="VARCHAR",
+                )
+            },
+        )
+    )
+    merged = manifest.merge_catalog(catalog)
+    cols = merged.nodes["source.shop.raw.payments"].columns
+    # `amount` keeps its documented type and description (catalog AMOUNT is the
+    # same column, case-folded, so it does not duplicate); `currency` is added.
+    assert cols["amount"].data_type == "NUMERIC(38,9)"
+    assert cols["amount"].description == "cents"
+    assert "AMOUNT" not in cols
+    assert cols["currency"].data_type == "VARCHAR"
+
+
+def _sql_node(uid: str, *, kind: ResourceType, sql: str | None, columns: dict[str, Column]) -> Node:
+    return Node(
+        unique_id=uid,
+        name=uid.split(".")[-1],
+        resource_type=kind,
+        fqn=tuple(uid.split(".")[1:]),
+        package_name="shop",
+        schema="analytics",
+        raw_code=None,
+        compiled_code=sql,
+        original_file_path=f"models/{uid.split('.')[-1]}.sql",
+        columns=columns,
+    )
+
+
+def test_catalog_lets_select_star_over_an_undocumented_source_resolve() -> None:
+    # A source with no documented columns and a model that `SELECT *`s it: without
+    # the catalog the star cannot expand and the model has no output columns; with
+    # the catalog supplying the source's columns, they flow through.
+    source = _node("source.shop.raw.payments", kind=ResourceType.SOURCE, columns={})
+    model = _sql_node(
+        "model.shop.stg_payments",
+        kind=ResourceType.MODEL,
+        sql="SELECT * FROM payments",
+        columns={},
+    )
+    manifest = Manifest(
+        schema_version="v12",
+        adapter_type="duckdb",
+        nodes={source.unique_id: source, model.unique_id: model},
+    )
+
+    def model_columns(m: Manifest) -> set[str]:
+        graph = build_manifest_graph(m).graph
+        return {
+            ref.column
+            for ref in graph.subjects()
+            if ref.source.kind is SourceKind.MODEL
+            and ref.source.unique_id == "model.shop.stg_payments"
+        }
+
+    assert model_columns(manifest) == set()
+
+    catalog = Catalog.from_raw(
+        _raw_catalog(
+            nodes={},
+            sources={
+                "source.shop.raw.payments": _catalog_entry(
+                    "source.shop.raw.payments",
+                    "raw",
+                    "payments",
+                    amount="DECIMAL",
+                    currency="VARCHAR",
+                )
+            },
+        )
+    )
+    assert model_columns(manifest.merge_catalog(catalog)) == {"amount", "currency"}
+
+
+def test_nodes_absent_from_catalog_pass_through_untouched() -> None:
+    model = _node(
+        "model.shop.orders",
+        kind=ResourceType.MODEL,
+        columns={"id": Column(name="id", data_type="INT", description=None)},
+    )
+    manifest = Manifest(schema_version="v12", adapter_type="duckdb", nodes={model.unique_id: model})
+    merged = manifest.merge_catalog(Catalog.from_raw(_raw_catalog(nodes={}, sources={})))
+    assert merged.nodes["model.shop.orders"] is manifest.nodes["model.shop.orders"]


### PR DESCRIPTION
Closes #77.

dbt's `catalog.json` (`dbt docs generate`) carries the warehouse-introspected column universe of every node, including the DAG leaves (seeds, sources) that have no SQL for dblect to derive columns from. Reading it lets `select *` and qualified references resolve against undocumented leaves, so a project that documents none of its seeds or sources still analyzes cleanly: manifest for structure, catalog for leaf columns, derivation for everything between.

## What

- **`manifest.catalog.Catalog`** reads only the per-node column names and types dblect needs, folding `nodes` and `sources` into one index keyed by unique_id (reuses `dbt_artifacts_parser.parse_catalog`).
- **`Manifest.merge_catalog`** unions catalog columns into each node's column set. Documented columns stay authoritative on conflict (matched case-insensitively, since a warehouse may report a different case than the project wrote); the catalog adds only columns a node lacks; nodes the catalog never mentions pass through untouched (identity-preserving).
- **`dblect check` / `audit`** accept `--catalog` (default: `catalog.json` alongside the manifest), merge it when present, and note on stderr when none is found, so a thin-leaf run is not mistaken for a fully resolved one.

## Design notes

- Merging at the manifest layer (not just `_build_schema`) means every consumer of `node.columns` — qualification, nullability, uniqueness — benefits, not only `select *` expansion.
- Catalog columns absent from the manifest become `Column(name, data_type=<catalog type>, description=None)`; a documented column is kept verbatim, so the human's `schema.yml` always wins.
- `init` (stub generation) is left out of scope per the issue; it's a one-line follow-up if stubs should include catalog-only leaf columns.
- The "note when leaf columns are missing" is a stderr line rather than a report-schema change, keeping this independent of the coverage-reporting work (#49).

## Verification

709 tests pass, pyright 0 errors, ruff clean (Python 3.12, matching CI). New tests cover catalog parsing, the merge contract (fills leaves, documented-wins on case-insensitive conflict, untouched pass-through), an end-to-end `SELECT *`-over-undocumented-source resolution via the builder, and the CLI `--catalog` wiring (reads when supplied, notes when absent, rejects a missing path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)