### PR TITLE
feat(check): name the columns in aggregation_not_well_typed findings (#109)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial project scaffolding: `pyproject.toml` (hatchling, ruff, pyright strict, pytest), `src/dblect/` layout, CI workflow, README, vendored jaffle test fixture, manifest ingestion module.
 
+### Changed
+- `aggregation_not_well_typed` findings now name what the coherence guard reasoned about: the aggregate and the column it reduced, the per-row companion that is not held constant, and the grouping that fails to hold it, instead of a generic message (#109).
+
 [Unreleased]: https://github.com/dvryaboy/dblect/commits/main

--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ $ dblect check .
 checked 1 contracts over 4 models: 1 finding
 
 aggregation_not_well_typed  model.jaffle_shop.total_daily_revenue.revenue
-      reducing 'revenue' mixes a per-row companion that nothing holds constant per group; the sum is not well typed
+      reducing 'revenue' with sum(amount): its per-row companion 'currency' is not held
+      constant by grouping on 'order_date'; the aggregation is not well typed
       models/marts/total_daily_revenue.sql
 ```
 

--- a/src/dblect/check/run.py
+++ b/src/dblect/check/run.py
@@ -49,6 +49,7 @@ from dblect.lineage.graph import (
 from dblect.lineage.properties.domain_type import (
     NAKED,
     DomainTag,
+    companion_columns,
     domain_type_grounded_scopes,
     domain_type_grounding,
     domain_type_property,
@@ -59,7 +60,7 @@ from dblect.lineage.properties.functional_dependency import (
     functional_dependency_grounding,
     functional_dependency_property,
 )
-from dblect.lineage.property import propagate
+from dblect.lineage.property import COLUMNREF_META_KEY, propagate
 from dblect.manifest import Manifest
 from dblect.types import ContractRegistry, ResolvedContracts, active_registry, resolve_contracts
 
@@ -368,40 +369,95 @@ def _aggregation_findings(
         if ann.value != NAKED:
             continue
         derivation = column_graph.derivation(ref)
-        if derivation is None or not _reduces_a_bare_column(derivation):
+        if derivation is None:
             continue
         operands = column_graph.edges.get(ref, frozenset())
-        if any(annotations.get(up, _NO_ANN).value != NAKED for up in operands):
-            out.append(
-                CheckFinding(
-                    kind=CheckFindingKind.AGGREGATION_NOT_WELL_TYPED,
-                    message=(
-                        f"reducing {ref.column!r} mixes a per-row companion that nothing holds "
-                        "constant per group; the sum is not well typed"
-                    ),
-                    model_unique_id=ref.source.unique_id,
-                    file_path=_file_of(manifest, ref.source),
-                    column=ref.column,
-                )
+        tagged = frozenset(up for up in operands if annotations.get(up, _NO_ANN).value != NAKED)
+        agg = _culprit_aggregate(derivation, tagged) if tagged else None
+        if agg is None:
+            continue
+        out.append(
+            CheckFinding(
+                kind=CheckFindingKind.AGGREGATION_NOT_WELL_TYPED,
+                message=_aggregation_message(ref, agg, annotations),
+                model_unique_id=ref.source.unique_id,
+                file_path=_file_of(manifest, ref.source),
+                column=ref.column,
             )
+        )
     return out
 
 
-def _reduces_a_bare_column(derivation: Expr) -> bool:
-    """Whether a projection is a non-windowed aggregate (one the coherence guard
-    judged) directly over a bare column.
+_GENERIC_AGG_MESSAGE = (
+    "reducing {col!r} mixes a per-row companion that nothing holds constant per group; "
+    "the aggregation is not well typed"
+)
 
-    Restricting to a bare-column operand keeps the finding precise. An aggregate
-    over an expression, ``sum(CASE WHEN ... THEN amount ELSE 0 END)`` being the
-    common one, already clears to naked at the expression because it mixes a
-    magnitude with a dimensionless literal, which is a different concern than a
-    companion that is not constant per group. The operand column carrying a tag
-    that the reduction cleared is the signal that names a mixed-currency sum.
-    """
-    return any(
-        isinstance(aggregation_site_meta(agg), AggregationSite) and isinstance(agg.this, exp.Column)
-        for agg in derivation.find_all(exp.AggFunc)
+
+def _aggregation_message(
+    output: ColumnRef,
+    agg: exp.AggFunc,
+    annotations: Mapping[ColumnRef, Annotation[DomainTag]],
+) -> str:
+    """Name what the coherence guard reasoned about: the aggregate and the column it
+    reduced, the per-row companion that is not held constant, and the grouping that
+    fails to hold it.
+
+    Faithful by construction: it reads the same ``AggregationSite`` the builder
+    stamped (and the guard judged) and the same ``companion_columns`` the guard
+    called, so the message describes the decision rather than re-deriving it. When the
+    reduced operand carries no tag or the companion cannot be pinpointed (an
+    unmodelled shape), it falls back to the generic wording rather than guess."""
+    operand = agg.this.meta.get(COLUMNREF_META_KEY)
+    if not isinstance(operand, ColumnRef) or operand not in annotations:
+        return _GENERIC_AGG_MESSAGE.format(col=output.column)
+    site = aggregation_site_meta(agg)
+    pinned: frozenset[ColumnRef] = site.pinned if site is not None else frozenset()
+    group_refs = site.group_refs if site is not None else None
+
+    companions = companion_columns(annotations[operand].value)
+    # A companion in the group key or pinned by the scope's WHERE is held constant;
+    # the rest are what the grouping leaves varying. If subtracting empties the set
+    # (an exotic multi-companion shape), name the companions rather than nothing.
+    held: frozenset[ColumnRef] = pinned | (group_refs or frozenset())
+    varying = frozenset(c for c in companions if c not in held) or companions
+    if not varying:
+        return _GENERIC_AGG_MESSAGE.format(col=output.column)
+
+    func = agg.key  # the lowercased aggregate name: "sum", "avg", ...
+    companion_list = ", ".join(repr(c.column) for c in sorted(varying, key=lambda r: r.column))
+    one = len(varying) == 1
+    word, verb = ("companion", "is") if one else ("companions", "are")
+    if group_refs:
+        groups = ", ".join(repr(g.column) for g in sorted(group_refs, key=lambda r: r.column))
+        tail = f"grouping on {groups}"
+    else:
+        tail = "the grouping, which does not resolve to columns,"
+    return (
+        f"reducing {output.column!r} with {func}({operand.column}): its per-row {word} "
+        f"{companion_list} {verb} not held constant by {tail}; the aggregation is not well typed"
     )
+
+
+def _culprit_aggregate(derivation: Expr, tagged: frozenset[ColumnRef]) -> exp.AggFunc | None:
+    """The bare-column aggregate the finding is about: a non-windowed aggregate over a
+    single column in ``tagged``, carrying the stamped site the coherence guard judged.
+
+    Restricting to a bare-column operand keeps the finding precise. An aggregate over
+    an expression (``sum(CASE WHEN ... THEN amount ELSE 0 END)``) already clears to
+    naked at the expression by mixing a magnitude with a dimensionless literal, a
+    different concern than a companion that is not constant per group. Which aggregate
+    *functions* carry the coherence obligation (combining vs selecting vs counting) is
+    the substrate's classification, refined separately."""
+    for agg in derivation.find_all(exp.AggFunc):
+        if not isinstance(agg.this, exp.Column):
+            continue
+        if not isinstance(aggregation_site_meta(agg), AggregationSite):
+            continue
+        operand = agg.this.meta.get(COLUMNREF_META_KEY)
+        if isinstance(operand, ColumnRef) and operand in tagged:
+            return agg
+    return None
 
 
 # --- helpers --------------------------------------------------------------------

--- a/tests/check/test_run_check.py
+++ b/tests/check/test_run_check.py
@@ -182,6 +182,21 @@ def test_mixed_currency_sum_is_flagged() -> None:
     assert agg[0].column == "total"
 
 
+def test_mixed_currency_sum_message_names_the_columns() -> None:
+    # The finding names what the coherence guard reasoned about: the aggregate and
+    # the column it reduced, the per-row companion that varies, and the grouping that
+    # fails to hold it constant, so a reader can act without opening the model (#109).
+    class Payments(ModelContract):
+        dbt_model = "payments"
+        amount: Money.columns(amount="amount", currency="currency")
+
+    report = run_check(_agg_manifest(), _DUCKDB)
+    [agg] = [f for f in report.findings if f.kind is CheckFindingKind.AGGREGATION_NOT_WELL_TYPED]
+    assert "amount" in agg.message  # the reduced column
+    assert "currency" in agg.message  # the per-row companion that varies
+    assert "country" in agg.message  # the grouping that does not hold it constant
+
+
 def test_sum_over_a_case_expression_is_not_flagged() -> None:
     # `sum(CASE WHEN ... THEN amount ELSE 0 END)` clears to naked at the CASE (it
     # mixes money with a dimensionless 0), which is a different concern than a


### PR DESCRIPTION
Closes #109. Scope: **messaging only**, per the split discussion.

## What

`aggregation_not_well_typed` reported a generic message:

```
reducing 'revenue' mixes a per-row companion that nothing holds constant per group; the sum is not well typed
```

It now names what the coherence guard actually reasoned about:

```
reducing 'revenue' with sum(amount): its per-row companion 'currency' is not held constant by grouping on 'order_date'; the aggregation is not well typed
```

The message reads the same `AggregationSite` the builder stamped (group keys, pinned columns) and the same `companion_columns` the guard called, so it describes the decision rather than re-deriving it. When the reduced operand carries no tag or the companion can't be pinpointed, it falls back to the prior generic wording. The wording is accurate for any reducing aggregate, so it survives the classification work unchanged.

## Out of scope (moved to #115)

The review surfaced that *which aggregate functions* carry the coherence obligation is a bigger, separate question: a real inspect/combine/select classification, a `count` false positive to fix, full duckdb + bigquery coverage, and dialect-extensible mappings. That is tracked in #115 and intentionally **not** in this PR — this PR ships the message improvement and leaves aggregate semantics (including the known `count` false positive) untouched.

## Tests

Test-first: a test asserts the message names the reduced column, the companion, and the grouping. The scenario suite exercises the new wording on real dbt-compiled SQL. README and CHANGELOG updated.

Full gate green: 838 passed, ruff check + format clean, pyright 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)