### PR TITLE
docs(flags): design plan for var-inference engine and `dblect scaffold flags` (#98)

### DIFF
--- a/docs/design/var-inference/discovery-inputs.md
+++ b/docs/design/var-inference/discovery-inputs.md
@@ -12,7 +12,7 @@ This stream covers the two external surfaces the analysis reads before it walks 
 
 ### Design
 
-Add a typed `Macro` to the manifest view and a name-indexed registry on `Manifest`:
+Add a typed `Macro` to the manifest view and a unique-id-indexed registry on `Manifest`:
 
 ```python
 @dataclass(frozen=True, slots=True)
@@ -24,16 +24,23 @@ class Macro:
     depends_on_macros: frozenset[str] = frozenset()
 ```
 
-`Manifest` gains a `macros: Mapping[str, Macro]` populated from `parsed.macros` in `from_raw`, alongside the existing node and source population. A lookup helper resolves a macro name to its definition, with the package-qualification rule dbt uses (a bare name resolves within the project first, then packages; a `package.name` reference resolves directly). The registry is the input macro-following consumes; this stream owns producing it, not walking it.
+`Manifest` gains a `macros: Mapping[str, Macro]` populated from `parsed.macros` in `from_raw`, alongside the existing node and source population, keyed by `unique_id` (the manifest's own key, unambiguous across packages). The registry is the input macro-following consumes; this stream owns producing it, not walking it.
+
+Status: implemented in [#103](https://github.com/dvryaboy/dblect/pull/103), split off `main` ahead of the rest of this stream. The `Macro` dataclass, the `macros` mapping on `Manifest`, and the `from_raw` wiring land in [`manifest/parse.py`](../../../src/dblect/manifest/parse.py), exported from the manifest package, with round-trip tests against the fixture in [`tests/manifest/test_parse.py`](../../../tests/manifest/test_parse.py).
+
+### Deferred to macro-following: name resolution
+
+A call site names a macro by bare name or `package.name`, not by `unique_id`, so the walker needs a lookup that resolves a name to a definition with the package-qualification rule dbt uses (a bare name resolves within the project first, then packages; a `package.name` reference resolves directly). That resolution is deferred to [macro-following](./macro-following.md): its contract is defined by how the walker dispatches, so it is built and tested alongside its only consumer rather than pinned ahead of it here. The registry as landed carries `name` and `package_name` on every entry, which is everything the resolver needs as input.
 
 ### Why it is separable
 
-It touches one file, adds a dataclass and a mapping, and changes no existing behavior. It can ship ahead of the walker. Its contract is a faithful transcription of the manifest's macro block into the typed view.
+It touches one file, adds a dataclass and a mapping, and changes no existing behavior. It shipped ahead of the walker. Its contract is a faithful transcription of the manifest's macro block into the typed view.
 
 ### Testing
 
-- A round-trip test against the fixture manifest asserting the registry has an entry per macro in the raw JSON, with `macro_sql` non-empty for the project's own macros.
-- A name-resolution test pinning the bare-name-then-package lookup order and the `package.name` direct path.
+- A round-trip test against the fixture manifest asserting the registry has an entry per macro in the raw JSON, with the `name`, `package_name`, `macro_sql`, and `depends_on.macros` edge set transcribed faithfully and `macro_sql` non-empty.
+
+The name-resolution test moves with the resolver to [macro-following](./macro-following.md).
 
 ## The project configuration reader
 

--- a/docs/design/var-inference/discovery-inputs.md
+++ b/docs/design/var-inference/discovery-inputs.md
@@ -1,0 +1,74 @@
+# Var inference: discovery inputs
+
+Status: design
+Audience: engineers wiring the manifest macro registry and the project-config reader
+Part of: [the var-inference plan](./plan.md)
+
+This stream covers the two external surfaces the analysis reads before it walks anything: the macro registry that [macro-following](./macro-following.md) expands, and the project configuration that supplies var defaults and target overrides to [inference](./inference-and-classification.md). Both are plumbing, both are small, and both are isolated enough to land and test on their own.
+
+## The manifest macro registry
+
+`var()` calls are reached through macros, so following them needs every macro's source body keyed by name. dbt's `manifest.json` carries this: a probe of the jaffle fixture found its macros under the top-level `macros` key, each entry exposing `name`, `package_name`, `macro_sql` (the source body), `depends_on`, and `unique_id`. The current manifest reader ([`manifest/parse.py`](../../../src/dblect/manifest/parse.py)) parses `nodes` and `sources` into the typed `Node` view but does not surface macros at all.
+
+### Design
+
+Add a typed `Macro` to the manifest view and a name-indexed registry on `Manifest`:
+
+```python
+@dataclass(frozen=True, slots=True)
+class Macro:
+    unique_id: str
+    name: str
+    package_name: str
+    macro_sql: str
+    depends_on_macros: frozenset[str] = frozenset()
+```
+
+`Manifest` gains a `macros: Mapping[str, Macro]` populated from `parsed.macros` in `from_raw`, alongside the existing node and source population. A lookup helper resolves a macro name to its definition, with the package-qualification rule dbt uses (a bare name resolves within the project first, then packages; a `package.name` reference resolves directly). The registry is the input macro-following consumes; this stream owns producing it, not walking it.
+
+### Why it is separable
+
+It touches one file, adds a dataclass and a mapping, and changes no existing behavior. It can ship ahead of the walker. Its contract is a faithful transcription of the manifest's macro block into the typed view.
+
+### Testing
+
+- A round-trip test against the fixture manifest asserting the registry has an entry per macro in the raw JSON, with `macro_sql` non-empty for the project's own macros.
+- A name-resolution test pinning the bare-name-then-package lookup order and the `package.name` direct path.
+
+## The project configuration reader
+
+Var defaults and target overrides live outside the manifest, in the project's YAML. The spec sources a variable's default from `dbt_project.yml` (declared vars and their defaults) and its target-specific values from `profiles.yml`. These feed inference as additional evidence: a boolean default with no contrary usage infers `bool`, and declared or target values are added to the inferred domain as observed members.
+
+### Design
+
+A small reader that, given the project directory, loads:
+
+- `dbt_project.yml` `vars:` block, yielding declared var names and their default values. dbt allows both a flat `vars:` map and a per-project-name nesting; the reader normalizes both to a name-to-default map.
+- `profiles.yml` (when present and readable) target-specific var overrides, yielding a per-target name-to-value map and the active target name.
+
+The reader returns a typed `ProjectConfig` carrying the declared defaults, the per-target overrides, and the active adapter and target (the adapter also drives `adapter.dispatch` resolution in macro-following). It is total and degrades quietly: a missing or unreadable `profiles.yml` yields no target overrides rather than an error, matching the spec's posture that profile cross-reference is best-effort.
+
+### The inline-default boundary
+
+dbt vars can carry a default at the call site, `var(name, default)`, rather than in `dbt_project.yml`. The compiled SQL has already folded that inline default in, so the base world is correct as it stands, but the project-config reader does not see it: it reads YAML, not call sites. The Jinja walker does see it (the second `Const` argument on the `Call`), so the inline default is recoverable from the [front end](./jinja-frontend.md) and is the natural place to capture it. Until it is consumed, a var whose only default is inline is discovered and typed but carries no recorded default, and degrades to its single compiled value as one world, the same degrade-not-lie the computed case takes. This boundary is noted in [`config-and-flag-worlds.md`](../config-and-flag-worlds.md) under "Dependency on var-inference".
+
+### Testing
+
+- A reader test against a fixture `dbt_project.yml` with a `vars:` block in both the flat and nested shapes, asserting the normalized default map.
+- A test that a missing `profiles.yml` yields empty target overrides without raising.
+
+## Fixtures this stream needs
+
+The current fixtures declare no vars, so this stream introduces small dbt-project fixtures whose `dbt_project.yml` declares vars with defaults (boolean, enum-like string, numeric) and whose `profiles.yml` carries target overrides, paired with model SQL that uses them. These fixtures are shared with the inference and scaffold streams.
+
+## Open questions
+
+- **Per-package vars.** Some vars are declared by installed packages. The spec leans toward filtering these out as not the user's vars; this reader can carry the package origin so the filter is a downstream choice rather than baked in here.
+- **Declared-but-unused vars.** Whether a var declared in `dbt_project.yml` with no usage still produces a scaffold entry. This stream surfaces the declaration; the [scaffold stream](./scaffold-and-cli.md) decides whether to emit it.
+
+## References
+
+- [The var-inference plan](./plan.md) and [the original spec](../var-inference-spec.md), "Inputs" and "Discovery".
+- The macro registry's consumer: [macro-following](./macro-following.md).
+- The defaults' consumer and the inline-default boundary: [inference and classification](./inference-and-classification.md), [`config-and-flag-worlds.md`](../config-and-flag-worlds.md).
+</content>

--- a/docs/design/var-inference/inference-and-classification.md
+++ b/docs/design/var-inference/inference-and-classification.md
@@ -1,0 +1,71 @@
+# Var inference: inference and classification
+
+Status: design
+Audience: engineers implementing type inference, domain inference, and var classification
+Part of: [the var-inference plan](./plan.md)
+
+This stream folds the `VarUsage` records the [front end](./jinja-frontend.md) and [macro-following](./macro-following.md) produce into one `DiscoveredVar` per variable: its type, its domain, its class, and the per-model usage map. Its outputs are what #99 and #100 consume, so the classification and the per-model map are designed for them, not only for the scaffold.
+
+## Aggregation
+
+After all nodes are walked, group `VarUsage` records by variable name. For each variable, run type inference, domain inference, and classification across its usages, cross-reference the [project config](./discovery-inputs.md) defaults and target values, and produce a `DiscoveredVar` as specified in [`var-inference-spec.md`](../var-inference-spec.md): name, kind, inferred type, inferred domain, default, target values, the usage list, an inference-quality marker, and the unfollowed usages.
+
+## Type inference
+
+Type inference reads each usage's `UsageContext` into a type assertion and combines assertions across usages via the type lattice. The rules are the spec's table: a truthy test asserts `bool`, an equality or in-set asserts the type of its operands, a numeric inequality or arithmetic asserts numeric, a SQL-literal position asserts a type from its position (numeric, quoted-string, identifier). Compatible assertions narrow; incompatible assertions are a conflict.
+
+A conflict (one usage asserts `str`, another `int`) is reported in the diagnostic output, the most permissive type wins for scaffolding, and a comment notes the conflict so the user adjudicates. The project-config default is an additional signal: a boolean default with no contrary usage infers `bool`, a string default infers `str`, a numeric default infers `int` or `float`.
+
+## Domain inference
+
+Domain inference identifies the value set a variable can take, defaulting to open-world unless evidence supports a finite domain. The spec's rules:
+
+- **Finite** when all usages are equality or in-set contexts (the domain is the union of those literals), or when the variable is boolean (a two-element domain). The default and target values must be members, or the inference is marked inconsistent.
+- **Partial** when some usages support a finite domain and some do not. The domain is the union of observed literals, noted as possibly incomplete.
+- **Branch points** when numeric comparisons are observed. The branch points partition the number line into intervals, and world enumeration covers each interval rather than each value (`var('threshold') > 100` yields the two worlds `threshold <= 100` and `threshold > 100`).
+
+Inferred domains are always reported as tentative, review for completeness. Static analysis sees what the SQL uses, not what a CI config or environment might supply, so the user has the final say on the closed-world reading. Default and target values are added to the domain as observed members without changing the open-versus-finite classification.
+
+## Classification: the gate before enumeration
+
+This is the requirement [#98](https://github.com/dvryaboy/dblect/issues/98) adds beyond the original spec, and the one #99 and #100 hinge on. Discovering every var and surfacing it as a world axis does not scale: a real project has hundreds of vars, most of which cannot change the compiled SQL. Each variable is classified by the union over its usage sites into one of three classes:
+
+- **Control-flow.** Used in `{% if %}`, `{% for %}`, `is_incremental()`, or an equality / in-set / numeric test that steers a branch. Recoverable from the AST shape alone (the [front end](./jinja-frontend.md) records whether a usage was reached under a branch-steering position). This is the only class surfaced as a world axis, because it can change the SQL structure. A var used in any control-flow context is control-flow, even when it is also substituted as a value elsewhere; the union takes the stronger class.
+- **Value-substitution.** Only ever substituted as a literal, never steering a branch. The SQL structure is invariant across its values, so it collapses to one world, the value the manifest already compiled. It is recorded and typed but not surfaced as an axis for now. The fact-level enumerator already handles value-substitution worlds, so enumerating these later is cheap; the deferral loses nothing.
+- **Computed.** Value not statically resolvable: reached only through an opaque macro, or carrying an open domain with no enumerable values. One world, the resolved value, degrade-not-lie.
+
+The class is a property of the variable, computed from the join of its usage contexts. A variable with a single control-flow usage among many value-substitution usages is control-flow. A variable all of whose usages are opaque is computed. The classifier is pure and total over the usage set, which makes it exhaustively testable.
+
+### Why the union, and why this is sound
+
+Surfacing only the control-flow subset as world axes is the first variability abstraction in the design's terms (see [`config-and-flag-worlds.md`](../config-and-flag-worlds.md), "Taming the world space"). It is sound because a value-substitution var cannot change the SQL structure, so analyzing its single compiled world is correct for that var; and it degrades honestly because the collapse is recorded in coverage rather than assumed. Taking the union toward the stronger class is the conservative direction: it never wrongly demotes a control-flow var to a collapsed world, which would hide a real structural difference.
+
+## The per-model var-usage map
+
+The second output #99 and #100 consume is which models read which vars. The model-responsiveness rule the bridge uses grounds a flag only in models that actually read its var, and #99's cone scoping intersects this with the lineage cone. The map falls out of the walk directly: each `VarUsage` carries the node it was found in (and the macro trail it came through), so grouping usages by node yields the per-model map. It is emitted alongside the `DiscoveredVar` records, scoped to the control-flow subset for #99's consumption (the spec notes per-contract narrowing runs over the control-flow subset, not all discovered vars).
+
+## Coverage
+
+Classification feeds coverage reporting: the analysis records which vars were surfaced as axes, which collapsed to one world and why (value-substitution, computed, open domain), so a one-world var is a stated number rather than a silent assumption. This is the "no silent caps" rule applied to the world dimension, raised in [`config-and-flag-worlds.md`](../config-and-flag-worlds.md), "Coverage as a first-class output".
+
+## Testing
+
+- Property-based tests over synthetic usage sets: the type lattice fold is associative and commutative (order of usages does not change the inferred type), and the classifier's union toward the stronger class is order-independent.
+- Per-rule tests for each type and domain rule, mirroring the front-end's per-context tests but at the aggregation boundary.
+- Classification tests: a var with mixed control-flow and value-substitution usages classifies control-flow; an all-opaque var classifies computed; a pure-literal var classifies value-substitution.
+- A branch-point test asserting the interval partition for numeric comparisons.
+- A per-model-map test asserting a var used in two models maps to both, including one reached through a macro.
+
+These pin the contracts (what a usage set infers and classifies to) rather than the fold's internals, so they survive a reorganization of the inference code.
+
+## Open questions
+
+- **Closed-world versus open-world default for inferred domains.** The spec marks inferred enum domains tentative. Whether a more explicit confirmation step is needed before treating an inferred domain as authoritative for enumeration.
+- **Numeric branch-point representation.** The exact `Domain` shape for interval-partitioned numeric domains (the spec leaves `Domain` as a list of intervals); pinning it here so the [scaffold](./scaffold-and-cli.md) and the enumerator agree.
+
+## References
+
+- [The var-inference plan](./plan.md) and [the original spec](../var-inference-spec.md), "Type inference rules" and "Domain inference rules".
+- The classification's consumers: [#99](https://github.com/dvryaboy/dblect/issues/99), [#100](https://github.com/dvryaboy/dblect/issues/100), and the world theory in [`config-and-flag-worlds.md`](../config-and-flag-worlds.md).
+- The usage records this folds: [the Jinja front end](./jinja-frontend.md), [macro following](./macro-following.md).
+</content>

--- a/docs/design/var-inference/jinja-frontend.md
+++ b/docs/design/var-inference/jinja-frontend.md
@@ -1,0 +1,91 @@
+# Var inference: the Jinja front end
+
+Status: design
+Audience: engineers implementing the source-Jinja walker for var discovery
+Part of: [the var-inference plan](./plan.md)
+
+This stream turns a node's source Jinja into a structured record of every `var()` and `env_var()` reference it makes directly (macro indirection is the [macro-following](./macro-following.md) stream). It is the second of dblect's two front ends: sqlglot over compiled SQL for structure, and this Jinja AST over source for the variability compiled SQL has already erased.
+
+## Why a Jinja AST and not the compiled SQL
+
+By the time dbt has run, a value-substitution var has collapsed to a literal indistinguishable from a hand-typed constant, and a control-flow var has had one branch chosen and the other erased. The compiled SQL the rest of dblect analyzes (`Node.analysis_sql`, which returns `compiled_code`) cannot see either. The on-disk template (`Node.raw_code`) still carries both, so this stream reads `raw_code` and parses it.
+
+## What the parser gives us
+
+A probe of `jinja2.Environment().parse()` established that the parser yields a clean AST in which every `UsageContext` the spec needs maps directly to a node shape, with literal operands resolved inline. The mapping the walker relies on:
+
+| Spec `UsageContext` | AST shape |
+|---|---|
+| `TruthyTest` | the `var` `Call` is the `If.test` (or nested under boolean ops in it) |
+| `Equality(operand)` | `Compare` whose first operand is the `var` `Call`, with an `eq` `Operand(Const)` |
+| `Inequality(operand, op)` | `Compare` with a `lt` / `gt` / `lteq` / `gteq` `Operand(Const)` |
+| `InSet(elements)` | `Compare` with an `in` `Operand(List[Const])` |
+| `Arithmetic(op, other)` | `Mul` / `Add` / etc. wrapping the `var` `Call` |
+| `SqlLiteral(position)` | the `var` `Call` sits under an `Output` node (interpolation) |
+| `MacroArg(macro, position)` | the `var` `Call` is an argument of another `Call` whose name is not `var` / `env_var` |
+| inline `var(name, default)` | the `Call` carries a second `Const` argument |
+
+`env_var` versus `var` is the callee name on the `Call`. `is_incremental()` is a `Call` to a bare name, discoverable the same way and relevant as an always-present control-flow axis. `config()`, `ref()`, `source()`, `{{ this }}`, whitespace control, `{% set %}`, and boolean `and` / `or` all parse cleanly and are simply not `var` / `env_var` calls, so the walker ignores them.
+
+The control-flow versus value-substitution signal, which the [classification](./inference-and-classification.md) stream and #99 / #100 depend on, is recoverable from the AST alone: a `var` `Call` reached under an `If.test`, a `For.iter`, or a branch-steering `Compare` is control-flow; one reached only under an `Output` or a plain expression is value-substitution. No text heuristics are needed for that decision.
+
+One footgun the C product-line literature warns about (TypeChef's token-straddling, where `{{ var('schema') }}.users` crosses a SQL token boundary) does not bite this stream. We parse the Jinja, not the rendered SQL, and that snippet parses cleanly into `Output` plus `TemplateData`. Token-straddling is a concern for the variability-aware compilation endgame in #100, where the rendered SQL is re-parsed, not for var discovery.
+
+## The parsing environment
+
+A bare `jinja2.Environment()` rejects tags dbt relies on. A probe of the fixture's macro bodies found the failures fall into a small, known set, and two of the categories are standard Jinja extensions rather than dbt inventions:
+
+| Tag | Source | Treatment |
+|---|---|---|
+| `do` | `jinja2.ext.do` (stdlib) | enable the extension |
+| `continue` / `break` | `jinja2.ext.loopcontrols` (stdlib) | enable the extension |
+| `materialization` | dbt block tag | generic block-tag extension |
+| `snapshot` | dbt block tag | generic block-tag extension |
+| `test` | dbt block tag (legacy generic-test definition) | generic block-tag extension |
+| `docs` | dbt block tag | generic block-tag extension |
+
+The dbt block tags share one shape, `{% TAG ...header... %} body {% endTAG %}`, handled by a single extension that skips the header tokens and parses the body as statements so a `var()` inside survives with its context intact:
+
+```python
+class DbtBlockTags(Extension):
+    tags = {"materialization", "snapshot", "docs", "test"}
+
+    def parse(self, parser):
+        tag = parser.stream.current.value
+        lineno = next(parser.stream).lineno
+        while parser.stream.current.type != "block_end":  # skip the header tokens
+            next(parser.stream)
+        body = parser.parse_statements((f"name:end{tag}",), drop_needle=True)
+        return nodes.Scope(body, lineno=lineno)            # parse INTO the body
+```
+
+The load-bearing choice is `parse_statements` over skip-to-end: it parses the body as real statements, so a `var()` inside a snapshot, including one nested in an `{% if %}`, keeps its syntactic context and is correctly classified as control-flow. We skip only the header tokens (`snapshot name`, `materialization ..., adapter='x'`), where vars do not live. The probe confirmed the fixture's macro bodies parse cleanly under this environment and that a `var()` inside a snapshot body is reached with its control-flow context preserved.
+
+The tag set is dbt's documented vocabulary, so it is closed and extending it is a one-line change. This makes snapshots first-class for var discovery: their `.sql` body is read through the same path, and the manifest supplies snapshot config (the validity columns already modeled in `ModelConfig`) separately.
+
+## Degrade-not-lie on parse failure
+
+Anything the environment still cannot parse (an exotic custom extension, a malformed body) must become one honest diagnostic, never a crash and never a silent miss. The walker catches the parse failure, records the node (or macro) as opaque with the reason, and the var it would have carried degrades to a single resolved world downstream. This is the spec's "detect by parse failure, mark opaque" rule, and it is the backstop that keeps the closed tag set from being a soundness risk: a tag we have not enumerated costs coverage, not correctness.
+
+## Outputs
+
+The walker emits `VarUsage` records as specified in [`var-inference-spec.md`](../var-inference-spec.md): var name, kind (`var` / `env_var`), `UsageContext`, source location (file, line, column from the AST node's `lineno` and the node's `original_file_path`), the macro trail (empty for direct usage, filled by the [macro-following](./macro-following.md) stream), and a confidence marker. Source location comes from the Jinja node's line number plus the node's file path; the column is best-effort since jinja2 nodes carry line but not column.
+
+## Testing
+
+- A test that every macro body in the fixture set parses under the configured environment, so a new dbt tag surfaces as a failing test rather than silent opaque-ing.
+- Per-rule unit tests: one synthetic template per `UsageContext`, asserting the emitted `VarUsage` (kind, context, operand). These are the rule-by-rule pins the spec's testing strategy calls for.
+- A snapshot-body test asserting a `var()` inside `{% snapshot %}` (and inside a nested `{% if %}` within it) is discovered with control-flow context.
+- A parse-failure test asserting an unparseable body yields an opaque diagnostic rather than raising.
+
+## Open questions
+
+- **Column position in source locations.** jinja2 AST nodes carry `lineno` but not column. Whether to recover column by re-lexing or to accept line-only locations in v1.
+- **Vars in seeds and sources.** The spec defers these. They have no `raw_code` to walk, so they are out of this stream's reach regardless; if they are wanted, they enter through config rather than the Jinja walk.
+
+## References
+
+- [The var-inference plan](./plan.md) and [the original spec](../var-inference-spec.md).
+- The two-front-end framing: [`config-and-flag-worlds.md`](../config-and-flag-worlds.md), "The parsing reality".
+- The downstream consumers of the control-flow signal: [inference and classification](./inference-and-classification.md), [#99](https://github.com/dvryaboy/dblect/issues/99), [#100](https://github.com/dvryaboy/dblect/issues/100).
+</content>

--- a/docs/design/var-inference/jinja-frontend.md
+++ b/docs/design/var-inference/jinja-frontend.md
@@ -1,8 +1,10 @@
 # Var inference: the Jinja front end
 
-Status: design
+Status: implemented in [#104](https://github.com/dvryaboy/dblect/pull/104), split off `main` ahead of the rest of this stream
 Audience: engineers implementing the source-Jinja walker for var discovery
 Part of: [the var-inference plan](./plan.md)
+
+The parsing environment (`src/dblect/varinf/environment.py`), the context-carrying walker (`walker.py`), and the `VarUsage` / `UsageContext` contracts (`usage.py`) land in #104, with the rule-by-rule pins and two property tests (discovery completeness against an independent `find_all` oracle, and totality on arbitrary input) in `tests/varinf/`. Two boundaries are deferred and noted under [Open questions](#open-questions): `is_incremental()` and the `SqlLiteral` position hint.
 
 This stream turns a node's source Jinja into a structured record of every `var()` and `env_var()` reference it makes directly (macro indirection is the [macro-following](./macro-following.md) stream). It is the second of dblect's two front ends: sqlglot over compiled SQL for structure, and this Jinja AST over source for the variability compiled SQL has already erased.
 
@@ -25,7 +27,9 @@ A probe of `jinja2.Environment().parse()` established that the parser yields a c
 | `MacroArg(macro, position)` | the `var` `Call` is an argument of another `Call` whose name is not `var` / `env_var` |
 | inline `var(name, default)` | the `Call` carries a second `Const` argument |
 
-`env_var` versus `var` is the callee name on the `Call`. `is_incremental()` is a `Call` to a bare name, discoverable the same way and relevant as an always-present control-flow axis. `config()`, `ref()`, `source()`, `{{ this }}`, whitespace control, `{% set %}`, and boolean `and` / `or` all parse cleanly and are simply not `var` / `env_var` calls, so the walker ignores them.
+`env_var` versus `var` is the callee name on the `Call`. `config()`, `ref()`, `source()`, `{{ this }}`, whitespace control, `{% set %}`, and boolean `and` / `or` all parse cleanly and are simply not `var` / `env_var` calls, so the walker ignores them.
+
+`is_incremental()` is also a `Call` to a bare name, and the walker sees it the same way, but it does not emit a `VarUsage` for it: it is not a var, it is an always-present control-flow axis whose type (`bool`), domain (first-run versus steady-state), and trigger (incremental materialization) are all known a priori. It enters the world system through bounded re-compilation keyed on `materialized == 'incremental'`, not through discovery, so forcing it into the var-shaped `VarUsage` would muddy that contract. If the per-model responsiveness map ever needs to know which models branch on it, that is a separate control-flow marker, not a `VarUsage`. The same holds for `target.name`.
 
 The control-flow versus value-substitution signal, which the [classification](./inference-and-classification.md) stream and #99 / #100 depend on, is recoverable from the AST alone: a `var` `Call` reached under an `If.test`, a `For.iter`, or a branch-steering `Compare` is control-flow; one reached only under an `Output` or a plain expression is value-substitution. No text heuristics are needed for that decision.
 
@@ -80,7 +84,9 @@ The walker emits `VarUsage` records as specified in [`var-inference-spec.md`](..
 
 ## Open questions
 
-- **Column position in source locations.** jinja2 AST nodes carry `lineno` but not column. Whether to recover column by re-lexing or to accept line-only locations in v1.
+- **`SqlLiteral` position hint.** The spec's `SqlLiteral(position)` distinguishes quoted-string, numeric, and identifier positions, which type inference reads (a numeric `LIMIT` position infers numeric, a quoted position infers `str`). Deciding that needs the SQL context around the interpolation, which the Jinja AST does not carry: an `Output` node knows it interpolates a value, not what SQL token surrounds it. #104 emits `SqlLiteral(UNKNOWN)` and defers the refinement (recovering the surrounding text, or a light re-lex) rather than guessing. Until then a value-substitution var still types from its other usages and from its declared default.
+- **Column position in source locations.** jinja2 AST nodes carry `lineno` but not column. Whether to recover column by re-lexing or to accept line-only locations in v1 (#104 takes line-only).
+- **`is_incremental()` and `target` as control-flow markers.** The walker recognizes these but emits no `VarUsage` (they are not vars). They are handled as always-present axes by bounded re-compilation. Whether the front end should additionally emit a non-var control-flow marker per model to feed per-model responsiveness ([#99](https://github.com/dvryaboy/dblect/issues/99)) is deferred to the always-present-axis stream that owns them.
 - **Vars in seeds and sources.** The spec defers these. They have no `raw_code` to walk, so they are out of this stream's reach regardless; if they are wanted, they enter through config rather than the Jinja walk.
 
 ## References

--- a/docs/design/var-inference/macro-following.md
+++ b/docs/design/var-inference/macro-following.md
@@ -1,0 +1,82 @@
+# Var inference: macro following
+
+Status: design
+Audience: engineers implementing the macro expansion engine
+Part of: [the var-inference plan](./plan.md)
+
+Many `var()` calls are reached only through macros: a model calls `{{ get_flag('include_tax') }}`, and the `var()` lives inside `get_flag`'s body. This stream follows those calls. It is separable from direct-usage discovery in the [front end](./jinja-frontend.md) and can land after it; a project whose vars are all referenced directly is fully handled without this stream, which covers the majority of small projects.
+
+The engine walks over already-parsed ASTs. The [front end](./jinja-frontend.md) configures the parsing environment and the [discovery-inputs](./discovery-inputs.md) stream supplies the macro registry, so this stream's job is the expansion and recursion logic, not parsing.
+
+## The walk
+
+When the AST walk encounters a `Call` whose callee names a macro in the registry (rather than `var` / `env_var`), the engine:
+
+1. Looks the macro up in the registry (a dictionary access; no scanning).
+2. Takes the macro's already-parsed body AST.
+3. Substitutes the call-site arguments for the macro's parameters (lexical substitution, described below).
+4. Walks into the substituted body, continuing to collect `VarUsage` records, with the macro name pushed onto the trail.
+5. Pops the macro from the trail when the sub-walk completes.
+
+The walk recurses when a macro body itself calls macros. Each `VarUsage` collected through a macro carries the trail of macros traversed to reach it, which the diagnostic report surfaces so the user can see where an inferred var came from.
+
+## Lexical parameter substitution
+
+A macro call binds positional and keyword arguments to the macro's declared parameters. Substitution replaces each parameter `Name` in the body AST with the argument expression from the call site. When the argument is a literal, the parameter becomes that `Const`, which is what makes symbolic conditional evaluation (below) possible. When the argument is itself a `var()` call or a more complex expression, the parameter becomes that subtree, so a `var()` passed as a macro argument is followed into the position the parameter occupies.
+
+The substitution is lexical, not a full Jinja evaluation: it rewrites the AST, it does not render. This keeps the engine static and free of a live dbt at analysis time.
+
+## Internal control flow
+
+A macro body can branch on a parameter:
+
+```jinja
+{% macro tricky(condition) %}
+  {% if condition %}{{ var('option_a') }}{% else %}{{ var('option_b') }}{% endif %}
+{% endmacro %}
+```
+
+The engine evaluates the condition symbolically against the substituted argument:
+
+- If the call-site argument is a literal (`{{ tricky(True) }}`), the condition resolves and only the taken branch is walked.
+- If the argument is a variable or non-literal expression, both branches are walked. Both `var('option_a')` and `var('option_b')` are recorded, with confidence set to partial and a note that the conditional could not be resolved.
+
+Recording both branches when the condition is unresolved is the sound choice: it over-collects usages rather than missing one, and the partial-confidence marker tells the user the over-collection is deliberate.
+
+## Depth limit and cycle detection
+
+- A maximum recursion depth (the spec sets five levels) bounds pathological expansion.
+- A call stack tracks the macros currently being expanded. A macro already on the stack is a cycle; the engine breaks it and marks the usage opaque with a recursive-macro reason rather than looping.
+
+## The opacity rules
+
+Several macro shapes cannot be followed statically. Each becomes an opaque diagnostic naming the reason, so the user knows exactly what needs manual declaration. The engine does not guess.
+
+- **Runtime-dependent macros.** A macro that queries the warehouse during compilation (introspecting columns, checking relation existence) cannot be expanded statically. The engine detects these by reference to `run_query`, `statement`, or adapter introspection calls in the body, and treats the macro as opaque.
+- **Adapter dispatch.** `{{ adapter.dispatch(...) }}` resolves at runtime by the configured adapter. The engine uses the adapter type from [discovery-inputs](./discovery-inputs.md) to pick the dispatch target and follows it normally; a missing target is opaque.
+- **Higher-order macros.** Macros taking other macros as arguments are out of scope for v1; the engine marks them opaque with an unsupported-pattern reason and hints the user to declare the affected vars manually.
+- **Custom Jinja extensions.** Most package extensions are pure text substitution and parse without issue under the configured environment. The few that perform side effects or non-standard parsing surface as parse failures and are treated as opaque, the same degrade path the [front end](./jinja-frontend.md) uses.
+
+The unifying rule is the spec's: a usage we cannot resolve statically is recorded as opaque with a reason, never dropped and never guessed. An opaque usage degrades its var to a single resolved world downstream.
+
+## Testing
+
+- Per-shape unit tests: a macro that wraps a `var()`, a macro that takes a `var()` as an argument, a macro with a literal-argument conditional (one branch walked), a macro with a non-literal conditional (both branches walked, partial confidence).
+- A cycle test: two mutually recursive macros, asserting the engine terminates and marks the usage opaque rather than looping.
+- A depth test: a chain past the limit, asserting it stops and marks opaque.
+- An adapter-dispatch test resolving to a known target and following it.
+- Opacity tests for a `run_query`-bearing macro and a higher-order macro, each asserting the opaque reason.
+
+These pin the engine's contracts at the boundary (what usages come out, with what confidence and trail) rather than its internal recursion mechanics, so they survive a refactor of the walk.
+
+## Open questions
+
+- **Macro `depends_on.macros` versus walking.** The manifest records each macro's macro dependencies. Whether to use that edge set to bound or pre-filter the walk, or to walk purely from the body AST. Walking from the body is simpler and authoritative; the edge set may be a useful cross-check.
+- **Argument binding fidelity.** dbt macros support defaults and `**kwargs`-style varargs in some patterns. How faithfully v1 binds these versus degrading to opaque on the exotic ones.
+
+## References
+
+- [The var-inference plan](./plan.md) and [the original spec](../var-inference-spec.md), "Macro handling".
+- The parsed-body source: [the Jinja front end](./jinja-frontend.md). The registry: [discovery inputs](./discovery-inputs.md).
+- The downstream effect of opacity (one resolved world): [inference and classification](./inference-and-classification.md).
+</content>

--- a/docs/design/var-inference/macro-following.md
+++ b/docs/design/var-inference/macro-following.md
@@ -6,13 +6,17 @@ Part of: [the var-inference plan](./plan.md)
 
 Many `var()` calls are reached only through macros: a model calls `{{ get_flag('include_tax') }}`, and the `var()` lives inside `get_flag`'s body. This stream follows those calls. It is separable from direct-usage discovery in the [front end](./jinja-frontend.md) and can land after it; a project whose vars are all referenced directly is fully handled without this stream, which covers the majority of small projects.
 
-The engine walks over already-parsed ASTs. The [front end](./jinja-frontend.md) configures the parsing environment and the [discovery-inputs](./discovery-inputs.md) stream supplies the macro registry, so this stream's job is the expansion and recursion logic, not parsing.
+The engine walks over already-parsed ASTs. The [front end](./jinja-frontend.md) configures the parsing environment and the [discovery-inputs](./discovery-inputs.md) stream supplies the macro registry (implemented in [#103](https://github.com/dvryaboy/dblect/pull/103): `Manifest.macros`, keyed by `unique_id`), so this stream's job is the expansion and recursion logic, not parsing.
+
+### Inherited from discovery-inputs: name resolution
+
+The registry is keyed by `unique_id`, but a call site names a macro by bare name or `package.name`. discovery-inputs deferred the name-to-definition resolver here on purpose, since its contract is fixed by how this walker dispatches rather than by the manifest shape. This stream implements it: a resolver over `Manifest.macros` that applies dbt's package-qualification rule (a bare name resolves within the project first, then packages; a `package.name` reference resolves directly), returning the `Macro` or signalling no match (an opaque usage, not an error). The registry already carries `name` and `package_name` on every entry, so this is pure lookup logic with no new manifest reading. Its test (the bare-name-then-package order and the `package.name` direct path) lands with it here.
 
 ## The walk
 
 When the AST walk encounters a `Call` whose callee names a macro in the registry (rather than `var` / `env_var`), the engine:
 
-1. Looks the macro up in the registry (a dictionary access; no scanning).
+1. Resolves the callee name to a registry entry through the name resolver above (bare-name-then-package, or `package.name` direct).
 2. Takes the macro's already-parsed body AST.
 3. Substitutes the call-site arguments for the macro's parameters (lexical substitution, described below).
 4. Walks into the substituted body, continuing to collect `VarUsage` records, with the macro name pushed onto the trail.
@@ -61,6 +65,7 @@ The unifying rule is the spec's: a usage we cannot resolve statically is recorde
 
 ## Testing
 
+- A name-resolution test (inherited from discovery-inputs) pinning the bare-name-then-package lookup order and the `package.name` direct path over `Manifest.macros`, plus a no-match yielding an opaque usage.
 - Per-shape unit tests: a macro that wraps a `var()`, a macro that takes a `var()` as an argument, a macro with a literal-argument conditional (one branch walked), a macro with a non-literal conditional (both branches walked, partial confidence).
 - A cycle test: two mutually recursive macros, asserting the engine terminates and marks the usage opaque rather than looping.
 - A depth test: a chain past the limit, asserting it stops and marks opaque.
@@ -71,7 +76,7 @@ These pin the engine's contracts at the boundary (what usages come out, with wha
 
 ## Open questions
 
-- **Macro `depends_on.macros` versus walking.** The manifest records each macro's macro dependencies. Whether to use that edge set to bound or pre-filter the walk, or to walk purely from the body AST. Walking from the body is simpler and authoritative; the edge set may be a useful cross-check.
+- **Macro `depends_on.macros` versus walking.** The manifest records each macro's macro dependencies, now surfaced as `Macro.depends_on_macros`. Whether to use that edge set to bound or pre-filter the walk, or to walk purely from the body AST. Walking from the body is simpler and authoritative; the edge set may be a useful cross-check.
 - **Argument binding fidelity.** dbt macros support defaults and `**kwargs`-style varargs in some patterns. How faithfully v1 binds these versus degrading to opaque on the exotic ones.
 
 ## References

--- a/docs/design/var-inference/plan.md
+++ b/docs/design/var-inference/plan.md
@@ -1,0 +1,75 @@
+# Var inference and flag scaffolding: implementation plan
+
+Status: design (living document; rewritten into an architecture doc at merge)
+Audience: engineers implementing dblect's flag discovery layer ([#98](https://github.com/dvryaboy/dblect/issues/98)) and reviewers of the work
+Scope: v1 of var handling, `var()` and `env_var()` only
+
+This is the big-picture plan for the var-inference engine and `dblect scaffold flags`. It sits above the original specification in [`var-inference-spec.md`](../var-inference-spec.md), which it refines rather than replaces: the spec defines the algorithm, the output format, and the inference rules; this plan organizes the build into work streams, records the design decisions taken since the spec was written, and links each work stream to its own design doc. The per-stream docs carry the detail.
+
+The convention for this document set follows the project's design-doc workflow: these docs live in the implementation PR and are iterated on through design and implementation. When the work is ready to merge, they are rewritten into architecture docs that describe what was built and the key decisions behind it.
+
+## Where this sits
+
+The flag system has two halves. The **bridge** half is built and runs end to end: [`src/dblect/check/flags.py`](../../../src/dblect/check/flags.py) lowers a hand-authored `DomainFlag` to the per-world `CompileFact`s the enumerator consumes, and `check_worlds` produces cross-world findings from it. That half deliberately runs on hand-declared flags today, with responsiveness named directly on each flag, because the **discovery** half does not exist yet.
+
+This work is the discovery half. It walks a dbt project, finds every `var()` and `env_var()`, infers enough about each to enumerate worlds (type, domain, default, branch points), classifies each by how it is used, and writes a draft flag file plus a diagnostic report that the user completes. It supplies the two inputs that let the bridge drop its hand-declarations: the **domain** to enumerate worlds over, and the **per-model var usage** that grounds model-responsiveness. It is also the prerequisite for wiring `check_worlds` into the `dblect check` CLI, since the CLI needs a flag-declaration surface to read.
+
+The broader theory and the world-evaluation strategy live in [`config-and-flag-worlds.md`](../config-and-flag-worlds.md); the user-facing surface lives in [`flags_and_configs_as_types.md`](../flags_and_configs_as_types.md). This plan is the engineering view of the discovery layer those two docs depend on.
+
+## What this feeds: #99 and #100
+
+Two follow-on issues consume this layer's outputs, so the outputs are designed for them from the start.
+
+- [#99 (cone-based per-contract world scoping)](https://github.com/dvryaboy/dblect/issues/99) consumes the **control-flow subset** of vars (the classification output) and the **per-model var usage** map. It intersects each contract's lineage cone with the responsive scopes of each control-flow flag to bound the world space by the largest interaction cluster rather than the global flag count.
+- [#100 (control-flow world evaluation)](https://github.com/dvryaboy/dblect/issues/100) consumes the same classification and per-model usage, plus #99's clusters, to produce both compiled SQL forms of a branch flag.
+
+The load-bearing consequence, beyond the original spec, is that **classification must land before naive enumeration**. Discovering every var and surfacing it as a world axis does not scale: a real project has hundreds of vars, most of which are not world axes. Each var is classified by the union over its usage sites into one of three classes:
+
+- **Control-flow**: used in `{% if %}`, `{% for %}`, `is_incremental()`, or an equality / in-set / numeric test that steers a branch. This is the only class surfaced as a world axis, because it can change the compiled SQL. A var used in any control-flow context is control-flow, even if it is also substituted as a value elsewhere.
+- **Value-substitution**: only ever substituted as a literal, never steering a branch. Collapses to one world, the value the manifest already compiled. Recorded and typed, not surfaced as an axis for now (the fact-level enumerator already handles value-substitution worlds, so enumerating these later is cheap).
+- **Computed**: value not statically resolvable (a macro that queries the warehouse, an exotic Jinja pattern). One world, the resolved value, degrade-not-lie.
+
+Coverage reports which axes collapsed and why, so a one-world var is a stated number rather than a silent assumption.
+
+## Work streams
+
+The build divides into work streams, each with its own design doc. The order below is the dependency order, not a fixed schedule.
+
+1. **[Jinja front end](./jinja-frontend.md).** The parsing environment and the typed AST walker that turns a node's source Jinja into `VarUsage` records for direct `var()` / `env_var()` references, with source locations and syntactic context. The custom-tag and snapshot concerns are resolved here, with measured evidence.
+2. **[Discovery inputs](./discovery-inputs.md).** The two external surfaces the analysis reads before it walks: a macro registry built from the manifest (the bodies macro-following expands) and the project configuration (`dbt_project.yml` declared vars and defaults, `profiles.yml` target overrides).
+3. **[Macro following](./macro-following.md).** The expansion engine that follows `var()` calls reached through macros: registry lookup, depth-limited recursion, cycle detection, lexical parameter substitution, symbolic evaluation of literal-argument conditionals, adapter dispatch, and the opacity rules for runtime-dependent and higher-order macros.
+4. **[Inference and classification](./inference-and-classification.md).** The lattice that folds a var's usages into a type and a domain, the classifier that assigns each var its control-flow / value-substitution / computed class, and the per-model var-usage map. This is the stream whose outputs #99 and #100 consume.
+5. **[Scaffold output and CLI](./scaffold-and-cli.md).** The generated flag file, the diagnostic report, the re-run merge semantics that preserve user edits, the `dblect scaffold flags` command, and the reconciliation between the authored flag surface the spec describes and the bridge flag the enumerator consumes.
+
+The first two streams are pure inputs and the most self-contained; the front end carries the resolved parsing risk. The inference and scaffold streams are where the user-visible behavior lands. Macro following is separable from direct-usage discovery and can follow it.
+
+## Resolved risks
+
+**Jinja parsing is not the risk.** A probe of `jinja2.Environment().parse()` against representative dbt templates and against the macro bodies in the jaffle fixture established that the parser yields a clean, structured AST in which every `UsageContext` the spec needs maps directly to a node shape, with literals resolved inline (including the inline `var(name, default)` the spec noted as a boundary). The control-flow versus value-substitution distinction, which #99 and #100 hinge on, is recoverable from the AST alone.
+
+The custom-tag concern resolved cleanly. The only parse failures across the fixture's macro bodies were a small, known set of tag names: two are standard Jinja extensions dbt enables (`do`, and the loop controls `continue` / `break`), and the rest are dbt block tags (`materialization`, `snapshot`, `test`, and the same-shaped `docs`). Enabling the two standard extensions and adding one generic block-tag extension that parses *into* the body (so a `var()` inside a snapshot, including one nested in an `{% if %}`, keeps its syntactic context) brought the fixture's macro bodies to a clean parse. Anything genuinely unknown still degrades to an opaque diagnostic rather than a crash. The front-end doc carries the detail and the asserting test that keeps a future dbt tag addition from silently degrading. Snapshots are therefore in scope, read through the same body-parsing path, with the manifest supplying snapshot config (validity columns) separately.
+
+## Open decisions
+
+These are genuinely open and are expected to settle during the PR's design iteration.
+
+1. **The authored flag surface versus the bridge flag.** The user-facing docs describe a `DomainFlag` with `dbt_var` / `type` / `domain` / `default` / `affects = RefinementEffect(...)`, and the spec's scaffold output emits classes of that shape. The flag the enumerator consumes today ([`flags.py`](../../../src/dblect/check/flags.py)) is the bridge form (`name`, `affects: Mapping[value, type]`, `scopes`), and `RefinementEffect` does not exist in code yet. The scaffold stream owns reconciling these: whether #98 introduces the authored surface and its effect types, or scaffolds the bridge form directly and tracks `RefinementEffect` separately. The [scaffold doc](./scaffold-and-cli.md) carries the options.
+2. **First-PR scope.** Whether the initial PR lands direct-usage discovery, classification, and the scaffold command (deferring macro following and polish to follow-ups, matching the spec's staged delivery), or attempts the fuller engine in one pass.
+3. **The spec's standing open questions.** Vars in seeds and sources, closed-world versus open-world default for inferred domains, declared-but-unused vars, per-package vars, scaffold versioning. These are listed in [`var-inference-spec.md`](../var-inference-spec.md) and resolved per stream as the streams that own them are designed.
+
+## Testing posture
+
+Following the project's testing norms: pin contracts at the boundaries, prefer property-based and exhaustive tests where they fit, avoid mocking and test theater. Each stream names its own testable contracts in its doc. Two cross-cutting commitments:
+
+- The front end carries a test that every macro body in the fixture set parses, so a new dbt tag surfaces as a failing test rather than silent opaque-ing.
+- Fixtures grow as small dbt projects that exercise each inference rule and each classification class, with the var-bearing projects the current fixtures lack. The aggregation and scaffold streams snapshot their output against these.
+
+## References
+
+- The original specification: [`var-inference-spec.md`](../var-inference-spec.md).
+- The world theory and evaluation strategy this discovery layer feeds: [`config-and-flag-worlds.md`](../config-and-flag-worlds.md).
+- The user-facing flag surface: [`flags_and_configs_as_types.md`](../flags_and_configs_as_types.md).
+- The facts substrate the bridge lowers to: [`lineage-facts.md`](../lineage-facts.md).
+- Per-stream design docs: [jinja-frontend](./jinja-frontend.md), [discovery-inputs](./discovery-inputs.md), [macro-following](./macro-following.md), [inference-and-classification](./inference-and-classification.md), [scaffold-and-cli](./scaffold-and-cli.md).
+</content>
+</invoke>

--- a/docs/design/var-inference/scaffold-and-cli.md
+++ b/docs/design/var-inference/scaffold-and-cli.md
@@ -1,0 +1,88 @@
+# Var inference: scaffold output and CLI
+
+Status: design
+Audience: engineers implementing the generated flag file, the diagnostic report, and the `dblect scaffold flags` command
+Part of: [the var-inference plan](./plan.md)
+
+This stream renders the `DiscoveredVar` records from [inference and classification](./inference-and-classification.md) into the two artifacts the user reviews, a draft flag file and a diagnostic report, and wires the `dblect scaffold flags` command that produces them. It owns the one design decision the rest of the plan defers to it: the relationship between the flag surface the user authors and the flag the enumerator consumes.
+
+## The flag-surface reconciliation
+
+The user-facing docs ([`flags_and_configs_as_types.md`](../flags_and_configs_as_types.md)) and the spec's output templates describe a `DomainFlag` of this shape:
+
+```python
+class IncludeTaxInRevenue(DomainFlag):
+    """TODO: describe what this flag controls."""
+    dbt_var = "include_tax_in_revenue"
+    type = bool
+    domain = [True, False]
+    default = False
+    affects = RefinementEffect(target=Revenue.contains_tax, value_when_true=True, value_when_false=False)
+```
+
+The flag the enumerator consumes today ([`src/dblect/check/flags.py`](../../../src/dblect/check/flags.py)) is the bridge form:
+
+```python
+@dataclass(frozen=True, slots=True)
+class DomainFlag:
+    name: str
+    affects: Mapping[Hashable, type[DomainType]]   # value -> fully-refined type
+    scopes: tuple[ColumnRef, ...]                   # declared responsiveness
+```
+
+These differ in three ways: the authored surface keys `affects` to a `RefinementEffect` over a type axis while the bridge keys it to a fully-refined type per value; the authored surface carries `dbt_var` / `type` / `domain` / `default` that the bridge does not; and `RefinementEffect` does not exist in code. The two are not in conflict so much as at different levels: the authored surface is what a person writes, the bridge form is what the enumerator reads, and something must lower one to the other (the same lowering the config-and-flag-worlds doc calls "lowering `affects` to a fact").
+
+Three ways to resolve it, to settle during the PR:
+
+- **Scaffold the authored surface, add the lowering.** Introduce the authored `DomainFlag` (with `dbt_var` / `type` / `domain` / `default` / `affects`) and `RefinementEffect` in the types layer, scaffold that, and add a lowering from the authored flag to the bridge form the enumerator already consumes. This matches every user-facing doc and is the most faithful to the spec's templates. Its cost is introducing `RefinementEffect` and its lowering, which is arguably its own piece of work.
+- **Scaffold the bridge form directly.** Generate the existing bridge `DomainFlag` (`name` / `affects: Mapping` / `scopes`), filling `name`, `domain` (as the `affects` keys), and leaving the per-value type and `scopes` as the user's `TODO`. This is the smallest change and keeps one flag class, at the cost of diverging from the authored surface the docs promise and asking the user to write the lower-level form.
+- **Scaffold the authored surface, defer the lowering.** Generate the authored `DomainFlag` shape as the scaffold target and track `RefinementEffect` plus its lowering as a separate issue, so #98 produces the file the user edits and the enumerator wiring lands with the lowering. This keeps #98 focused on discovery and matches the docs, at the cost of a scaffold whose output the enumerator cannot yet read end to end.
+
+The recommendation leans toward scaffolding the authored surface (the docs are written around it and the `affects` clause is the whole point of the user's involvement), with the lowering's scheduling, in #98 or a follow-up, decided by first-PR scope. This decision is recorded as open in [the plan](./plan.md) and is the first thing to lock.
+
+## The generated flag file
+
+Default path `dblect/flags/discovered.py`, overridable. One class per `DiscoveredVar`, sorted by name, in the resolved flag shape. The class carries the inferred type, the inferred domain (with the tentative note where the domain came from observation), the default from project config, source-location comments showing where the var was used (so the user can verify discovery and find missed usages), and a `TODO` on `affects` and the docstring. The spec's templates show the boolean, enum, open-domain, and inference-failed variants; the renderer produces each from the var's inference quality.
+
+Only the **control-flow subset** is surfaced as flag classes with world axes; value-substitution and computed vars are recorded in the report (and optionally as commented or quality-marked entries) so the user sees them without their being enumerated. This keeps the file to the vars that are actually world axes, the scaling decision from [classification](./inference-and-classification.md).
+
+## The diagnostic report
+
+Default path `dblect/flags/discovery_report.md`. A summary (counts of discovered vars and env_vars, fully / partially / failed inference), a per-variable section with inferred properties and status, an inference-failed section with reasons and recommendations, and an unfollowed-usages section naming the macros and patterns that could not be followed and the vars they affect. The report is where coverage lands: which vars were surfaced as axes and which collapsed to one world and why. The spec's report layout is the template.
+
+## Re-run merge semantics
+
+`dblect scaffold flags` is run repeatedly as the project evolves, and must not clobber the `affects` clauses and docstrings the user has written. The merge rule, from the spec's open question now treated as a requirement:
+
+- A class with a non-default `affects` (the user has filled it in) is user-owned and preserved unchanged.
+- Inference-derived fields (type, domain, source-location comments) on classes still at their `TODO` default are updated to the latest inference.
+- When a preserved class's inferred type changes between runs (the SQL changed), the class is left as the user wrote it and a diagnostic notes the difference, so the user decides whether to accept the new inference.
+- New vars produce new draft classes; vars that disappeared are noted in the report rather than silently removed.
+
+This makes re-running safe and the recommended way to keep declarations in sync. A format-version marker on the generated file lets a future tool version detect and migrate older output.
+
+## The CLI command
+
+A `scaffold` command group with a `flags` subcommand under the existing Typer app in [`cli/__init__.py`](../../../src/dblect/cli/__init__.py), alongside `init`, `audit`, and `check`. It resolves the manifest the same way those commands do (the shared `_resolve_manifest_path` and `_load_manifest` helpers, falling back to `dbt compile`), reads the [project config](./discovery-inputs.md), runs discovery and inference, and writes the two artifacts, never overwriting a user-owned class. Its options mirror the existing commands (`project_dir`, `--manifest`, `--dbt-executable`), plus output-path overrides for the flag file and report.
+
+## Testing
+
+- Snapshot tests of the generated file and report against the var-bearing fixtures from [discovery inputs](./discovery-inputs.md), one snapshot per inference-quality variant (boolean, enum, open-domain, inference-failed).
+- A re-run test: scaffold, hand-edit a class's `affects` to a non-default, re-scaffold, and assert the edited class is preserved while a `TODO`-default class is updated.
+- A generated-file validity test: the rendered Python imports and the classes construct (a generated file that does not import is a broken scaffold).
+- A CLI test exercising `dblect scaffold flags` end to end against a fixture project, asserting both artifacts are written and exit status.
+
+The snapshots pin the user-visible output; the re-run and validity tests pin the merge contract and that the output is usable, which are the properties that matter to the user rather than the renderer's internals.
+
+## Open questions
+
+- **The flag-surface reconciliation** above, the gating decision for this stream.
+- **Declared-but-unused vars.** Whether a var declared in project config with no usage produces a class (it may be used in future) or is noted only in the report (noise reduction). The spec leaves this open.
+- **Output location and packaging.** Whether `dblect/flags/` is the right home given the existing `dblect/` declaration tree the `init` command scaffolds, and how the discovered flags are imported into a `check` run.
+
+## References
+
+- [The var-inference plan](./plan.md) and [the original spec](../var-inference-spec.md), "Output format" and "Open questions".
+- The authored flag surface: [`flags_and_configs_as_types.md`](../flags_and_configs_as_types.md). The bridge and the lowering: [`flags.py`](../../../src/dblect/check/flags.py), [`config-and-flag-worlds.md`](../config-and-flag-worlds.md).
+- The records this renders: [inference and classification](./inference-and-classification.md).
+</content>


### PR DESCRIPTION
> **Status update (var-inference discovery-inputs):** the manifest macro registry described in `discovery-inputs.md` has been implemented and split out as its own PR, [#103](https://github.com/dvryaboy/dblect/pull/103) (off `main`, since it is separable and changes no existing behavior). The docs here are updated to mark it done and to defer the name-to-definition resolver to the macro-following stream, where its contract is fixed by how the walker dispatches. The **Jinja front end** described in `jinja-frontend.md` has since been implemented and split out as [#104](https://github.com/dvryaboy/dblect/pull/104) (off `main`). The remaining design (macro-following, inference, scaffold) is still in the "shape before implementation" phase described below. Note on sequencing: the next stream to ship is the always-present-axis worlds (incremental full-refresh vs steady-state), prioritized ahead of the rest of var-inference because it is broadly applicable to any project with incremental models.

Opens the design phase for #98 (the var-inference engine and `dblect scaffold flags`). Per our SOP, these docs live in the PR and are iterated on through design and implementation, then rewritten into architecture docs at merge. **No code yet** — this is the plan to review and shape before implementation.

## What's here

A big-picture plan plus one design doc per work stream, under `docs/design/var-inference/`:

| Doc | Owns |
|---|---|
| `plan.md` | Where #98 sits (bridge half exists, discovery half missing), what it feeds #99/#100, the classification-before-enumeration requirement, work-stream index, resolved risks, open decisions, sequencing |
| `jinja-frontend.md` | Parsing environment + typed walker + `VarUsage` extraction; the snapshot/custom-tag resolution with measured evidence |
| `discovery-inputs.md` | Manifest macro registry (extend `parse.py`) + `dbt_project.yml`/`profiles.yml` reader; the inline-default boundary |
| `macro-following.md` | Expansion engine: recursion, cycle detection, lexical substitution, symbolic conditional eval, adapter dispatch, opacity rules |
| `inference-and-classification.md` | Type/domain lattice + the three-way classifier + per-model usage map (the outputs #99/#100 consume) |
| `scaffold-and-cli.md` | Generated flag file, diagnostic report, re-run merge, the `scaffold flags` command, and the flag-surface reconciliation |

## Key findings baked in

- **Jinja parsing is not the risk.** A probe of `jinja2.Environment().parse()` shows every `UsageContext` the spec needs maps directly to an AST node shape, with the control-flow vs value-substitution signal (what #99/#100 hinge on) recoverable from the AST alone.
- **Custom tags / snapshots resolved.** The only parse failures across the fixture's macro bodies were a small known tag set; two are stdlib Jinja extensions (`do`, `continue`/`break`) and the rest are dbt block tags (`materialization`, `snapshot`, `test`, `docs`). Enabling the two stdlib extensions plus one generic block-tag extension that parses *into* the body brings the macro bodies to a clean parse and reads `var()` inside a snapshot (including under a nested `{% if %}`) with control-flow context preserved. Anything genuinely unknown still degrades to an opaque diagnostic.

## Decisions I want your call on (surfaced, not resolved)

1. **Authored flag surface vs the bridge flag.** The docs describe a `DomainFlag` with `dbt_var`/`type`/`domain`/`default`/`affects = RefinementEffect(...)`; the enumerator today consumes the bridge form (`name`/`affects: Mapping`/`scopes`), and `RefinementEffect` doesn't exist in code. `scaffold-and-cli.md` lays out three options with a recommendation (scaffold the authored surface, add the lowering).
2. **First-PR scope.** Direct-usage discovery + classification + scaffold command first (defer macro-following + polish), or the fuller engine in one pass.
3. **The spec's standing open questions** (seeds/sources, closed- vs open-world domain default, declared-but-unused vars, per-package vars, scaffold versioning), resolved per stream as each is designed.

Once the gating decisions (1 and 2) are settled I'll firm the docs from "options" to "decided" and add the file-by-file implementation breakdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

