### PR TITLE
docs(changelog): curate the project history under [Unreleased]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,100 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+A static analyzer for dbt projects that reads a compiled manifest, propagates
+column-level facts through the DAG, and reports structural and
+declaration-level findings the user can navigate to and act on. Nothing is
+tagged yet; this section accumulates the work that a first release will carry.
+
 ### Added
-- Initial project scaffolding: `pyproject.toml` (hatchling, ruff, pyright strict, pytest), `src/dblect/` layout, CI workflow, README, vendored jaffle test fixture, manifest ingestion module.
+
+**Manifest and SQL ingestion**
+
+- Typed dbt manifest ingestion: `Manifest`, `Node`, and a `Dag` with topology,
+  parsed from `manifest.json`.
+- Analysis over each model's compiled SQL (not the raw Jinja), parsed once per
+  run and shared across detectors via a sqlglot wrapper.
+- `catalog.json` ingestion for seed and source columns, so undocumented DAG
+  leaves resolve.
+- Source-Jinja front end that discovers `var` and `env_var` references, and a
+  typed view of the manifest's macro registry.
+
+**Column-level lineage substrate**
+
+- A K-relations / semiring propagator carrying where-provenance through the DAG,
+  with CTE and UNION intermediates materialized in the lineage graph.
+- The `lineage.facts` substrate: one property propagator over a shared fact
+  representation, with nullability discoverers backed by the manifest.
+- Conditional facts that carry their guarding predicate, a predicate-implication
+  engine, and a predicate-flow property that accumulates each relation's row
+  filter, so conditional uniqueness, candidate keys, and `NOT NULL` activate
+  across relations and at intra-model scopes.
+- Nested-field (STRUCT) lineage with explicit `UNNEST` grain.
+
+**Uniqueness analysis**
+
+- Uniqueness facts from dbt declarations and from structural proof, an
+  ordering-key detector and a join-fan-out detector over substrate keys, and
+  propagation of uniqueness through SQL operations and across model
+  dependencies.
+- Candidate keys derived through surrogate-hash columns; seeds and snapshots
+  spanned as test targets.
+
+**Domain-type contracts (the declaration DSL)**
+
+- The authoring core: `DomainType`, `ModelContract`, `Field`, and the bridge
+  that lowers a contract to substrate facts.
+- A contract and proxy layer: an expression AST, column proxies, the
+  `@contract` decorator, and fact constructors.
+- Companion-binding column properties (the currency story), may/must refinement
+  for widened magnitudes, and domain-type transfer through joins
+  (functional-dependency-through-join, outer-join taint, join-key and fan-out
+  signals).
+- A config discoverer that grounds an incremental model's `unique_key`, and
+  fact-level flag-world plumbing.
+
+**Structural hazard detectors**
+
+- Structural detectors over every model: outer-join `WHERE` inversion,
+  non-determinism, the NULL-group-after-outer-join family (`GROUP BY`, join
+  key, `NOT IN`), and snapshot reads missing a temporal filter.
+- Source-line provenance on every finding, and `-- noqa-fixture:` suppression
+  with a required reason.
+
+**Cross-world analysis**
+
+- One analysis door (`dblect.analysis.analyze`) over both detector families,
+  returning every finding under one sealed type so a consumer cannot silently
+  drop a family.
+- Incremental-worlds checking: compile a model's full-refresh and steady-state
+  forms data-free, run both detector families over each, and difference the
+  findings so a hazard living only in the unexercised branch surfaces.
+- Coverage reporting that separates resolution (lineage the propagator could
+  follow) from grounding (columns a fact actually checks).
+
+**CLI and reporting**
+
+- The `dblect` CLI: `check` runs both detector families over a project, `init`
+  scaffolds the declaration tree and writes model stubs, `version` prints the
+  installed version.
+- Text and JSON reporters under one versioned schema, with a non-zero exit on
+  unsuppressed findings and a `--no-fail` override. Status messages go to
+  stderr so stdout is a clean report.
+- A validated-adapter gate, with `--dialect` as the operator's opt-in
+  acknowledgment that detector behavior is best-effort off the validated set.
+- A library of demo scenarios: developer-introduced bugs that `dblect check`
+  catches.
+
+**Execution harness**
+
+- A DuckDB execution harness that runs dbt models via subprocess with fixture
+  overrides, the substrate the runtime layers will build on.
 
 ### Changed
-- `aggregation_not_well_typed` findings now name what the coherence guard reasoned about: the aggregate and the column it reduced, the per-row companion that is not held constant, and the grouping that fails to hold it, instead of a generic message (#109).
+
+- `aggregation_not_well_typed` findings now name what the coherence guard
+  reasoned about: the aggregate and the column it reduced, the per-row companion
+  that is not held constant, and the grouping that fails to hold it, instead of
+  a generic message (#109).
 
 [Unreleased]: https://github.com/dvryaboy/dblect/commits/main


### PR DESCRIPTION
## What

The `CHANGELOG.md` had only the scaffolding stub. This curates the project's history into a readable `[Unreleased]` entry, organized by subsystem.

**No release is declared.** The version stays `0.0.1` and the work sits under `[Unreleased]`. Release tooling (release-please) is intentionally deferred to whenever a first release is actually cut, since it belongs at that point, not before.

## Why hand-write it

Most of the foundational work (the lineage / facts substrate, the domain-type DSL, the detector families) landed **before** Conventional Commits were adopted, under freeform titles (`Add …`, `Implement …`) or scope-as-type titles (`domain-type:`, `lineage:`) that a changelog generator does not recognize. Running a tool over today's history would surface only the recent `feat:` lines and silently drop the meatiest work, so the initial entry is curated by hand.

## Contents

- `CHANGELOG.md` — an `[Unreleased]` entry covering manifest/SQL ingestion, the lineage substrate, uniqueness analysis, domain-type contracts, structural detectors, cross-world analysis, the CLI, and the execution harness, plus the `aggregation_not_well_typed` messaging change from #109 folded in under Changed.

## Note

Rebased onto current `main` to absorb #109's CHANGELOG edit (that was the merge conflict). Future feature PRs can keep appending their entries under `[Unreleased]`; when you decide to cut a release, that section becomes the release notes and release-please can take over from there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)