### PR TITLE
feat(uniqueness): span seeds and snapshots as test targets (#52)

### DIFF
--- a/src/dblect/lineage/properties/uniqueness.py
+++ b/src/dblect/lineage/properties/uniqueness.py
@@ -175,11 +175,11 @@ def grain_preserved(keys: CandidateKeySet, origin_key: Key) -> bool:
 
 # --- discoverers -------------------------------------------------------------
 
-# Uniqueness grounds on relations a downstream model can ref by name: models and
-# sources. Seeds and snapshots are eligible in the shared default but kept out
-# until their downstream consumers are tested against them; see issue #52.
-_TARGET_PREFIXES: tuple[str, ...] = ("model.", "source.")
-
+# Uniqueness grounds on any relation a downstream model can ref by name: models,
+# sources, seeds, and snapshots alike (a seed or snapshot feeds downstream SQL the
+# same way a source does, and the relation graph's name map registers all four).
+# The test-target resolution uses the shared default prefix set, which spans the
+# data-flow kinds, so the discoverers stay in step with the nullability siblings.
 _SOURCE_KIND: Mapping[ResourceType, SourceKind] = {
     ResourceType.MODEL: SourceKind.MODEL,
     ResourceType.SOURCE: SourceKind.SOURCE,
@@ -225,7 +225,7 @@ class _UniqueTestDiscoverer:
             col = tm.kwargs.get("column_name")
             if not isinstance(col, str) or not col:
                 continue
-            target = generic_test_target_uid(node, eligible_prefixes=_TARGET_PREFIXES)
+            target = generic_test_target_uid(node)
             scope = _source_ref(manifest, target) if target is not None else None
             if scope is None:
                 continue
@@ -267,7 +267,7 @@ class _UniqueCombinationDiscoverer:
             # rather than ground a partial key.
             if not cols or len(cols) != len(raw_list):
                 continue
-            target = generic_test_target_uid(node, eligible_prefixes=_TARGET_PREFIXES)
+            target = generic_test_target_uid(node)
             scope = _source_ref(manifest, target) if target is not None else None
             if scope is None:
                 continue

--- a/tests/lineage/test_uniqueness_facts.py
+++ b/tests/lineage/test_uniqueness_facts.py
@@ -78,6 +78,23 @@ def _source(uid: str) -> Node:
     )
 
 
+def _leaf(uid: str, *, kind: ResourceType) -> Node:
+    """A seed or snapshot: a leaf relation a downstream model refs by name, with no
+    SQL of its own (a seed is data; a snapshot's SQL is dbt-managed)."""
+    return Node(
+        unique_id=uid,
+        name=uid.split(".")[-1],
+        resource_type=kind,
+        fqn=(uid,),
+        package_name="shop",
+        schema="analytics",
+        raw_code=None,
+        compiled_code=None,
+        original_file_path=None,
+        columns={},
+    )
+
+
 def _test(
     uid: str,
     *,
@@ -140,6 +157,35 @@ def test_unique_test_on_source_grounds_on_the_source_relation() -> None:
     test = _unique("test.shop.u", column="id", target=src.unique_id)
     facts = list(unique_test_discoverer().discover(_manifest(src, test), name_to_source={}))
     assert facts[0].scope == SourceRef(SourceKind.SOURCE, src.unique_id)
+
+
+def test_unique_test_on_seed_grounds_on_the_seed_relation() -> None:
+    seed = _leaf("seed.shop.country_codes", kind=ResourceType.SEED)
+    test = _unique("test.shop.u", column="code", target=seed.unique_id)
+    facts = list(unique_test_discoverer().discover(_manifest(seed, test), name_to_source={}))
+    assert facts[0].scope == SourceRef(SourceKind.SEED, seed.unique_id)
+    assert facts[0].value == CandidateKeySet.of(_key("code"))
+
+
+def test_unique_test_on_snapshot_grounds_on_the_snapshot_relation() -> None:
+    snap = _leaf("snapshot.shop.orders_snapshot", kind=ResourceType.SNAPSHOT)
+    test = _unique("test.shop.u", column="dbt_scd_id", target=snap.unique_id)
+    facts = list(unique_test_discoverer().discover(_manifest(snap, test), name_to_source={}))
+    assert facts[0].scope == SourceRef(SourceKind.SNAPSHOT, snap.unique_id)
+
+
+def test_unique_combination_on_snapshot_grounds_a_composite_key() -> None:
+    # The arbiter-style SCD2 case: a composite unique_key declared on a snapshot.
+    snap = _leaf("snapshot.shop.matched_pairs", kind=ResourceType.SNAPSHOT)
+    test = _test(
+        "test.shop.uc",
+        name="unique_combination_of_columns",
+        kwargs={"combination_of_columns": ["touchpoint_id", "universal_order_id"]},
+        target=snap.unique_id,
+    )
+    facts = list(unique_combination_discoverer().discover(_manifest(snap, test), name_to_source={}))
+    assert facts[0].scope == SourceRef(SourceKind.SNAPSHOT, snap.unique_id)
+    assert facts[0].value == CandidateKeySet.of(_key("touchpoint_id", "universal_order_id"))
 
 
 def test_unique_test_column_is_case_folded() -> None:

--- a/tests/lineage/test_uniqueness_propagation.py
+++ b/tests/lineage/test_uniqueness_propagation.py
@@ -77,6 +77,22 @@ def _source(uid: str) -> Node:
     )
 
 
+def _leaf(uid: str, *, kind: ResourceType) -> Node:
+    """A seed or snapshot leaf: a downstream model refs it by name like a source."""
+    return Node(
+        unique_id=uid,
+        name=uid.split(".")[-1],
+        resource_type=kind,
+        fqn=(uid,),
+        package_name="shop",
+        schema="analytics",
+        raw_code=None,
+        compiled_code=None,
+        original_file_path=None,
+        columns={},
+    )
+
+
 def _unique(uid: str, *, column: str, target: str) -> Node:
     return Node(
         unique_id=uid,
@@ -121,6 +137,26 @@ def test_passthrough_carries_the_source_key() -> None:
         _model("model.shop.stg", "SELECT id, amount FROM orders"),
     )
     assert keys["model.shop.stg"] == CandidateKeySet.of(_key("id"))
+
+
+def test_unique_test_on_a_seed_flows_into_a_model_that_refs_it() -> None:
+    seed = _leaf("seed.shop.country_codes", kind=ResourceType.SEED)
+    keys = _keys(
+        seed,
+        _unique("test.shop.u", column="code", target=seed.unique_id),
+        _model("model.shop.stg_countries", "SELECT code, name FROM country_codes"),
+    )
+    assert keys["model.shop.stg_countries"] == CandidateKeySet.of(_key("code"))
+
+
+def test_unique_test_on_a_snapshot_flows_into_a_model_that_refs_it() -> None:
+    snap = _leaf("snapshot.shop.orders_snapshot", kind=ResourceType.SNAPSHOT)
+    keys = _keys(
+        snap,
+        _unique("test.shop.u", column="dbt_scd_id", target=snap.unique_id),
+        _model("model.shop.current_orders", "SELECT dbt_scd_id, amount FROM orders_snapshot"),
+    )
+    assert keys["model.shop.current_orders"] == CandidateKeySet.of(_key("dbt_scd_id"))
 
 
 def test_projection_rename_remaps_the_key() -> None:


### PR DESCRIPTION
Closes #52.

A `unique` / `unique_combination_of_columns` test attached to a **seed** or **snapshot** now grounds a candidate-key fact, bringing uniqueness in step with the nullability siblings (which already span all four data-flow kinds) and with the shared `generic_test_target_uid` default.

## What

- Dropped the `eligible_prefixes=("model.", "source.")` narrowing in `uniqueness/facts` so both discoverers resolve targets across all data-flow kinds.
- No other change was needed: `_SOURCE_KIND` already maps `SEED`/`SNAPSHOT`, and `build_relation_graph`'s name map already registers seeds and snapshots, so a model that refs one picks up its key by name exactly as it does a source.

## Tests

- Discoverer grounding: `unique` on a seed → `SEED`-scoped fact; on a snapshot → `SNAPSHOT`-scoped fact; `unique_combination_of_columns` on a snapshot → composite key (the arbiter-style SCD2 case).
- End-to-end propagation: a `unique` on a seed and on a snapshot each flow through to a model that refs the leaf.

## Verification

706 tests pass, pyright 0 errors, ruff clean (Python 3.12, matching CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)