### PR TITLE
docs(readme): use `dblect check`, drop the unbuilt `audit` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,20 @@ The `left join` keeps every payment, even ones whose `order_id` finds no matchin
 The same pass also flags a `WHERE` on the nullable side of an outer join (silently inverts it to an inner join, dropping the very rows the outer join meant to keep), `COALESCE` on a join key (masks "no match" as a real value), window and `array_agg`/`string_agg` calls with no `ORDER BY` (nondeterministic output), nondeterministic builtins like `current_timestamp()` in join keys or partition clauses, joins that fan out because the joined-in side is not unique on the join key, and reads of a dbt snapshot with no temporal filter (you get every historical version of every row, not the current state). These need nothing declared: dblect uses whatever keys your `schema.yml` and native constraints already assert and stays quiet where it has no grounds to speak.
 
 ```
-$ dblect audit .
-audit: scanned 5 models, 1 finding
+$ dblect check .
+dblect: 1 finding over 5 models (0 contracts resolved, 5 scanned, 0 predicate(s) collected)
 
-models/customers.sql  (model.jaffle_shop.customers)
-  L44  null_group_after_outer_join
-      GROUP BY orders.customer_id references column(s) from nullable join side
-      (orders); unmatched rows collapse into a NULL group
-      snippet: orders.customer_id
+coverage:
+  resolution: 100.0% of columns (27/27)
+  grounding: domain_type 0/27; functional_dependency 0/5
+  contract columns checkable: 0/0
+  worlds: 1 (base); no flag axes enumerated
+
+structural findings:
+  models/customers.sql  (model.jaffle_shop.customers)
+    L44  null_group_after_outer_join
+        GROUP BY orders.customer_id references column(s) from nullable join side (orders); unmatched rows collapse into a NULL group
+        snippet: orders.customer_id
 ```
 
 ### You can suppress these warnings
@@ -56,8 +62,8 @@ Sometimes the catch-all bucket is on purpose: orphaned payments get pooled delib
 ```
 
 ```
-$ dblect audit .
-audit: scanned 5 models, 0 findings, 1 suppressed
+$ dblect check .
+dblect: 0 findings over 5 models (0 contracts resolved, 5 scanned, 0 predicate(s) collected)
 
 suppressed:
   models/customers.sql:L44  null_group_after_outer_join  -- unmatched payments are intentionally pooled; handled downstream
@@ -99,11 +105,11 @@ A single day holds payments in several currencies, so `sum(amount)` adds dollars
 
 ```
 $ dblect check .
-checked 1 contracts over 4 models: 1 finding
+dblect: 1 finding over 4 models (1 contracts resolved, 4 scanned, 0 predicate(s) collected)
 
-aggregation_not_well_typed  model.jaffle_shop.total_daily_revenue.revenue
-      reducing 'revenue' with sum(amount): its per-row companion 'currency' is not held
-      constant by grouping on 'order_date'; the aggregation is not well typed
+declaration findings:
+  aggregation_not_well_typed  model.jaffle_shop.total_daily_revenue.revenue
+      reducing 'revenue' with sum(amount): its per-row companion 'currency' is not held constant by grouping on 'order_date'; the aggregation is not well typed
       models/marts/total_daily_revenue.sql
 ```
 
@@ -144,12 +150,12 @@ Finding line numbers refer to the compiled SQL the analyzer parsed, not to the o
 Inside any dbt project:
 
 ```bash
-dblect audit .       # structural hazards, no declarations needed
+dblect check .       # structural hazards, zero declarations needed
 dblect init .        # scaffold dblect/ and generate editor stubs from your manifest
-dblect check .       # propagate the types you declare and report meaning-level findings
+dblect check .       # now also reports meaning-level findings from the types you declared
 ```
 
-`dblect audit` produces findings in under a minute on typical projects. From there, declare semantic types on the columns that matter and run `dblect check` in CI.
+`dblect check` produces structural findings in under a minute on typical projects, with no declarations required. From there, declare semantic types on the columns that matter and run `dblect check` in CI.
 
 See the [demo walkthrough](docs/design/demo_walkthrough.md) for an end-to-end tour against `jaffle_shop_duckdb`, and [docs/current_state/architecture.md](docs/current_state/architecture.md) for what is built today.
 

--- a/docs/dblect-overview.md
+++ b/docs/dblect-overview.md
@@ -4,7 +4,7 @@ A semantic correctness framework for dbt analytics pipelines. It adds a typed de
 
 ## Using it
 
-Run `dblect init` inside your dbt project. It scaffolds the `dblect/` directory, bootstraps dblect as a project dev dependency, parses your dbt project, generates editor stubs, and runs the zero-declaration audit. First real findings land in under a minute on typical projects, with zero declarations required. The audit catches ordering hazards, replay-determinism issues, and foreign-key fanout risks. `dblect audit` re-runs the audit on demand thereafter.
+Run `dblect init` inside your dbt project. It scaffolds the `dblect/` directory, bootstraps dblect as a project dev dependency, parses your dbt project, generates editor stubs, and runs the zero-declaration audit. First real findings land in under a minute on typical projects, with zero declarations required. The audit catches ordering hazards, replay-determinism issues, and foreign-key fanout risks. `dblect check` re-runs it on demand thereafter, and reports meaning-level findings once you declare types.
 
 From there:
 

--- a/docs/design/dblect_technical_intro.md
+++ b/docs/design/dblect_technical_intro.md
@@ -321,9 +321,9 @@ Registration happens via `__init_subclass__`. When the class definition is execu
 
 dblect consumes dbt's manifest as the single source of truth for project structure. Two integration patterns, both supported:
 
-*Pattern A (convenient default).* `dblect audit` invokes `dbt parse` if the manifest is stale, reads the resulting `target/manifest.json`, then loads dblect declarations. One command from the user's perspective. Adds `dbt-core` as a Python dependency.
+*Pattern A (convenient default).* `dblect check` invokes `dbt parse` if the manifest is stale, reads the resulting `target/manifest.json`, then loads dblect declarations. One command from the user's perspective. Adds `dbt-core` as a Python dependency.
 
-*Pattern B (explicit).* The user runs `dbt parse` (or any dbt command that writes a manifest) themselves; `dblect audit --manifest path/to/manifest.json` consumes the existing one. Uses `dbt-artifacts-parser` instead of full `dbt-core`. Fits well in CI environments where dbt and dblect run in separate stages.
+*Pattern B (explicit).* The user runs `dbt parse` (or any dbt command that writes a manifest) themselves; `dblect check --manifest path/to/manifest.json` consumes the existing one. Uses `dbt-artifacts-parser` instead of full `dbt-core`. Fits well in CI environments where dbt and dblect run in separate stages.
 
 The full load sequence:
 
@@ -342,7 +342,7 @@ parse manifest
 
 This approach needs no code generation, with the tradeoff that editors offer limited autocomplete on the proxy because `__getattr__` returns a generic type.
 
-For richer editor experience, the framework reads the manifest and writes a `dblect/_stubs/models.py` file with concrete class definitions. This happens automatically as part of `dblect init` and re-runs whenever the manifest changes (the next `dblect audit` or `dblect check` regenerates if stale):
+For richer editor experience, the framework reads the manifest and writes a `dblect/_stubs/models.py` file with concrete class definitions. This happens automatically as part of `dblect init` and re-runs whenever the manifest changes (the next `dblect check` regenerates if stale):
 
 ```python
 # auto-generated; do not edit

--- a/docs/design/demo_walkthrough.md
+++ b/docs/design/demo_walkthrough.md
@@ -44,7 +44,7 @@ $ dblect init
 [dblect] Parsing dbt project (dbt parse)... done in 1.8s
 [dblect] Generated stubs for 5 dbt models → dblect/_stubs/models.py
 
-[dblect] Running audit:
+[dblect] Running check:
   ✓ Static SQL analysis            5 models       0.4s
   ✓ Ambiguous-ordering detection   5 models       0.2s
   ✓ Replay determinism             5/5 ran        2.1s
@@ -63,10 +63,10 @@ $ dblect init
           Suggested: filter `where orders.customer_id is not null` before the
                      GROUP BY, or declare the orphan-handling intent explicitly.
 
-[dblect] Full report: .dblect/audit-2026-05-20-101522.html
+[dblect] Full report: .dblect/check-2026-05-20-101522.html
 
 [dblect] Next steps:
-  • Re-run audit anytime:  dblect audit
+  • Re-run anytime:        dblect check
   • Declare types:         edit dblect/types.py
   • Add contracts:         dblect focus <model>
 ```

--- a/docs/design/tiers_and_rough_implementation_order.md
+++ b/docs/design/tiers_and_rough_implementation_order.md
@@ -24,7 +24,7 @@ The user's interaction is one command:
 dblect init
 ```
 
-`dblect init` scaffolds the project (lays down `dblect/`, adds dblect to the project's dependency manifest, runs the package manager, generates editor stubs from the manifest), parses dbt, and runs the audit end-to-end. First findings land in under a minute on typical projects. Subsequent runs use `dblect audit` (re-runs the audit on the existing scaffolding) or `dblect check` (the contracts pipeline introduced once contracts are declared).
+`dblect init` scaffolds the project (lays down `dblect/`, adds dblect to the project's dependency manifest, runs the package manager, generates editor stubs from the manifest), parses dbt, and runs the audit end-to-end. First findings land in under a minute on typical projects. Subsequent runs use `dblect check`, which runs the structural audit immediately and adds the declaration-level contract checks once contracts are declared.
 
 Internally, dblect does the following:
 
@@ -249,7 +249,7 @@ A few capabilities apply across all layers rather than belonging to one:
 
 **MCP server.** Exposes dblect's analytical primitives as tools for LLM-environment integration: `read_dbt_manifest`, `analyze_model`, `propose_focus_chain`, `run_audit`, `check_contracts`, `generate_counterexample`. Lets Claude Code or any agentic environment drive declaration drafting, audit triage, contract setup. Independent of the CLI; same primitives, different interface.
 
-**CLI.** Standalone CLI for headless and CI use. v1 verbs: `init` (bootstrap-to-first-findings, one shot), `audit` (re-run the audit), `check` (run contracts once they are declared, with `--flag-world` for selecting subsets), `show-case` (materialize a stored counterexample locally). `focus` (interactive contract drafting) and `impact --flag X` (flag-flip preflight) are slotted but deferred. Required for CI integration; sufficient for users who prefer not to drive via an LLM environment.
+**CLI.** Standalone CLI for headless and CI use. v1 verbs: `init` (bootstrap-to-first-findings, one shot), `check` (run the structural audit immediately and the contract checks once contracts are declared, with `--flag-world` for selecting subsets), `show-case` (materialize a stored counterexample locally). `focus` (interactive contract drafting) and `impact --flag X` (flag-flip preflight) are slotted but deferred. Required for CI integration; sufficient for users who prefer not to drive via an LLM environment.
 
 **Ignore mechanism.** Findings can be muted via `# noqa-fixture: <reason>` comments (the canonical syntax, same flavor as `# noqa: ...` in linters) or YAML config entries. Requires a reason; muted findings are reviewable in PR; mutes don't silently propagate.
 
@@ -275,7 +275,7 @@ Order respects dependencies. Each milestone ends in a state where dblect does so
 7. **Equivalence-aware diffing.** Multiset, order-up-to-ties, set equivalence. Becomes load-bearing in later phases.
 8. **Replay determinism via differential execution.**
 9. **Static ambiguous-ordering detection.** Pattern matching on the SQL AST.
-10. **Report generation, ignore mechanism (`# noqa-fixture`), CLI basics (`init`, `audit`).**
+10. **Report generation, ignore mechanism (`# noqa-fixture`), CLI basics (`init`, `check`).**
 
 **Milestone:** `dblect init` ships against real dbt projects, finds real bugs end-to-end.
 


### PR DESCRIPTION
The CLI registers `version`, `check`, and `init` — there is no `audit` command. But the README invoked `dblect audit` in both "What it catches" examples and as the first line of Quick Start, so a friendly dev's very first command errored with `No such command 'audit'`. `check` is the single analysis command: it runs the structural hazards immediately and adds meaning-level findings once types are declared.

## Changes

- Replace every `dblect audit` invocation with `dblect check`.
- Rewrite Quick Start as the progressive single-command story: `check` (structural, zero declarations) -> `init` (scaffold) -> declare types -> `check` (now meaning-level too).
- Regenerate the three example outputs from **real** `dblect check` runs against the bundled fixtures, so the summary line, coverage block, and finding format match what the tool actually prints. The prior outputs were hand-written with a made-up summary shape (`audit: scanned 5 models, 1 finding`, `checked 1 contracts over 4 models: 1 finding`); verified verbatim against `tests/fixtures/jaffle` and the `total_daily_revenue` scenario.
- Similar changes made to design docs that referenced the `dblect audit` command

Conceptual uses of "audit" (the zero-declaration audit, the structural audit) are unchanged; only the command name moves.
