### PR TITLE
perf(tests): cut suite time by reusing duckdb, merging seed+run, parallelising CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,9 @@ jobs:
         run: uv run pyright
 
       - name: Tests (pytest with coverage)
-        run: uv run pytest --cov --cov-report=term-missing --cov-report=xml
+        # -n auto parallelises across the runner's cores; loadscope keeps each module on
+        # one worker so the module-scoped dbt-compile fixtures still run once apiece.
+        run: uv run pytest -n auto --dist loadscope --cov --cov-report=term-missing --cov-report=xml
 
       - name: Upload coverage artifact
         if: matrix.python-version == '3.13'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dev = [
     # See the cap rationale under [project.optional-dependencies] (parser #219).
     "dbt-core>=1.8,<1.11.8",
     "dbt-duckdb>=1.8",
+    "pytest-xdist>=3.6",
 ]
 
 [tool.hatch.version]

--- a/src/dblect/execution/run.py
+++ b/src/dblect/execution/run.py
@@ -10,9 +10,12 @@ The contract:
   fixture map (seed/source name → list of row dicts), copies the project to
   a temporary working directory, writes any provided fixtures into ``seeds/``
   as CSV, writes a generated ``profiles.yml`` pointing at an ephemeral
-  DuckDB file, runs ``dbt seed`` then ``dbt run --select +<model>``, and
-  finally reads the produced table back through the DuckDB driver.
-* Subprocess failures during seed or run raise `RunError`, carrying the
+  DuckDB file, runs ``dbt build --select +<model>`` (seeds and models build
+  together in DAG order; data and unit tests are excluded so a declared test
+  never gates materialisation), and finally reads the produced table back
+  through the DuckDB driver. One ``dbt build`` invocation replaces a separate
+  ``dbt seed`` and ``dbt run``, so the project is parsed once rather than twice.
+* Subprocess failures during the build raise `RunError`, carrying the
   phase, exit code, stdout, and stderr. Compilation errors, missing
   upstreams, and SQL errors all surface this way: dbt formats them into
   stderr and we don't swallow it.
@@ -47,8 +50,7 @@ from dblect.execution.project_env import (
 class Phase(StrEnum):
     """Which stage of `run_model` failed when a `RunError` was raised."""
 
-    SEED = "seed"
-    RUN = "run"
+    BUILD = "build"
     QUERY = "query"
 
 
@@ -75,10 +77,8 @@ class RunResult:
     model_name: str
     columns: tuple[str, ...]
     rows: tuple[tuple[Any, ...], ...]
-    seed_stdout: str
-    seed_stderr: str
-    run_stdout: str
-    run_stderr: str
+    build_stdout: str
+    build_stderr: str
 
     @property
     def row_count(self) -> int:
@@ -107,8 +107,8 @@ def run_model(
         model_name: dbt name of the model to materialise (e.g., ``"customers"``).
             Upstream seeds and models are built automatically via the ``+`` selector.
         fixtures: Optional mapping of seed name → list of row dicts. Each
-            mapped seed is rewritten as a CSV under ``seeds/`` before
-            ``dbt seed`` runs; unmapped seeds use the project's existing CSVs.
+            mapped seed is rewritten as a CSV under ``seeds/`` before the
+            build runs; unmapped seeds use the project's existing CSVs.
         profile_name: Profile name to write into the generated ``profiles.yml``.
             Defaults to the ``profile:`` value in ``dbt_project.yml``.
         dbt_executable: Path or name of the dbt CLI. Useful when dbt is
@@ -118,11 +118,11 @@ def run_model(
 
     Returns:
         A `RunResult` carrying the model's columns, rows, and the captured
-        seed/run subprocess output.
+        ``dbt build`` subprocess output.
 
     Raises:
-        RunError: If ``dbt seed`` or ``dbt run`` returns non-zero, or if the
-            produced table can't be read from DuckDB.
+        RunError: If ``dbt build`` returns non-zero, or if the produced table
+            can't be read from DuckDB.
         FileNotFoundError: If `project_dir` doesn't exist or doesn't contain
             ``dbt_project.yml``.
     """
@@ -147,27 +147,27 @@ def run_model(
 
         env = {**os.environ, "DBT_PROFILES_DIR": str(profiles_dir)}
 
-        seed_proc = run_dbt(
-            dbt_executable,
-            ["seed", "--project-dir", str(work_project)],
-            env=env,
-        )
-        if seed_proc.returncode != 0:
-            raise RunError(Phase.SEED, seed_proc.returncode, seed_proc.stdout, seed_proc.stderr)
-
-        run_proc = run_dbt(
+        # One `dbt build` seeds and runs the model's ancestry in DAG order. Data and
+        # unit tests are excluded so a declared test failing on the materialised rows
+        # never blocks the run; the harness reports the table, and the analysis layer
+        # judges it.
+        build_proc = run_dbt(
             dbt_executable,
             [
-                "run",
+                "build",
                 "--project-dir",
                 str(work_project),
                 "--select",
                 f"+{model_name}",
+                "--exclude-resource-type",
+                "test",
+                "--exclude-resource-type",
+                "unit_test",
             ],
             env=env,
         )
-        if run_proc.returncode != 0:
-            raise RunError(Phase.RUN, run_proc.returncode, run_proc.stdout, run_proc.stderr)
+        if build_proc.returncode != 0:
+            raise RunError(Phase.BUILD, build_proc.returncode, build_proc.stdout, build_proc.stderr)
 
         try:
             columns, rows = _query_table(duckdb_path, model_name)
@@ -182,10 +182,8 @@ def run_model(
             model_name=model_name,
             columns=columns,
             rows=rows,
-            seed_stdout=seed_proc.stdout,
-            seed_stderr=seed_proc.stderr,
-            run_stdout=run_proc.stdout,
-            run_stderr=run_proc.stderr,
+            build_stdout=build_proc.stdout,
+            build_stderr=build_proc.stderr,
         )
 
 

--- a/tests/execution/test_run.py
+++ b/tests/execution/test_run.py
@@ -78,16 +78,15 @@ def test_run_error_surfaces_dbt_compile_failure(jaffle_project_dir: Path, tmp_pa
 
     broken = tmp_path / "broken_project"
     shutil.copytree(jaffle_project_dir, broken)
-    # Break customers.sql so dbt-compile / dbt-run fails loudly.
+    # Break customers.sql so the dbt build fails loudly.
     customers = broken / "models" / "customers.sql"
     customers.write_text("select * from {{ ref('does_not_exist') }}")
 
     with pytest.raises(RunError) as excinfo:
         run_model(broken, "customers")
-    # dbt parses the full project at the start of every subcommand, so a
-    # broken `ref` surfaces during `dbt seed` (the first thing we run)
-    # rather than waiting for `dbt run`.
-    assert excinfo.value.phase is Phase.SEED
+    # dbt parses the full project before doing any work, so a broken `ref`
+    # surfaces while the single `dbt build` is starting up.
+    assert excinfo.value.phase is Phase.BUILD
     assert excinfo.value.returncode != 0
 
 

--- a/tests/lineage/_duckdb_oracle.py
+++ b/tests/lineage/_duckdb_oracle.py
@@ -24,24 +24,34 @@ Table = tuple[str, tuple[str, ...], Sequence[Sequence[object]]]
 
 @contextmanager
 def materialized(
-    tables: Sequence[Table], model_sql: str
+    con: duckdb.DuckDBPyConnection, tables: Sequence[Table], model_sql: str
 ) -> Generator[duckdb.DuckDBPyConnection, None, None]:
-    """Create ``tables`` in an in-memory duckdb, materialize ``model_sql`` as ``_m``,
-    and yield the connection for the caller to query. The connection is closed on exit.
+    """Create ``tables`` on ``con``, materialize ``model_sql`` as ``_m``, and yield the
+    connection for the caller to query.
+
+    The connection is shared across Hypothesis examples (the ``oracle_con`` fixture), so
+    tables are created with ``CREATE OR REPLACE`` and dropped on exit: each example sees
+    a clean slate without paying to open a fresh in-memory database, which dominated
+    these PBTs' runtime.
     """
-    con = duckdb.connect(":memory:")
+    created: list[str] = []
     try:
         for name, cols, rows in tables:
-            con.execute(f"CREATE TABLE {name} ({', '.join(f'{c} INTEGER' for c in cols)})")
+            con.execute(
+                f"CREATE OR REPLACE TABLE {name} ({', '.join(f'{c} INTEGER' for c in cols)})"
+            )
+            created.append(name)
             if rows:
                 placeholders = ", ".join(["?"] * len(cols))
                 con.executemany(
                     f"INSERT INTO {name} VALUES ({placeholders})", [list(r) for r in rows]
                 )
-        con.execute(f"CREATE TABLE _m AS {model_sql}")
+        con.execute(f"CREATE OR REPLACE TABLE _m AS {model_sql}")
+        created.append("_m")
         yield con
     finally:
-        con.close()
+        for name in reversed(created):
+            con.execute(f"DROP TABLE IF EXISTS {name}")
 
 
 def scalar(con: duckdb.DuckDBPyConnection, query: str) -> int:

--- a/tests/lineage/conftest.py
+++ b/tests/lineage/conftest.py
@@ -1,0 +1,24 @@
+"""Fixtures shared by the lineage soundness PBTs.
+
+The empirical soundness PBTs each run hundreds of Hypothesis examples, and every
+example materializes a tiny model in duckdb. Opening a fresh in-memory database per
+example dominated their runtime, so the examples share one connection for the whole
+session and clean their tables up between materializations (see ``_duckdb_oracle``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import duckdb
+import pytest
+
+
+@pytest.fixture(scope="session")
+def oracle_con() -> Iterator[duckdb.DuckDBPyConnection]:
+    """One in-memory duckdb connection reused across every soundness-PBT example."""
+    con = duckdb.connect(":memory:")
+    try:
+        yield con
+    finally:
+        con.close()

--- a/tests/lineage/test_pbt_domain_type_soundness.py
+++ b/tests/lineage/test_pbt_domain_type_soundness.py
@@ -131,11 +131,10 @@ def _predicted_factor(dimension: Dimension) -> float:
     return factor
 
 
-def _materialize(s: Scenario, *, scaled: bool) -> list[float]:
-    con = duckdb.connect(":memory:")
+def _materialize(con: duckdb.DuckDBPyConnection, s: Scenario, *, scaled: bool) -> list[float]:
     try:
         cols_ddl = ", ".join(f"{c} DOUBLE" for c in s.columns)
-        con.execute(f"CREATE TABLE t (rid INTEGER, {cols_ddl})")
+        con.execute(f"CREATE OR REPLACE TABLE t (rid INTEGER, {cols_ddl})")
         placeholders = ", ".join(["?"] * (len(s.columns) + 1))
         payload = [
             [
@@ -151,16 +150,18 @@ def _materialize(s: Scenario, *, scaled: bool) -> list[float]:
         result = con.execute(f"SELECT r FROM ({_model_sql(s)}) sub ORDER BY rid").fetchall()
         return [float(r[0]) for r in result]
     finally:
-        con.close()
+        con.execute("DROP TABLE IF EXISTS t")
 
 
 def _scale_value(value: float, currency: str, scaled: bool) -> float:
     return value * _SCALES[currency] if scaled else value
 
 
-@given(_scenario())
+@given(s=_scenario())
 @settings(max_examples=400, deadline=None, suppress_health_check=[HealthCheck.too_slow])
-def test_dimension_claim_predicts_unit_rescaling(s: Scenario) -> None:
+def test_dimension_claim_predicts_unit_rescaling(
+    oracle_con: duckdb.DuckDBPyConnection, s: Scenario
+) -> None:
     """The analyzer's output dimension predicts exactly how the materialized result
     transforms under independent rescaling of the declared units, with naked columns held
     fixed (the analyzer claimed nothing about them). A conflict or naked output carries no
@@ -169,8 +170,8 @@ def test_dimension_claim_predicts_unit_rescaling(s: Scenario) -> None:
     if not isinstance(value, Tagged) or not isinstance(value.dimension, Dimension):
         return  # conflict (mixed currency), naked, or polymorphic: no monomial to witness
     factor = _predicted_factor(value.dimension)
-    raw = _materialize(s, scaled=False)
-    rescaled = _materialize(s, scaled=True)
+    raw = _materialize(oracle_con, s, scaled=False)
+    rescaled = _materialize(oracle_con, s, scaled=True)
     assert len(raw) == len(rescaled)
     for original, scaled_result in zip(raw, rescaled, strict=True):
         expected = original * factor

--- a/tests/lineage/test_pbt_functional_dependency_soundness.py
+++ b/tests/lineage/test_pbt_functional_dependency_soundness.py
@@ -131,10 +131,11 @@ def _claimed(s: Scenario) -> FDSet:
     return anns[_MODEL].value
 
 
-def _materialize(s: Scenario) -> tuple[tuple[str, ...], list[tuple[object, ...]]]:
-    con = duckdb.connect(":memory:")
+def _materialize(
+    con: duckdb.DuckDBPyConnection, s: Scenario
+) -> tuple[tuple[str, ...], list[tuple[object, ...]]]:
     try:
-        con.execute("CREATE TABLE t (g INTEGER, x INTEGER, y INTEGER)")
+        con.execute("CREATE OR REPLACE TABLE t (g INTEGER, x INTEGER, y INTEGER)")
         if s.rows:
             con.executemany("INSERT INTO t VALUES (?, ?, ?)", [list(r) for r in s.rows])
         cursor = con.execute(_model_sql(s))
@@ -143,7 +144,7 @@ def _materialize(s: Scenario) -> tuple[tuple[str, ...], list[tuple[object, ...]]
         names = tuple(str(d[0]).lower() for d in description)
         return names, [tuple(r) for r in cursor.fetchall()]
     finally:
-        con.close()
+        con.execute("DROP TABLE IF EXISTS t")
 
 
 def _fd_holds(
@@ -162,16 +163,18 @@ def _fd_holds(
     return None
 
 
-@given(_scenario())
+@given(s=_scenario())
 @settings(max_examples=300, deadline=None, suppress_health_check=[HealthCheck.too_slow])
-def test_every_claimed_fd_holds_on_the_data(s: Scenario) -> None:
+def test_every_claimed_fd_holds_on_the_data(
+    oracle_con: duckdb.DuckDBPyConnection, s: Scenario
+) -> None:
     claimed = _claimed(s)
     assert not claimed.is_bottom
     if s.group_cols:
         # Anti-vacuity: a GROUP BY always yields at least the group-key dependency,
         # so a walk that silently claims nothing cannot pass on silence alone.
         assert claimed.fds
-    names, rows = _materialize(s)
+    names, rows = _materialize(oracle_con, s)
     for fd in claimed.fds:
         assert {fd.dependent, *fd.determinant} <= set(names), (
             f"claimed FD names a column the result lacks: {fd} vs {names} for sql={_model_sql(s)!r}"
@@ -305,11 +308,12 @@ def _join_claimed(s: JoinScenario) -> FDSet:
     return anns[_JOIN_MODEL].value
 
 
-def _join_materialize(s: JoinScenario) -> tuple[tuple[str, ...], list[tuple[object, ...]]]:
-    con = duckdb.connect(":memory:")
+def _join_materialize(
+    con: duckdb.DuckDBPyConnection, s: JoinScenario
+) -> tuple[tuple[str, ...], list[tuple[object, ...]]]:
     try:
-        con.execute("CREATE TABLE pay (k INTEGER, a INTEGER)")
-        con.execute("CREATE TABLE dim (k INTEGER, g INTEGER, v INTEGER)")
+        con.execute("CREATE OR REPLACE TABLE pay (k INTEGER, a INTEGER)")
+        con.execute("CREATE OR REPLACE TABLE dim (k INTEGER, g INTEGER, v INTEGER)")
         if s.rows_pay:
             con.executemany("INSERT INTO pay VALUES (?, ?)", [list(r) for r in s.rows_pay])
         if s.rows_dim:
@@ -320,12 +324,15 @@ def _join_materialize(s: JoinScenario) -> tuple[tuple[str, ...], list[tuple[obje
         names = tuple(str(d[0]).lower() for d in description)
         return names, [tuple(r) for r in cursor.fetchall()]
     finally:
-        con.close()
+        con.execute("DROP TABLE IF EXISTS pay")
+        con.execute("DROP TABLE IF EXISTS dim")
 
 
-@given(_join_scenario())
+@given(s=_join_scenario())
 @settings(max_examples=300, deadline=None, suppress_health_check=[HealthCheck.too_slow])
-def test_every_claimed_join_fd_holds_on_the_data(s: JoinScenario) -> None:
+def test_every_claimed_join_fd_holds_on_the_data(
+    oracle_con: duckdb.DuckDBPyConnection, s: JoinScenario
+) -> None:
     claimed = _join_claimed(s)
     assert not claimed.is_bottom
     selected = dict(s.projection)
@@ -342,7 +349,7 @@ def test_every_claimed_join_fd_holds_on_the_data(s: JoinScenario) -> None:
             # The padded side's drop is the contract: NULL padding can break the
             # dependency, so the walk must stay silent about it.
             assert out_fd not in claimed.fds, f"padded-side FD claimed for sql={_join_sql(s)!r}"
-    names, rows = _join_materialize(s)
+    names, rows = _join_materialize(oracle_con, s)
     for fd in claimed.fds:
         assert {fd.dependent, *fd.determinant} <= set(names), (
             f"claimed FD names a column the result lacks: {fd} vs {names} for sql={_join_sql(s)!r}"

--- a/tests/lineage/test_pbt_nullability_soundness.py
+++ b/tests/lineage/test_pbt_nullability_soundness.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+import duckdb
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
@@ -136,9 +137,11 @@ def _manifest(s: NullScenario) -> Manifest:
     )
 
 
-@given(_null_scenario())
+@given(s=_null_scenario())
 @settings(max_examples=300, deadline=None, suppress_health_check=[HealthCheck.too_slow])
-def test_non_null_columns_are_never_null_over_materialized_rows(s: NullScenario) -> None:
+def test_non_null_columns_are_never_null_over_materialized_rows(
+    oracle_con: duckdb.DuckDBPyConnection, s: NullScenario
+) -> None:
     """Every output column the analyzer calls NON_NULL has no nulls in the duckdb
     materialization. The check never recomputes which columns should be nullable; the
     data is the judge."""
@@ -148,7 +151,7 @@ def test_non_null_columns_are_never_null_over_materialized_rows(s: NullScenario)
         c for c in _OUTPUT_COLS if anns[ColumnRef(model, c)].value is Nullability.NON_NULL
     ]
     tables: list[Table] = [("bt", ("bk", "bv"), s.rows_bt), ("jt", ("jk", "jv"), s.rows_jt)]
-    with materialized(tables, _null_sql(s)) as con:
+    with materialized(oracle_con, tables, _null_sql(s)) as con:
         for col in non_null_cols:
             nulls = scalar(con, f"SELECT COUNT(*) FROM _m WHERE {col} IS NULL")
             assert nulls == 0, (

--- a/tests/lineage/test_pbt_uniqueness_soundness.py
+++ b/tests/lineage/test_pbt_uniqueness_soundness.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 
+import duckdb
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
@@ -72,10 +73,15 @@ def _promoted_keys(manifest: Manifest) -> frozenset[Key]:
     return activated[SourceRef(SourceKind.MODEL, _MODEL_UID)].keys
 
 
-def _assert_keys_sound(tables: Sequence[Table], model_sql: str, keys: frozenset[Key]) -> None:
+def _assert_keys_sound(
+    con: duckdb.DuckDBPyConnection,
+    tables: Sequence[Table],
+    model_sql: str,
+    keys: frozenset[Key],
+) -> None:
     """Materialize ``tables`` and the model in duckdb; assert every key in ``keys`` has
     as many distinct key tuples as the model has rows (so it is genuinely unique)."""
-    with materialized(tables, model_sql) as con:
+    with materialized(con, tables, model_sql) as con:
         total = scalar(con, "SELECT COUNT(*) FROM _m")
         for key in keys:
             cols = ", ".join(sorted(key))
@@ -259,9 +265,11 @@ def _scenario_manifest(s: Scenario) -> Manifest:
     )
 
 
-@given(_scenario())
+@given(s=_scenario())
 @settings(max_examples=300, deadline=None, suppress_health_check=[HealthCheck.too_slow])
-def test_unconditional_promoted_keys_are_unique_over_materialized_rows(s: Scenario) -> None:
+def test_unconditional_promoted_keys_are_unique_over_materialized_rows(
+    oracle_con: duckdb.DuckDBPyConnection, s: Scenario
+) -> None:
     """Every key the analyzer promotes for a filter/join/group/distinct model is
     genuinely unique over the duckdb-materialized rows. The test never recomputes
     which keys should survive; the data is the judge."""
@@ -271,7 +279,7 @@ def test_unconditional_promoted_keys_are_unique_over_materialized_rows(s: Scenar
         assert key <= output_cols, f"key {sorted(key)} not in outputs {sorted(output_cols)}"
     data_by_name = dict(s.data)
     tables: list[Table] = [(src.name, src.columns, data_by_name[src.name]) for src in s.sources]
-    _assert_keys_sound(tables, _scenario_sql(s.model), keys)
+    _assert_keys_sound(oracle_con, tables, _scenario_sql(s.model), keys)
 
 
 # --- conditional activation -------------------------------------------------------
@@ -341,13 +349,15 @@ def _cond_manifest(s: CondScenario) -> Manifest:
     )
 
 
-@given(_cond_scenario())
+@given(s=_cond_scenario())
 @settings(max_examples=300, deadline=None, suppress_health_check=[HealthCheck.too_slow])
-def test_conditionally_activated_keys_are_unique_over_materialized_rows(s: CondScenario) -> None:
+def test_conditionally_activated_keys_are_unique_over_materialized_rows(
+    oracle_con: duckdb.DuckDBPyConnection, s: CondScenario
+) -> None:
     """A conditional ``unique`` key promoted by activation is genuinely unique over the
     materialized rows. The source data honors the conditional declaration, so an
     over-eager activation (promoting the key when the model filter does not restrict to
     the predicate subset) surfaces as a duplicate the data check catches."""
     keys = _promoted_keys(_cond_manifest(s))
     tables: list[Table] = [("orders", ("id", "g"), s.rows)]
-    _assert_keys_sound(tables, _cond_sql(s), keys)
+    _assert_keys_sound(oracle_con, tables, _cond_sql(s), keys)

--- a/uv.lock
+++ b/uv.lock
@@ -312,6 +312,7 @@ dev = [
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
 ]
 
@@ -334,6 +335,7 @@ dev = [
     { name = "pyright", specifier = ">=1.1.380" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-cov", specifier = ">=5.0" },
+    { name = "pytest-xdist", specifier = ">=3.6" },
     { name = "ruff", specifier = ">=0.6" },
 ]
 
@@ -540,6 +542,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/56/8f/65fc623b51448f2bfba1a9ec6ab3debb4664c0876c0113a5e782600b53ac/duckdb-1.5.3-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d0405eae18ec6e8210a471c97dbfe87a7e4d605274b7fe572a1f276e92158f13", size = 21455828, upload-time = "2026-05-20T11:55:23.847Z" },
     { url = "https://files.pythonhosted.org/packages/2b/db/d0274cbe9f5fe219f77c0bdf900ac77103569e83c102a4225ce04cbc607d/duckdb-1.5.3-cp314-cp314-win_amd64.whl", hash = "sha256:33ae08b3e818d7613d8936744b67718c2062c2f530376895bfd89efb51b81538", size = 13640011, upload-time = "2026-05-20T11:55:26.276Z" },
     { url = "https://files.pythonhosted.org/packages/07/5d/8f1899b8bef291caf953992fcd6c24df9f29387a35645e58c2504a5ca473/duckdb-1.5.3-cp314-cp314-win_arm64.whl", hash = "sha256:746433e49bbc667b4df283153415fbe37e9083e0eff6c3cd6e54de7536869cd4", size = 14411554, upload-time = "2026-05-20T11:55:29.037Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -1060,6 +1071,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The test suite was dominated by redundant warehouse work. Three changes bring it down with **no coverage lost** (same Hypothesis example counts, same assertions, all 832 tests still pass; coverage stays 92%).

| Run | Before | After |
|---|---|---|
| Serial (local default) | 163s | **103s** |
| CI (parallel + coverage) | ~163s + cov | **67s** |
| Local full parallel | — | **~47s** |

## Changes

**1. Soundness PBTs reuse one duckdb connection.** The lineage soundness PBTs ran ~1900 Hypothesis examples, each opening a fresh `duckdb.connect(":memory:")` (~12ms of pure engine setup apiece). A session-scoped `oracle_con` fixture is now shared across examples; the oracle and the inline `_materialize` helpers `CREATE OR REPLACE` their tables and drop them on exit, so each example still starts clean. Those six tests drop from ~48s to ~20s.

**2. `run_model` parses the project once.** It previously ran `dbt seed` then `dbt run` as two subprocesses, parsing the whole project twice. One `dbt build --select +<model> --exclude-resource-type test --exclude-resource-type unit_test` seeds and runs the ancestry in DAG order in a single parse (seeds are `ref`'d ancestors; tests excluded so a declared test never gates materialisation). `Phase.SEED`/`Phase.RUN` collapse to `Phase.BUILD`; `RunResult`'s output fields collapse to `build_*` (nothing outside the tests read them). Successful execution cases halve from ~10s to ~5.5s.

**3. CI parallelism.** Added `pytest-xdist` (dev group) and wired `-n auto --dist loadscope` into the CI test step. `loadscope` keeps each module on one worker so the module-scoped `dbt compile` fixtures still run once apiece (worksteal was slightly faster wall-clock but re-ran those fixtures across workers). `-n` is intentionally **not** in `addopts`: `-n auto` adds a ~6.7s worker-startup tax to single-test runs, which would hurt the inner dev loop. Run the full suite fast locally with `uv run pytest -n auto --dist loadscope`.

## Verification

- All 832 tests pass serially and under `-n auto --dist loadscope`.
- `ruff check`, `ruff format --check`, and `pyright` are clean.
- Coverage unchanged at 92%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)