### PR TITLE
feat(uniqueness): derive candidate keys through surrogate-hash columns (#89)

### DIFF
--- a/src/dblect/lineage/properties/uniqueness.py
+++ b/src/dblect/lineage/properties/uniqueness.py
@@ -68,6 +68,7 @@ from dblect.manifest import (
     ResourceType,
     generic_test_target_uid,
 )
+from dblect.sql import SQLParseError, parse_sql
 from dblect.sql import _sqlglot as sg
 from dblect.sql._sqlglot import JoinSide
 
@@ -399,6 +400,241 @@ class _ConfigKeyDiscoverer:
 
 def config_key_discoverer(profile: AdapterProfile) -> FactDiscoverer[CandidateKeySet, SourceRef]:
     return _ConfigKeyDiscoverer(profile)
+
+
+# --- surrogate-hash keys -----------------------------------------------------
+#
+# A relation is often keyed by a surrogate hash of a column tuple
+# (`to_hex(md5(concat(a, b)))`, `dbt_utils.generate_surrogate_key([...])`), with a
+# `unique` test declared on the hash column. The hash determines its input tuple
+# (modulo collision), so uniqueness on the hash is uniqueness on the inputs, and a
+# downstream join on `(a, b)` can then use the key. Recognizing the idiom is
+# conservative: only a recognized hash function over a structural combination
+# (concat, cast, coalesce, case-folding, literals) of plain columns grounds the
+# input key, and only when those inputs are themselves output columns of the
+# relation; anything opaque grounds nothing rather than a wrong key.
+
+# Hash functions whose output uniquely determines their input tuple. Resolved by
+# name so the set is stable across sqlglot versions that lack a given node.
+# Both the hex (`exp.MD5`, the `TO_HEX(MD5(...))` form) and raw-digest
+# (`exp.MD5Digest`, the bare `MD5(...)` form) spellings, plus SHA and BigQuery's
+# FARM_FINGERPRINT.
+_HASH_FUNCS: tuple[type[Expr], ...] = tuple(
+    getattr(exp, n)
+    for n in ("MD5", "MD5Digest", "SHA", "SHA2", "FarmFingerprint")
+    if hasattr(exp, n)
+)
+# Single-argument wrappers that do not change which tuple is hashed, looked through
+# to reach the hash (e.g. `TO_HEX(MD5(...))`, `LOWER(...)`).
+_HASH_PASSTHROUGH: tuple[type[Expr], ...] = tuple(
+    getattr(exp, n) for n in ("Hex", "Lower", "Upper") if hasattr(exp, n)
+)
+# Structural combinators that assemble columns into the hashed value without making
+# the input anything other than those columns.
+_STRUCTURAL: tuple[type[Expr], ...] = tuple(
+    getattr(exp, n)
+    for n in ("Concat", "DPipe", "Cast", "TryCast", "Coalesce", "Lower", "Upper", "Trim", "Paren")
+    if hasattr(exp, n)
+)
+
+
+def _expr_args(node: Expr) -> list[Expr]:
+    """The ``Expr`` children of ``node``, flattening list-valued args (a CONCAT's
+    expressions) and dropping non-expression args (a string flag, a CAST's
+    ``DataType``)."""
+    out: list[Expr] = []
+    for value in node.args.values():
+        if isinstance(value, exp.DataType):
+            continue
+        if isinstance(value, Expr):
+            out.append(value)
+        elif isinstance(value, list):
+            out.extend(v for v in cast("list[object]", value) if isinstance(v, Expr))
+    return out
+
+
+def _pure_input_columns(node: Expr) -> frozenset[str] | None:
+    """The column names feeding ``node`` when it is built only from columns and
+    literals via structural combinators; ``None`` if any opaque node intervenes (an
+    unknown function, arithmetic, a subquery), since then the hashed value is not a
+    plain tuple of the columns and the key equivalence does not hold."""
+    if isinstance(node, exp.Column):
+        return frozenset({sg.column_name(node).lower()})
+    if isinstance(node, exp.Literal):
+        return frozenset()
+    if isinstance(node, _STRUCTURAL):
+        cols: set[str] = set()
+        for child in _expr_args(node):
+            sub = _pure_input_columns(child)
+            if sub is None:
+                return None
+            cols |= sub
+        return frozenset(cols)
+    return None
+
+
+def _surrogate_hash_inputs(expr: Expr) -> frozenset[str] | None:
+    """The input columns of a recognized surrogate hash, or ``None`` if ``expr`` is
+    not one. At least one column is required, so a hash of only literals is not a
+    key."""
+    node: Expr | None = expr
+    seen = 0
+    while (
+        node is not None
+        and not isinstance(node, _HASH_FUNCS)
+        and isinstance(node, _HASH_PASSTHROUGH)
+    ):
+        inner = node.this
+        node = inner if isinstance(inner, Expr) else None
+        seen += 1
+        if seen > 4:
+            return None
+    if not isinstance(node, _HASH_FUNCS):
+        return None
+    cols: set[str] = set()
+    for child in _expr_args(node):
+        sub = _pure_input_columns(child)
+        if sub is None:
+            return None
+        cols |= sub
+    return frozenset(cols) or None
+
+
+def _output_projections(tree: Expr) -> Mapping[str, Expr] | None:
+    """Map each output column name to the expression that produces it, for the
+    relation's top-level SELECT. ``None`` for a UNION or other shape whose output
+    columns the substitution cannot read off one projection list."""
+    if not isinstance(tree, exp.Select):
+        return None
+    out: dict[str, Expr] = {}
+    for proj in tree.expressions:
+        if isinstance(proj, exp.Alias):
+            name = proj.alias_or_name
+            inner = proj.this
+            if name and isinstance(inner, Expr):
+                out[name.lower()] = inner
+        elif isinstance(proj, exp.Column) and not isinstance(proj.this, exp.Star):
+            out[sg.column_name(proj).lower()] = proj
+    return out
+
+
+def _declared_key_columns(tm: object) -> list[str] | None:
+    """The key columns a uniqueness test declares, or ``None`` if it is not one.
+    Mirrors the unique / unique_combination discoverers' shape so the surrogate
+    expansion sees the same declared keys they ground."""
+    from dblect.manifest import DbtTestMetadata
+
+    if not isinstance(tm, DbtTestMetadata) or not tm.enabled:
+        return None
+    if tm.name == "unique":
+        col = tm.kwargs.get("column_name")
+        return [col] if isinstance(col, str) and col else None
+    if tm.name.endswith("unique_combination_of_columns"):
+        raw = tm.kwargs.get("combination_of_columns")
+        if not isinstance(raw, list):
+            return None
+        raw_list = cast("list[object]", raw)
+        cols = [c for c in raw_list if isinstance(c, str) and c]
+        return cols if cols and len(cols) == len(raw_list) else None
+    return None
+
+
+class _SurrogateKeyDiscoverer:
+    """Grounds a candidate key on the input columns of a surrogate-hash key.
+
+    Reads the same uniqueness tests as the unique / unique_combination discoverers;
+    for any declared key whose member is a recognized surrogate hash of output
+    columns, emits the key with that member replaced by its inputs. The original
+    discoverers still emit the as-declared key, so both hold (they meet)."""
+
+    def __init__(self, profile: AdapterProfile, *, parsed: Mapping[str, Expr] | None) -> None:
+        self._dialect = profile.sqlglot_dialect
+        self._parsed = parsed
+
+    def _tree(self, uid: str, sql: str) -> Expr | None:
+        """The model's parsed tree, reusing a caller-shared parse when available so
+        the audit's parse-once invariant holds, else parsing once here."""
+        if self._parsed is not None:
+            shared = self._parsed.get(uid)
+            return shared if isinstance(shared, Expr) else None
+        try:
+            return parse_sql(sql, dialect=self._dialect)
+        except SQLParseError:
+            return None
+
+    def discover(
+        self, manifest: Manifest, *, name_to_source: Mapping[str, SourceRef]
+    ) -> Collection[Fact[CandidateKeySet, SourceRef]]:
+        out: list[Fact[CandidateKeySet, SourceRef]] = []
+        for node in manifest.nodes.values():
+            declared = _declared_key_columns(node.test_metadata)
+            if declared is None:
+                continue
+            target = generic_test_target_uid(node)
+            if target is None:
+                continue
+            model = manifest.nodes.get(target)
+            # Only a model carries SQL to recognize a hash in; a source/seed/snapshot
+            # has no projection to read the input tuple from.
+            if model is None or model.resource_type is not ResourceType.MODEL:
+                continue
+            sql = model.analysis_sql
+            if sql is None:
+                continue
+            tree = self._tree(target, sql)
+            if tree is None:
+                continue
+            projections = _output_projections(tree)
+            if projections is None:
+                continue
+            outputs = set(projections)
+            substituted: set[str] = set()
+            changed = False
+            for col in declared:
+                inputs = (
+                    _surrogate_hash_inputs(projections[col.lower()])
+                    if col.lower() in projections
+                    else None
+                )
+                if inputs is not None and inputs <= outputs:
+                    substituted |= inputs
+                    changed = True
+                else:
+                    substituted.add(col.lower())
+            if not changed:
+                continue
+            out.append(
+                Fact(
+                    scope=SourceRef(SourceKind.MODEL, target),
+                    value=_single_key(*substituted),
+                    provenance=Declared(_test_source(node.test_metadata)),
+                    detail=node.name,
+                    condition=_test_condition(node.test_metadata),
+                )
+            )
+        return out
+
+
+def _test_source(tm: object) -> DeclaredSource:
+    from dblect.manifest import DbtTestMetadata
+
+    if isinstance(tm, DbtTestMetadata) and tm.name.endswith("unique_combination_of_columns"):
+        return DeclaredSource.DBT_UTILS_TEST
+    return DeclaredSource.DBT_GENERIC_TEST
+
+
+def _test_condition(tm: object) -> Predicate | None:
+    from dblect.manifest import DbtTestMetadata
+
+    if isinstance(tm, DbtTestMetadata) and tm.where is not None:
+        return Predicate(tm.where)
+    return None
+
+
+def surrogate_key_discoverer(
+    profile: AdapterProfile, *, parsed: Mapping[str, Expr] | None = None
+) -> FactDiscoverer[CandidateKeySet, SourceRef]:
+    return _SurrogateKeyDiscoverer(profile, parsed=parsed)
 
 
 # --- the relation reducer ----------------------------------------------------
@@ -869,6 +1105,7 @@ def uniqueness_property(
     profile: AdapterProfile,
     *,
     extra: tuple[FactDiscoverer[CandidateKeySet, SourceRef], ...] = (),
+    parsed: Mapping[str, Expr] | None = None,
 ) -> Property[CandidateKeySet, SourceRef]:
     """The manifest-backed uniqueness property: declared keys (unique tests,
     ``unique_combination_of_columns``, native PRIMARY KEY / UNIQUE, the
@@ -887,6 +1124,7 @@ def uniqueness_property(
         unique_combination_discoverer(),
         native_key_discoverer(profile),
         config_key_discoverer(profile),
+        surrogate_key_discoverer(profile, parsed=parsed),
         *extra,
     )
     # The uniqueness discoverers ground against the manifest directly, so they

--- a/src/dblect/lineage/properties/uniqueness.py
+++ b/src/dblect/lineage/properties/uniqueness.py
@@ -68,7 +68,13 @@ from dblect.manifest import (
     ResourceType,
     generic_test_target_uid,
 )
-from dblect.sql import SQLParseError, parse_sql
+from dblect.sql import (
+    SURROGATE_HASH_FUNCTIONS,
+    SURROGATE_HASH_PASSTHROUGH,
+    SURROGATE_HASH_STRUCTURAL,
+    SQLParseError,
+    parse_sql,
+)
 from dblect.sql import _sqlglot as sg
 from dblect.sql._sqlglot import JoinSide
 
@@ -412,30 +418,10 @@ def config_key_discoverer(profile: AdapterProfile) -> FactDiscoverer[CandidateKe
 # conservative: only a recognized hash function over a structural combination
 # (concat, cast, coalesce, case-folding, literals) of plain columns grounds the
 # input key, and only when those inputs are themselves output columns of the
-# relation; anything opaque grounds nothing rather than a wrong key.
-
-# Hash functions whose output uniquely determines their input tuple. Resolved by
-# name so the set is stable across sqlglot versions that lack a given node.
-# Both the hex (`exp.MD5`, the `TO_HEX(MD5(...))` form) and raw-digest
-# (`exp.MD5Digest`, the bare `MD5(...)` form) spellings, plus SHA and BigQuery's
-# FARM_FINGERPRINT.
-_HASH_FUNCS: tuple[type[Expr], ...] = tuple(
-    getattr(exp, n)
-    for n in ("MD5", "MD5Digest", "SHA", "SHA2", "FarmFingerprint")
-    if hasattr(exp, n)
-)
-# Single-argument wrappers that do not change which tuple is hashed, looked through
-# to reach the hash (e.g. `TO_HEX(MD5(...))`, `LOWER(...)`).
-_HASH_PASSTHROUGH: tuple[type[Expr], ...] = tuple(
-    getattr(exp, n) for n in ("Hex", "Lower", "Upper") if hasattr(exp, n)
-)
-# Structural combinators that assemble columns into the hashed value without making
-# the input anything other than those columns.
-_STRUCTURAL: tuple[type[Expr], ...] = tuple(
-    getattr(exp, n)
-    for n in ("Concat", "DPipe", "Cast", "TryCast", "Coalesce", "Lower", "Upper", "Trim", "Paren")
-    if hasattr(exp, n)
-)
+# relation; anything opaque grounds nothing rather than a wrong key. The hash,
+# passthrough, and structural node vocabularies are SQL-grammar facts owned by the
+# `sql` layer (SURROGATE_HASH_*), shared so this property stays independent of which
+# spellings a dialect produces.
 
 
 def _expr_args(node: Expr) -> list[Expr]:
@@ -462,7 +448,7 @@ def _pure_input_columns(node: Expr) -> frozenset[str] | None:
         return frozenset({sg.column_name(node).lower()})
     if isinstance(node, exp.Literal):
         return frozenset()
-    if isinstance(node, _STRUCTURAL):
+    if isinstance(node, SURROGATE_HASH_STRUCTURAL):
         cols: set[str] = set()
         for child in _expr_args(node):
             sub = _pure_input_columns(child)
@@ -481,15 +467,15 @@ def _surrogate_hash_inputs(expr: Expr) -> frozenset[str] | None:
     seen = 0
     while (
         node is not None
-        and not isinstance(node, _HASH_FUNCS)
-        and isinstance(node, _HASH_PASSTHROUGH)
+        and not isinstance(node, SURROGATE_HASH_FUNCTIONS)
+        and isinstance(node, SURROGATE_HASH_PASSTHROUGH)
     ):
         inner = node.this
         node = inner if isinstance(inner, Expr) else None
         seen += 1
         if seen > 4:
             return None
-    if not isinstance(node, _HASH_FUNCS):
+    if not isinstance(node, SURROGATE_HASH_FUNCTIONS):
         return None
     cols: set[str] = set()
     for child in _expr_args(node):

--- a/src/dblect/sql/__init__.py
+++ b/src/dblect/sql/__init__.py
@@ -3,6 +3,9 @@
 from dblect.sql.parse import SQLParseError, parse_sql
 from dblect.sql.patterns import (
     PORTABLE_NON_DETERMINISTIC_BUILTINS,
+    SURROGATE_HASH_FUNCTIONS,
+    SURROGATE_HASH_PASSTHROUGH,
+    SURROGATE_HASH_STRUCTURAL,
     AggregateSummary,
     Finding,
     FindingKind,
@@ -27,6 +30,9 @@ from dblect.sql.patterns import (
 
 __all__ = [
     "PORTABLE_NON_DETERMINISTIC_BUILTINS",
+    "SURROGATE_HASH_FUNCTIONS",
+    "SURROGATE_HASH_PASSTHROUGH",
+    "SURROGATE_HASH_STRUCTURAL",
     "AggregateSummary",
     "Finding",
     "FindingKind",

--- a/src/dblect/sql/patterns.py
+++ b/src/dblect/sql/patterns.py
@@ -163,6 +163,40 @@ PORTABLE_NON_DETERMINISTIC_BUILTINS: frozenset[str] = frozenset(
 )
 
 
+# --- surrogate-hash grammar --------------------------------------------------
+#
+# The typed-node vocabulary for recognizing a surrogate-hash key: a hash of a
+# structural combination of columns. These are SQL-grammar facts (the `exp.*`
+# classes are dialect-independent even though the per-dialect parser picks them),
+# so they live here rather than in the uniqueness property. An adapter that hashes
+# via a function sqlglot parses to `exp.Anonymous` would compose a name set on top,
+# as the non-determinism builtins do; nothing demands that yet.
+#
+# These are tuples, not frozensets like the sets above, because membership is
+# tested with `isinstance`, whose subclass-awareness is load-bearing: `TO_HEX(...)`
+# parses to `exp.LowerHex`, a subclass of `exp.Hex`, so listing `Hex` looks through
+# the hex wrapper. A hash's hex and raw-digest spellings, though, are siblings, not
+# in a subclass relation (`MD5`/`MD5Digest`, `SHA2`/`SHA2Digest`), so both are
+# listed explicitly. Resolved by name for tolerance across sqlglot versions.
+SURROGATE_HASH_FUNCTIONS: tuple[type[Expr], ...] = tuple(
+    getattr(exp, n)
+    for n in ("MD5", "MD5Digest", "SHA", "SHA1Digest", "SHA2", "SHA2Digest", "FarmFingerprint")
+    if hasattr(exp, n)
+)
+# Single-argument wrappers that do not change which tuple is hashed, looked through
+# to reach the hash (e.g. `TO_HEX(MD5(...))`, `LOWER(...)`).
+SURROGATE_HASH_PASSTHROUGH: tuple[type[Expr], ...] = tuple(
+    getattr(exp, n) for n in ("Hex", "Lower", "Upper") if hasattr(exp, n)
+)
+# Structural combinators that assemble columns into the hashed value without making
+# the input anything other than those columns.
+SURROGATE_HASH_STRUCTURAL: tuple[type[Expr], ...] = tuple(
+    getattr(exp, n)
+    for n in ("Concat", "DPipe", "Cast", "TryCast", "Coalesce", "Lower", "Upper", "Trim", "Paren")
+    if hasattr(exp, n)
+)
+
+
 def finding_at(kind: FindingKind, *, message: str, node: Expr) -> Finding:
     """Build a Finding whose snippet and source span both come from `node`."""
     span = sg.line_range(node)

--- a/src/dblect/uniqueness/detector.py
+++ b/src/dblect/uniqueness/detector.py
@@ -184,7 +184,7 @@ def make_fact_grounded_detectors(
     semantics ground the uniqueness keys, so parsing and enforcement agree.
     """
     graph = build_relation_graph(manifest, dialect=profile.sqlglot_dialect, parsed=parsed).graph
-    keys = propagate(graph, uniqueness_property(manifest, profile))
+    keys = propagate(graph, uniqueness_property(manifest, profile, parsed=parsed))
     # Predicate-flow is consulted only where a conditional key waits to activate, so
     # seed the flow pass with those scopes and let it pull in their upstreams rather
     # than walking every relation in the graph. The seed must stay exactly "every

--- a/tests/lineage/test_surrogate_key_facts.py
+++ b/tests/lineage/test_surrogate_key_facts.py
@@ -1,0 +1,158 @@
+"""Surrogate-hash keys ground a candidate key on their input columns (#89).
+
+A relation keyed by a surrogate hash (`to_hex(md5(concat(a, b)))`,
+`dbt_utils.generate_surrogate_key([...])`) declares uniqueness on the hash
+column, but the real key is the input tuple `(a, b)`: a downstream join on
+`a, b` should see a key. The surrogate-key discoverer recognizes the hash idiom
+in the model's own projection and grounds a key on the inputs, but only when the
+shape is unambiguous (a recognized hash over structural combinations of columns
+that are themselves output columns); anything opaque grounds nothing rather than
+a wrong key.
+"""
+
+from __future__ import annotations
+
+from dblect.adapters import profile_for_adapter
+from dblect.lineage.graph import SourceKind, SourceRef
+from dblect.lineage.properties.uniqueness import surrogate_key_discoverer
+from dblect.manifest import DbtTestMetadata, Manifest, Node, ResourceType
+
+_BQ = profile_for_adapter("bigquery")
+
+
+def _model(uid: str, sql: str) -> Node:
+    return Node(
+        unique_id=uid,
+        name=uid.split(".")[-1],
+        resource_type=ResourceType.MODEL,
+        fqn=(uid,),
+        package_name="shop",
+        schema="analytics",
+        raw_code=None,
+        compiled_code=sql,
+        original_file_path=None,
+        columns={},
+    )
+
+
+def _unique(uid: str, *, column: str, target: str) -> Node:
+    return Node(
+        unique_id=uid,
+        name=uid.split(".")[-1],
+        resource_type=ResourceType.OTHER,
+        fqn=(uid,),
+        package_name="shop",
+        schema=None,
+        raw_code=None,
+        compiled_code=None,
+        original_file_path=None,
+        columns={},
+        depends_on=frozenset({target}),
+        test_metadata=DbtTestMetadata(name="unique", kwargs={"column_name": column}),
+        attached_node=target,
+    )
+
+
+def _combination(uid: str, *, columns: list[str], target: str) -> Node:
+    return Node(
+        unique_id=uid,
+        name=uid.split(".")[-1],
+        resource_type=ResourceType.OTHER,
+        fqn=(uid,),
+        package_name="shop",
+        schema=None,
+        raw_code=None,
+        compiled_code=None,
+        original_file_path=None,
+        columns={},
+        depends_on=frozenset({target}),
+        test_metadata=DbtTestMetadata(
+            name="unique_combination_of_columns",
+            kwargs={"combination_of_columns": columns},
+        ),
+        attached_node=target,
+    )
+
+
+def _manifest(*nodes: Node) -> Manifest:
+    return Manifest(
+        schema_version="v12", adapter_type="bigquery", nodes={n.unique_id: n for n in nodes}
+    )
+
+
+def _keys(*nodes: Node) -> set[frozenset[str]]:
+    facts = list(surrogate_key_discoverer(_BQ).discover(_manifest(*nodes), name_to_source={}))
+    return {k for f in facts for k in f.value.keys}
+
+
+def test_unique_on_a_surrogate_hash_grounds_a_key_on_the_inputs() -> None:
+    model = _model(
+        "model.shop.m",
+        "SELECT TO_HEX(MD5(CONCAT(a, '-', b))) AS sk, a, b FROM up",
+    )
+    test = _unique("test.shop.u", column="sk", target=model.unique_id)
+    assert frozenset({"a", "b"}) in _keys(model, test)
+
+
+def test_dbt_utils_surrogate_key_shape_is_recognized() -> None:
+    # The compiled dbt_utils.generate_surrogate_key shape: coalesce+cast inside the
+    # concat, hashed. The structural wrappers must not defeat recognition.
+    model = _model(
+        "model.shop.m",
+        "SELECT MD5(CONCAT("
+        "COALESCE(CAST(a AS STRING), '_null_'), '-', "
+        "COALESCE(CAST(b AS STRING), '_null_'))) AS sk, a, b FROM up",
+    )
+    test = _unique("test.shop.u", column="sk", target=model.unique_id)
+    assert frozenset({"a", "b"}) in _keys(model, test)
+
+
+def test_inputs_not_projected_grounds_no_input_key() -> None:
+    # The hash inputs are not output columns, so {a, b} is not a key the relation
+    # can express; grounding it would be a wrong key.
+    model = _model("model.shop.m", "SELECT MD5(CONCAT(a, b)) AS sk FROM up")
+    test = _unique("test.shop.u", column="sk", target=model.unique_id)
+    assert _keys(model, test) == set()
+
+
+def test_hash_over_an_opaque_expression_grounds_nothing() -> None:
+    # An unknown function wraps a column inside the hash, so the input tuple is not
+    # the plain columns; stay silent rather than ground a wrong key.
+    model = _model(
+        "model.shop.m",
+        "SELECT MD5(CONCAT(a, SOME_UDF(b))) AS sk, a, b FROM up",
+    )
+    test = _unique("test.shop.u", column="sk", target=model.unique_id)
+    assert _keys(model, test) == set()
+
+
+def test_plain_column_unique_test_grounds_nothing() -> None:
+    model = _model("model.shop.m", "SELECT id, amount FROM up")
+    test = _unique("test.shop.u", column="id", target=model.unique_id)
+    assert _keys(model, test) == set()
+
+
+def test_composite_key_substitutes_the_hash_member() -> None:
+    model = _model(
+        "model.shop.m",
+        "SELECT x, MD5(CONCAT(a, b)) AS sk, a, b FROM up",
+    )
+    test = _combination("test.shop.uc", columns=["x", "sk"], target=model.unique_id)
+    assert frozenset({"x", "a", "b"}) in _keys(model, test)
+
+
+def test_input_key_flows_end_to_end_through_the_property() -> None:
+    # Wired into uniqueness_property: the inputs key is grounded and propagates, so
+    # a downstream model that re-keys on the inputs is seen as unique on them.
+    from dblect.lineage.builder import build_relation_graph
+    from dblect.lineage.properties.uniqueness import uniqueness_property
+    from dblect.lineage.property import propagate
+
+    model = _model("model.shop.m", "SELECT TO_HEX(MD5(CONCAT(a, b))) AS sk, a, b FROM up")
+    test = _unique("test.shop.u", column="sk", target=model.unique_id)
+    manifest = _manifest(model, test)
+    graph = build_relation_graph(manifest, dialect="bigquery").graph
+    anns = propagate(graph, uniqueness_property(manifest, _BQ))
+    keys = anns[SourceRef(SourceKind.MODEL, "model.shop.m")].value.keys
+    assert frozenset({"a", "b"}) in keys  # the inputs key
+    assert frozenset({"sk"}) in keys  # the declared hash key still holds too

--- a/tests/lineage/test_surrogate_key_facts.py
+++ b/tests/lineage/test_surrogate_key_facts.py
@@ -12,6 +12,8 @@ a wrong key.
 
 from __future__ import annotations
 
+import pytest
+
 from dblect.adapters import profile_for_adapter
 from dblect.lineage.graph import SourceKind, SourceRef
 from dblect.lineage.properties.uniqueness import surrogate_key_discoverer
@@ -139,6 +141,26 @@ def test_composite_key_substitutes_the_hash_member() -> None:
     )
     test = _combination("test.shop.uc", columns=["x", "sk"], target=model.unique_id)
     assert frozenset({"x", "a", "b"}) in _keys(model, test)
+
+
+@pytest.mark.parametrize(
+    "hash_expr",
+    [
+        # The hash families a BigQuery model reaches for as a surrogate key. sqlglot
+        # parses each to its own node (`SHA256` -> `SHA2Digest`, the bare digest form;
+        # `TO_HEX(SHA256(...))` -> `LowerHex` over it; `FARM_FINGERPRINT` -> its own
+        # node), so all must be recognized for the input key to ground. The MD5 forms
+        # are covered by test_unique_on_a_surrogate_hash_grounds_a_key_on_the_inputs.
+        "FARM_FINGERPRINT(CONCAT(a, b))",
+        "SHA256(CONCAT(a, b))",
+        "TO_HEX(SHA256(CONCAT(a, b)))",
+        "SHA1(CONCAT(a, b))",
+    ],
+)
+def test_bigquery_hash_families_ground_the_input_key(hash_expr: str) -> None:
+    model = _model("model.shop.m", f"SELECT {hash_expr} AS sk, a, b FROM up")
+    test = _unique("test.shop.u", column="sk", target=model.unique_id)
+    assert frozenset({"a", "b"}) in _keys(model, test)
 
 
 def test_input_key_flows_end_to_end_through_the_property() -> None:


### PR DESCRIPTION
Closes #89.

A relation keyed by a surrogate hash (`to_hex(md5(concat(a, b)))`, `dbt_utils.generate_surrogate_key([...])`) declares uniqueness on the hash column, but the real key is the input tuple `(a, b)` — and a downstream join on `a, b` should see a key. A new `surrogate_key_discoverer` recognizes the hash idiom in the model's own projection and grounds a key on the inputs.

## What

- **Conservative recognition:** a recognized hash function (`MD5`/`MD5Digest`, `SHA`, `SHA2`, `FARM_FINGERPRINT`, looking through `TO_HEX`/`LOWER`/`UPPER`) over a *structural* combination — `concat`, `cast`, `coalesce`, case-folding, literals — of plain columns. Any opaque node under the hash (an unknown function, arithmetic, a subquery) means the hashed value isn't a plain tuple of those columns, so it grounds **nothing** rather than a wrong key.
- **Substitution fires only when the hash inputs are output columns** of the relation, so the derived key is actually expressible on it. Covers a single `unique` on the hash and a `unique_combination_of_columns` that includes it; the original declared key still holds (they meet).
- **Wired into `uniqueness_property`** with the run's parsed trees threaded through, so the audit's parse-once invariant holds rather than re-parsing each keyed model (verified by the existing `test_run_audit_parses_each_model_once`).

## Tests (written first)

Input-key grounding, the compiled `dbt_utils.generate_surrogate_key` coalesce/cast shape, inputs-not-projected and opaque-input silence, a plain non-hash column, a composite key, and end-to-end flow through the property (both the inputs key and the declared hash key hold).

## Pairs with #52

A snapshot's surrogate composite key (the arbiter `*_schema_evolution_hash` pattern) grounds its inputs once both this and #52 land.

## Verification

722 tests pass; ruff check, ruff format --check, and pyright all clean (Python 3.12, matching CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)