### PR TITLE
docs(current_state): sync architecture to the built surface, add capabilities ledger

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,11 +8,12 @@ Three buckets, each answering a different question.
 
 ## What's *built* today: current state
 
-- [**current_state/architecture.md**](current_state/architecture.md): a walkthrough of the code as it stands: manifest ingestion (including dbt tests + constraints) → SQL parsing → structural detectors → uniqueness facts (declarations + structural proof) and the uniqueness-aware detector → audit walker → CLI + reporters. Reads bottom-up from a fresh checkout. Start here if you want to navigate the source or extend a detector.
+- [**current_state/capabilities.md**](current_state/capabilities.md): the status view. What works end to end today, what is scaffolded but not yet load-bearing, what the runtime half still lacks, and the concrete distance to a usable 0.1.0. Start here for "how far along is this."
+- [**current_state/architecture.md**](current_state/architecture.md): a walkthrough of the code as it stands: manifest ingestion (including dbt tests + constraints) → SQL parsing → structural detectors → the lineage substrate → uniqueness, nullability, and snapshot detectors → the domain-type declaration family → audit walker → CLI + reporters. Reads bottom-up from a fresh checkout. Start here if you want to navigate the source or extend a detector.
 
 ## What's *designed but not built*: forward-looking
 
-Working design notes for the layers above the current static analyzer. These describe the intended shape; the code that implements them mostly doesn't exist yet.
+Working design notes for the layers above the current static analyzer. These describe the intended shape. Several have since landed as static implementations (the semantic-types and typed-contract DSL, var discovery); the runtime-execution and generator pieces are still ahead. See [current_state/capabilities.md](current_state/capabilities.md) for the built-vs-designed ledger.
 
 - [**design/dblect_technical_intro.md**](design/dblect_technical_intro.md): the typed contracts and semantic-types DSL. Style A (decorated methods on `ModelContract` subclasses), the type registry, refinements, flag-conditional types.
 - [**design/tiers_and_rough_implementation_order.md**](design/tiers_and_rough_implementation_order.md): the three tiers of developer investment (audit / semantic types / focused contracts) and the implementation sequence across them.

--- a/docs/current_state/architecture.md
+++ b/docs/current_state/architecture.md
@@ -1,8 +1,8 @@
 # dblect: current architecture
 
-A description of what's built right now, not what's planned. Forward-looking work (typed contracts, runtime PBT, replay-determinism, generator framework, multi-table coordinated generation, MCP) lives in [docs/design/](../design/) and is not implemented yet.
+A description of what's built right now, not what's planned. The forward-looking work that genuinely does not exist yet is the **runtime half**: property-based execution, replay-determinism via differential runs, the generator framework, multi-table coordinated generation, and the MCP server. Those live in [docs/design/](../design/). The typed-contract and semantic-types DSL described there *is* implemented as a static layer (the declaration family below); what is not yet built is running its contracts against generated data. For a capability-by-capability map of what works end to end today and the distance to a 0.1.0 release, see [capabilities.md](./capabilities.md).
 
-What exists today is the **static analyzer**: one command (`dblect check`) that reads a dbt project and runs both detector families over it, the structural hazard detectors over every model's SQL and the declaration-level contract checks where contracts are declared, then prints findings the user can navigate to and act on. The structural family earns its keep against a real dbt project before any types or contracts are declared; the declaration family adds to it once contracts exist.
+What exists today is the **static analyzer**: one command (`dblect check`) that reads a dbt project and runs both detector families over it, the structural hazard detectors over every model's SQL and the declaration-level (domain-type and contract) checks where declarations exist, then prints findings the user can navigate to and act on. The structural family earns its keep against a real dbt project before any types or contracts are declared; the declaration family adds to it once declarations exist, and it is the layer that catches the headline meaning-shift bug (a column's revenue type flipping net to gross upstream) at PR-review time, statically, with no execution.
 
 ## What you can do with it today
 
@@ -35,11 +35,18 @@ json` produces a documented schema for CI consumption.
 ```
 src/dblect/
 ├── manifest/          # parse manifest.json into typed Node + DAG, surface dbt tests + constraints
+├── adapters/          # per-warehouse AdapterProfile (dialect, write enforcement, hazardous builtins)
 ├── sql/               # parse compiled SQL, walk the AST, detect hazards
 ├── uniqueness/        # audit detectors (window order-keys, join fanout) over substrate keys
+├── nullability/       # NULL-hazard detectors (group-by / join-key / NOT-IN over nullable upstreams)
+├── snapshot/          # snapshot-model temporal-filter detector
 ├── lineage/           # lineage graphs + the facts substrate + one property propagator
+├── types/             # the domain-type DSL: DomainType, refinements, scalars, fact bridge
+├── contracts/         # ModelContract, @contract methods, column proxies, expression AST, stub generation
+├── varinf/            # discover dbt var()/env_var() usage from source Jinja (flag-world scaffolding)
+├── demo/              # the worked Money/Currency example domain used by walkthroughs and tests
 ├── audit/             # orchestrate the structural detectors over a manifest
-├── check/             # resolve declaration contracts, propagate, report declaration findings
+├── check/             # resolve declarations, propagate domain-type + functional-dependency properties, report
 ├── analysis.py        # the one door: run both detector families, return one report
 ├── report.py          # render an AnalysisReport (both families) as text or JSON
 ├── cli/               # the `dblect` typer app
@@ -212,6 +219,32 @@ The facts themselves come from declarations (`unique`, dbt-utils `unique_combina
 
 Both detectors are enabled by default. Because they're opportunistic, no opt-in flag is needed; projects without declared uniqueness simply see no findings from them. Findings of kinds `NON_UNIQUE_WINDOW_ORDER_KEYS` and `JOIN_FANOUT` are suppressible via the standard `-- noqa-fixture:` syntax.
 
+## The nullability layer (`src/dblect/nullability/`)
+
+Nullability is a column-scoped property on the same substrate: which columns can carry a NULL, tracking outer-join introductions across the model graph. The discoverers ground it from declarations (`not_null` tests, native `NOT NULL` constraints) and the propagator taints columns that an outer join can leave unmatched. The detectors here consume that property to flag three hazards the structural pass cannot see without provenance:
+
+- **`null_group_on_nullable_key`**: a `GROUP BY` over a column the lineage knows is nullable, so unmatched rows collapse into one NULL group. (The structural `null_group_after_outer_join` is the syntax-only sibling; this one fires on cross-model nullability.)
+- **`join_on_nullable_key`**: a join whose key column is nullable, where NULLs never match and rows drop silently.
+- **`not_in_nullable_subquery`**: `<col> NOT IN (SELECT <nullable> ...)`, the SQL footgun where a single NULL in the subquery makes the whole predicate return no rows.
+
+Like the uniqueness detectors, these are opportunistic: with no grounded nullability they stay silent rather than guess.
+
+## The snapshot detector (`src/dblect/snapshot/`)
+
+dbt snapshots capture slowly-changing dimensions, and a snapshot whose query lacks a temporal filter re-captures unchanged history on every run. `snapshot_temporal_filter_missing` flags a snapshot model whose SQL has no filter on its updated-at / check column. The detector assembly lives in its own package so the audit walker stays agnostic to snapshot specifics.
+
+## The declaration family (`src/dblect/types/`, `contracts/`, `check/`)
+
+The declaration family is the static realization of the semantic-types and typed-contract DSL from [docs/design/](../design/). It is the half of the analyzer that catches meaning shifts rather than SQL-shape hazards, and it runs through the same lineage substrate as the structural family.
+
+- [**`types/`**](../../src/dblect/types/): the domain-type DSL. `DomainType` is a Pydantic-shaped class whose fields are typed scalars (`Decimal(18, 2)`, enums, ...); `refine(...)` pins parameters to make a refinement (`Money.refine(currency=USD)`). `bridge.py` lowers a declared type into the facts the substrate grounds from.
+- [**`contracts/`**](../../src/dblect/contracts/): `ModelContract` binds a domain type to a dbt model's columns; `@contract`-decorated methods build boolean expressions over column proxies (`proxy.py`, `ast.py`, `compile.py`) without importing sqlglot. `stubs.py` generates the editor `models` stubs `dblect init` writes.
+- [**`check/`**](../../src/dblect/check/): `run_check` resolves the declarations against the manifest, propagates two properties over the substrate (a relation-scoped **functional-dependency** property, then a column-scoped **domain-type** property that reads it), and lets the findings fall out of what the substrate concluded: a declaration that does not resolve is a `CONTRACT_ISSUE`; a column whose inferred type contradicts its declared type is a `DOMAIN_TYPE_CONTRADICTION` (currency creep) reported wherever the taint reached; a reduction over one field of a multi-field type whose other fields are not held constant is an `AGGREGATION_NOT_WELL_TYPED` (the mixed-currency sum). `coverage.py` reports resolution and grounding so a clean report cannot hide thin coverage; `RESOLUTION_BELOW_FLOOR` fires when lineage resolves too little of the project.
+
+Contract predicates (the `@contract` method bodies) are **collected and counted, not executed** today: running them needs materialized data, which belongs to the runtime loop. The static check stays static, so this family verifies type *propagation* and *coherence*, not value-level contract satisfaction.
+
+`varinf/` sits alongside as a discovery pass: it walks source Jinja for `var()` / `env_var()` usage and builds a typed environment. It is the scaffolding the flag-world layer will enumerate over; it does not emit findings yet.
+
 ## The lineage substrate (`src/dblect/lineage/`)
 
 Most SQL footguns only become visible when you know where a column's *values* came from. Does this `LEFT JOIN ... WHERE upstream NOT IN (...)` silently drop rows because some upstream value is NULL? Is the column you're ranking on actually unique in the source, or did a CTE reshuffle it? Did an aggregate flatten away a key the next window function expects? Answering any of these means walking back from an output column, through the model graph, to the real source columns its values originated in, and reasoning about what happened along the way.
@@ -383,13 +416,12 @@ Strict pyright and ruff in CI. The detectors, uniqueness layer, and suppression 
 
 ## What's deliberately not here yet
 
-Forward-looking pieces that are designed but not built. See [docs/design/](../design/) for each:
+Forward-looking pieces that are designed but not built. The semantic-types DSL, the `@contract` declaration layer, `dblect init` with stub generation, and var/env_var discovery have all landed since the first draft of this doc; what remains unbuilt is the entire **runtime half** and the operator-facing tooling around it. See [docs/design/](../design/) for each, and [capabilities.md](./capabilities.md) for the full built-vs-unbuilt ledger:
 
-- **Semantic types** and the typed-contract DSL (the semantic-types and focused-contracts layers in the design docs).
-- **Runtime checks**: replay-determinism via differential execution, heuristic invariants (row-count sanity, PK uniqueness, monotonicity), generator-driven structural PBT.
-- **Generator framework**: contract-directed generation, intent catalog, multi-table coordinated generation.
-- **Flag/var inference**: discovering dbt vars from SQL and scaffolding typed flag declarations.
-- **`dblect init`**: scaffolds `dblect/`, generates editor stubs from the manifest, integrates with the project's package manager.
-- **MCP server**, **HTML reports**, **SARIF output**, **YAML suppression config**.
+- **Contract verification (execution)**: `dblect check` *collects and counts* contract predicates today but does not run them. Executing a contract needs materialized data, which is the runtime loop below.
+- **Runtime checks**: replay-determinism via differential execution, heuristic invariants (row-count sanity, PK uniqueness, monotonicity), generator-driven structural PBT. The DuckDB execution harness exists but is not on the check path.
+- **Generator framework**: contract-directed generation, intent catalog, multi-table coordinated generation. This is the largest single body of remaining work.
+- **Flag/var worlds on the check path**: var/env_var *discovery* ships (`varinf/`), and fact-level flag-world plumbing is wired, but world enumeration and per-contract world scoping do not yet drive findings (issues #98–#100).
+- **MCP server**, **HTML reports**, **SARIF output**, **YAML suppression config**, **change-impact / flag-flip preflight CLI**.
 
 Each of those is its own body of work. The current static analyzer is independent of them. It's the layer everything else builds on top of.

--- a/docs/current_state/capabilities.md
+++ b/docs/current_state/capabilities.md
@@ -1,0 +1,77 @@
+# dblect: capabilities and the road to 0.1.0
+
+A capability-by-capability ledger of what works end to end today, what is scaffolded but not yet load-bearing, and what a first usable release still needs. [architecture.md](./architecture.md) describes how the built pieces fit together; this document is the status view. The vision and the layered investment model live in [docs/dblect-overview.md](../dblect-overview.md) and [docs/design/tiers_and_rough_implementation_order.md](../design/tiers_and_rough_implementation_order.md).
+
+## The shape of the project
+
+The vision has two complementary halves: a **static** analyzer that reasons about the dbt DAG without running anything, and a **runtime** half that generates data and executes models to find value-level bugs. The static half is substantially built and works against real projects. The runtime half is designed but not built.
+
+## What works end to end today
+
+Run `dblect check <project>` and it does all of this in one pass, in seconds, with no execution and no LLM:
+
+**Structural hazard detectors (zero declarations required).** Twelve checks over compiled SQL, each pinned to a file and line:
+
+- ordering hazards: unordered ranking windows, unordered aggregates (`ARRAY_AGG`/`STRING_AGG` with no `ORDER BY`)
+- join hazards: join fanout against declared/inferred keys, `COALESCE` on a join key, `WHERE` on an outer-joined nullable column (silent inner-join), join on a nullable key
+- NULL hazards: `GROUP BY` collapsing unmatched rows into a NULL group (syntactic and lineage-aware variants), `NOT IN` over a nullable subquery
+- determinism: non-deterministic builtins (`now()`, `random()`, ...) in load-bearing positions, adapter-aware
+- window-key soundness: ranking windows whose order keys are not unique over their scope
+- snapshot temporal-filter-missing
+
+**The meaning-shift checker (the headline capability).** With domain types declared on the columns that matter, `dblect check` propagates types along the DAG and catches the canonical bug the project exists for: a column's semantic type flipping upstream (revenue net to gross, currency creep) so a downstream contract no longer holds. This is the `domain_type_contradiction` finding, and it fires at PR-review time with no data and no execution. The `aggregation_not_well_typed` finding catches the mixed-currency-sum class. Demonstrated end to end by the `currency_creep` scenario fixture.
+
+**The supporting machinery, all built and tested:**
+
+- the lineage substrate: one K-relations property propagator carrying where-provenance, nullability, uniqueness, functional-dependency, and domain-type properties over column- and relation-scoped graphs
+- conditional facts: `where`-filtered dbt tests captured with their predicate and activated through a sound implication engine
+- the domain-type DSL: `DomainType`, refinements, typed scalars, `ModelContract`, `@contract` methods over column proxies, and the fact bridge
+- incremental worlds: an incremental model is compiled both ways (full-refresh and steady-state) and the detectors run over each, catching hazards that live only in the unexercised branch
+- adapter profiles: per-warehouse dialect, write-enforcement, and hazardous-builtin knowledge behind a registry
+- `dblect init`: scaffolds the `dblect/` tree and generates editor stubs from the manifest
+- `dblect check`: text and JSON (documented schema) reporters, coverage reporting, `-- noqa-fixture:` suppression, a resolution floor so thin coverage cannot read as a clean bill
+- catalog.json ingestion for seed/source leaf columns; nested-field (STRUCT) lineage
+- var/env_var discovery from source Jinja (`varinf`)
+
+822 tests pass, including property-based tests for DAG topology, semiring laws, lineage propagation, and an execution-oracle soundness PBT for uniqueness. Strict pyright and ruff in CI.
+
+## Scaffolded but not yet load-bearing
+
+- **Flag/config worlds (the multi-world-under-flags analysis).** The engine is real and tested: `enumerate_worlds` / `check_worlds` lower a set of compile-time flags into worlds, run the properties per world, and report per-world findings and coverage. But it is **dark** today in two senses. It takes **hand-authored `DomainFlag`s** rather than flags discovered from the project, and it is **not wired into the `dblect check` CLI or the analysis door** — the check path runs the base world only (`worlds: 1 (base)`). The Jinja front end for var discovery has landed (`varinf`, PR #104) and the manifest macro registry is in place (#103), but the rest of the pipeline that would light this up on a real project (macro-following, the control-flow-vs-value-substitution classifier, domain inference, `dblect scaffold flags`, and the CLI wiring that reads the scaffolded flag file) is still ahead. See issue #98 and the design under `docs/design/var-inference/` (PR #102, design-only). Per-contract world scoping (#99) and control-flow world evaluation (#100) sit on top of it. Flag-flip preflight depends on the whole stack.
+- **The DuckDB execution harness.** `execution/run.py` runs dbt models against ephemeral DuckDB and reads results back. It powers the incremental-world compiler and tests, but is **not on the `dblect check` path**. It is the substrate the runtime layer will sit on.
+- **Contract predicates.** `@contract` method bodies are collected and counted, not executed. Verifying them needs materialized data.
+
+## Not built: the runtime half
+
+This is genuinely greenfield and is the larger half of the original vision:
+
+- property-based execution: type-driven generators (Hegel/Hypothesis), structural PBT, heuristic invariants (row-count sanity, PK uniqueness, monotonicity, conservation)
+- replay-determinism via differential execution (run N times, diff under equivalence)
+- the generator framework: contract-directed generation, the intent catalog, multi-table coordinated FK-respecting generation, domain-aware shrinking. This is the single largest body of remaining work and where most of the implementation difficulty lives.
+- change-impact analysis and flag-flip preflight at PR time
+- the MCP server, HTML/SARIF reporting, `dblect show-case`
+
+## Distance to a usable 0.1.0
+
+The runtime half is months of work gated on the coordinated-generation crux, so it should not gate 0.1.0. That leaves a real scoping fork on the static side, turning on whether the **multi-world-under-flags analysis** is part of the basic vision the first release delivers.
+
+**Fork A: base-world static analyzer.** Single-world (base) analysis: the meaning-shift checker plus the dozen zero-declaration hazard detectors, packaged and hardened, with flag-worlds deferred. This runs in seconds with no execution and no LLM, so per-run cost is negligible, and it is independent of the var-inference work. It still needs:
+
+1. **A second validated warehouse adapter (Snowflake or BigQuery).** Today only `duckdb` is validated end to end; every real project on another warehouse trips the best-effort warning. This is the biggest real-world adoption blocker, because the target audience runs Snowflake/BigQuery, not DuckDB.
+2. **CI ergonomics.** SARIF output (#9), `--diff <base-ref>` to limit findings to changed lines (#10), and severity with a tunable fail threshold (#11). These are what let a team adopt it in CI without drowning in pre-existing findings on day one.
+3. **Source-line mapping.** Findings currently point at compiled-SQL line numbers; for macro-heavy models these diverge from the `.sql` the developer wrote. Back-mapping to source positions makes findings actionable.
+4. **Suppression for declaration findings** (#117), and a real-project shakedown beyond the jaffle and scenario fixtures to calibrate false-positive rates.
+5. **Packaging and distribution:** `pip install dblect`, a quickstart, and the `init` to first-finding path validated on an external project.
+
+None of these is a new subsystem; the work is breadth and hardening. Fork A is realistically **weeks of focused work**, dominated by item 1 and item 2.
+
+**Fork B: static analyzer with flag-world analysis.** If the powerful multi-world-under-flags analysis is a headline capability of the first release (and it is one of the more differentiated parts of the vision), then **var-inference (#98) is on the critical path**, not a deferrable polish item. The world engine already exists, but it is unusable on a real project until the project's flags can be *discovered and scaffolded* rather than hand-declared: a real project has hundreds of vars, most of which are not world axes, so the control-flow classifier is what makes enumeration tractable. Landing this means everything past the Jinja front end:
+
+- macro-following (expansion, cycle detection, symbolic conditional eval)
+- the three-way classifier (control-flow vs value-substitution vs computed) and domain/type inference
+- `dblect scaffold flags` (generate the `DomainFlag` file, with the user filling in the `affects` clause static analysis cannot infer)
+- wiring `check_worlds` into the `dblect check` CLI so it reads the scaffolded flag surface and reports per-world findings
+
+Today that pipeline is design-only (PR #102) past the discovery front end. It is a genuine body of work — call it the long pole of the static side, on the order of the original facts-substrate or domain-type efforts, not a few-day task. Fork B is therefore **meaningfully longer than Fork A**, plausibly the dominant cost of the release.
+
+**Recommendation.** Ship Fork A as 0.1.0 to get value in front of real projects quickly and cheaply, and treat flag-world analysis (Fork B) as the headline of a fast-following 0.1.x or 0.2.0 once var-inference lands. The base-world analyzer already delivers the meaning-shift capability the project exists for; flag-worlds deepen it but are not required for the first useful release. If instead flag-world analysis is considered non-negotiable for 0.1.0, plan the release around var-inference as its critical path and size it accordingly. The runtime half remains the 0.2.0+ arc in either case.


### PR DESCRIPTION
## Why

Taking stock of distance to a usable 0.1.0 surfaced that `current_state/architecture.md` had drifted into *underpromising*. It still described the semantic-types and typed-contract DSL as forward-looking/unbuilt, when that layer ships today as a static analysis (the declaration family: `domain_type_contradiction`, `aggregation_not_well_typed`), and it omitted several landed packages from the layout. Verified against the code: 822 tests pass, and `dblect check` catches the headline meaning-shift bug end to end on the `currency_creep` scenario.

## What changed

`architecture.md` (kept architectural):
- Intro and "deliberately not here yet" rescoped: the genuinely-unbuilt work is the **runtime half** (PBT execution, generators, coordinated generation, MCP) plus contract *execution*, not the DSL.
- Layout block filled in (`adapters/`, `nullability/`, `snapshot/`, `types/`, `contracts/`, `varinf/`, `demo/`).
- New architectural sections: the nullability layer, the snapshot detector, and the declaration family (`types/` → `contracts/` → `check/`, two-property propagation).

New `current_state/capabilities.md` (the status view, so architecture.md stays architecture):
- Capability-by-capability ledger: what works end to end today, what's scaffolded but not load-bearing, the unbuilt runtime half.
- Calls out that the **multi-world flag engine exists and is tested but is dark**: it takes hand-declared `DomainFlag`s and is not wired into the `dblect check` CLI (base world only today).
- Frames the 0.1.0 distance as a scoping fork: **Fork A** (base-world static analyzer, ~weeks, gated on a second validated adapter + CI ergonomics) vs **Fork B** (flag-world analysis as a headline, gated on the var-inference long pole, #98).

`docs/README.md`: index entries point at the new file; design-section preamble softened (several design docs have since landed as static implementations).

No code changes.