### PR TITLE
feat(bootstrap): dblect:bootstrap AI-assistant skill + `dblect setup` (#121)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,14 @@ dblect check .       # now also reports meaning-level findings from the types yo
 
 `dblect check` produces structural findings in under a minute on typical projects, with no declarations required. From there, declare semantic types on the columns that matter and run `dblect check` in CI.
 
+Authoring those declarations is where an AI coding agent helps. Install the bootstrap skill into your agent and let it walk the project, propose types on the columns whose meaning matters, and run the check loop with you:
+
+```bash
+dblect setup claude .   # or: cursor, codex
+```
+
+This writes a harness-specific skill (`.claude/skills/`, `.cursor/rules/`, or an `AGENTS.md` block); run `dblect setup <target> --print` to review it first.
+
 See the [demo walkthrough](docs/design/demo_walkthrough.md) for an end-to-end tour against `jaffle_shop_duckdb`, and [docs/current_state/architecture.md](docs/current_state/architecture.md) for what is built today.
 
 ## Status

--- a/src/dblect/bootstrap/__init__.py
+++ b/src/dblect/bootstrap/__init__.py
@@ -1,0 +1,97 @@
+"""The bootstrap skill: instructions that drive an AI coding agent through
+investigating a dbt project and drafting dblect's semantic declaration layer.
+
+The authored content lives in ``skill.md`` (harness-agnostic markdown). ``dblect
+setup <target>`` adapts it to a Claude Code skill, a Cursor rule, or an
+``AGENTS.md`` block. None of this is on the analysis path: it is instruction text
+the agent reads, versioned beside the DSL it teaches. ``skill.md`` keeps its
+declaration examples honest by being runnable code, pinned by ``tests/bootstrap``.
+"""
+
+from __future__ import annotations
+
+import re
+from enum import StrEnum
+from importlib.resources import files
+from pathlib import Path
+
+SKILL_NAME = "dblect-bootstrap"
+SKILL_DESCRIPTION = (
+    "Investigate a dbt project and draft dblect domain types and contracts on the "
+    "columns whose meaning matters, then run `dblect check` and self-correct."
+)
+
+# AGENTS.md owns the user's prose; dblect writes only between these markers so a
+# re-run replaces its own block instead of stacking a second copy.
+_BEGIN = "<!-- BEGIN dblect:bootstrap -->"
+_END = "<!-- END dblect:bootstrap -->"
+_CODEX_BLOCK = re.compile(re.escape(_BEGIN) + r".*?" + re.escape(_END) + r"\n?", re.DOTALL)
+
+_PYTHON_BLOCK = re.compile(r"^```python\n(.*?)^```", re.MULTILINE | re.DOTALL)
+
+
+class SetupTarget(StrEnum):
+    """An AI coding agent surface ``dblect setup`` can install the skill into."""
+
+    CLAUDE = "claude"
+    CURSOR = "cursor"
+    CODEX = "codex"
+
+
+def skill_body() -> str:
+    """The authored, harness-agnostic skill markdown."""
+    return (files("dblect.bootstrap") / "skill.md").read_text(encoding="utf-8")
+
+
+def python_examples(body: str | None = None) -> list[str]:
+    """Every fenced ``python`` block in the skill. Each is self-contained, runnable
+    code, so the drift guard can exec them against the live API."""
+    return [m.group(1) for m in _PYTHON_BLOCK.finditer(body if body is not None else skill_body())]
+
+
+def render(target: SetupTarget) -> str:
+    """The skill wrapped for ``target``: front matter for the file surfaces, a
+    delimited block for ``AGENTS.md``."""
+    body = skill_body()
+    if target is SetupTarget.CLAUDE:
+        return f"---\nname: {SKILL_NAME}\ndescription: {SKILL_DESCRIPTION}\n---\n\n{body}"
+    if target is SetupTarget.CURSOR:
+        return f"---\ndescription: {SKILL_DESCRIPTION}\nglobs:\nalwaysApply: false\n---\n\n{body}"
+    return f"{_BEGIN}\n{body.rstrip()}\n{_END}\n"
+
+
+def target_path(target: SetupTarget, project_dir: Path) -> Path:
+    """Where ``target`` reads its skill from inside ``project_dir``."""
+    if target is SetupTarget.CLAUDE:
+        return project_dir / ".claude" / "skills" / SKILL_NAME / "SKILL.md"
+    if target is SetupTarget.CURSOR:
+        return project_dir / ".cursor" / "rules" / f"{SKILL_NAME}.mdc"
+    return project_dir / "AGENTS.md"
+
+
+def install(target: SetupTarget, project_dir: Path) -> Path:
+    """Write the skill into ``project_dir`` for ``target`` and return the path. The
+    file surfaces own their path, so writing is a replace; ``AGENTS.md`` is shared,
+    so dblect's block is merged in, preserving the rest of the file."""
+    path = target_path(target, project_dir)
+    document = render(target)
+    if target is SetupTarget.CODEX:
+        existing = path.read_text(encoding="utf-8") if path.exists() else ""
+        path.write_text(_merge_codex_block(existing, document), encoding="utf-8")
+        return path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(document, encoding="utf-8")
+    return path
+
+
+def _merge_codex_block(existing: str, block: str) -> str:
+    if _CODEX_BLOCK.search(existing):
+        return _CODEX_BLOCK.sub(lambda _: block, existing)
+    separator = (
+        ""
+        if not existing or existing.endswith("\n\n")
+        else "\n"
+        if existing.endswith("\n")
+        else "\n\n"
+    )
+    return f"{existing}{separator}{block}"

--- a/src/dblect/bootstrap/skill.md
+++ b/src/dblect/bootstrap/skill.md
@@ -53,9 +53,14 @@ only when it rides on a magnitude as that magnitude's unit, as `currency` does o
 Restraint is part of the job. Type a column only when one of the two kinds above
 genuinely lives in it. A bare identifier is not a type; a key or foreign key is
 already read from your dbt test; an unconstrained free-text or one-off numeric column
-is just its SQL type. A vouched declaration the data does not support is worse than
-none, because dblect trusts it and propagates it. When in doubt, leave it, or ask the
-user rather than guess (see "Interview the user").
+is just its SQL type. One more case earns a deliberate skip: a **data-dependent
+unit**, where the parameter that fixes a magnitude's meaning lives in the data rather
+than in code or a companion column. A "season wins" figure whose basis is 80 games
+some seasons and 82 others, set by the schedule, cannot be honestly pinned to either,
+and there is no column carrying the basis to bind to. Pinning it would be a vouched
+claim that is wrong half the time, so leave it untyped. A vouched declaration the
+data does not support is worse than none, because dblect trusts it and propagates it.
+When in doubt, leave it, or ask the user rather than guess (see "Interview the user").
 
 Two further surfaces are out of scope for this pass, because they do not run on the
 `dblect check` path yet: configuration flags (`DomainFlag`) and runnable contract
@@ -79,6 +84,22 @@ dblect init .
 
 `init` scaffolds the `dblect/` declaration tree and writes `dblect/_stubs/models.py`.
 
+**Check `target-path` first.** dblect looks for the manifest and catalog under
+`<project>/target/` by default. If `dbt_project.yml` sets a non-default `target-path`
+(for example `target-path: ../docs`), `init` and `check` will not find the artifacts
+there and `init` fails with "dbt compile succeeded but target/manifest.json is
+missing." Read `target-path` from `dbt_project.yml`, and if it is not `target`, pass
+`--manifest <path>/manifest.json` and `--catalog <path>/catalog.json` on **every**
+`init` and `check`. Settle this once.
+
+**List the Python models, because dblect cannot see them.** dblect analyzes a model
+by parsing its compiled SQL, so a dbt Python model (`.py`, `language: python`) cannot
+be parsed and is reported under `skipped:` with a parse-error reason. This matters
+beyond those models: a column whose lineage passes through a skipped model loses its
+provenance, which can turn a real check into a conservative artifact (see Step 5).
+Note which models are Python up front so you recognize the gap when a finding lands
+on a column downstream of one.
+
 **Get the column names right, because every binding depends on them.** dblect
 resolves a declared column against the project's compiled columns. Two sources feed
 that resolution, and they differ in coverage:
@@ -93,7 +114,9 @@ that resolution, and they differ in coverage:
 So produce the catalog before you rely on resolution. If the models are built,
 `dbt docs generate` writes `target/catalog.json`; if not, `dbt build` first. Without
 it, undocumented leaf columns (seeds, sources) will not resolve and your bindings
-will look like they are missing when they are merely unseen.
+will look like they are missing when they are merely unseen. When the stubs look
+thin or stale, read a model's real columns straight from `catalog.json`
+(`nodes.<unique_id>.columns`) rather than trusting the stub.
 
 Read the project structure: the `models/` tree (usually split into `staging/` and
 `marts/`), each model's `.sql`, and the `schema.yml` files that carry column
@@ -193,6 +216,33 @@ RevenueUSD = Money.refine(currency=Currency.USD)
 # Multi-currency: bind the currency facet to the column that records it.
 PaymentMoney = Money.columns(amount="amount", currency="currency")
 ```
+
+**A magnitude on a fixed scale is the same shape, with a one-member unit.** Money is
+the multi-unit case (the currency varies). Many loaded columns are magnitudes on a
+single fixed scale: an Elo rating, a probability on a `0..10000` integer scale, a
+score. They are not plain `Decimal`s, because an Elo is not interchangeable with a
+probability even though both are numbers. Give the magnitude its own identity with a
+`UnitEnum` that has one member, and `refine` to pin that sole unit (the same move as
+pinning a single currency). Pinning is what sources the unit facet; leave it open and
+the facet has no column behind it, which surfaces as `unsourced_field`.
+
+```python
+from dblect.types import Decimal, DomainType, UnitEnum
+
+class RatingScale(UnitEnum):
+    ELO = "elo"
+
+class Rating(DomainType):
+    value: Decimal(10, 2)
+    scale: RatingScale
+
+# Pin the sole unit. An Elo rating and a probability are now distinct types that do
+# not unify, even though both are just numbers underneath.
+EloRating = Rating.refine(scale=RatingScale.ELO)
+```
+
+For a dimensionless count (a number of games, rows, attempts), use the built-in
+`Count` magnitude rather than inventing a unit; it is always safe to sum.
 
 **Bind types to a model with a `ModelContract`.** Name the model with `dbt_model`
 and annotate each column you are typing. A contract with only column bindings and
@@ -313,6 +363,16 @@ Then read the findings and loop. Two kinds matter here:
   into a gross contract. This is the headline catch. Decide whether the declaration
   is stale (the data legitimately changed and the type should open up) or the SQL
   introduced a real bug, and fix the half that is wrong.
+- **`aggregation_not_well_typed`** means a sum or other aggregate combined values the
+  analyzer could not prove are the same kind. Often that is the real catch (a
+  mixed-currency sum). But it can also be a conservative artifact: when the group
+  shape is unresolved, or the column's lineage routes through a **skipped Python
+  model** (Step 1), the analyzer cannot prove per-group constancy and fires rather
+  than stay silent. Before acting on one, test whether it is real: does it fire
+  independent of the column it supposedly conflicts with, and does the lineage trace
+  back through a skipped model or an unresolved group? If so, it is a can't-prove
+  artifact from a lineage gap, not a meaning conflict; note it and move on rather than
+  contorting the declarations to chase it.
 
 Iterate until the contract issues are gone. A remaining `domain_type_contradiction`
 may be a true finding worth surfacing to the user rather than silencing; explain it
@@ -320,8 +380,9 @@ and let them decide.
 
 ## What good looks like
 
-A small, honest declaration layer: domain types on the money and rate columns that
-matter, refinements that pin the currency or the net/gross reading you confirmed
-with the user, and a functional-dependency fact or two where a rollup needs it. A
-handful of contracts, not a wall of them. Every binding grounded in a real column
-name and every vouched fact grounded in a real invariant of the project.
+A small, honest declaration layer: domain types on the magnitudes that carry a unit
+(money, rates, fixed-scale quantities), refinements that pin the unit or the
+net/gross reading you confirmed with the user, and a functional-dependency fact or
+two where a rollup needs it. A handful of contracts, not a wall of them. Every
+binding grounded in a real column name and every vouched fact grounded in a real
+invariant of the project.

--- a/src/dblect/bootstrap/skill.md
+++ b/src/dblect/bootstrap/skill.md
@@ -42,18 +42,36 @@ refinements, and the fact-returning contracts below.
 
 ## Step 1: orient
 
-Confirm you are in a dbt project (a `dbt_project.yml` exists) and that dblect has
-a manifest to read. If `target/manifest.json` is missing, run `dbt compile`
-yourself, or let `dblect init` produce it for you (it falls back to `dbt compile`):
+First confirm how dblect is invoked here. Run `dblect --help`. If it is not on the
+PATH, it may live in the project's virtualenv (`.venv/bin/dblect`) or be run through
+the project's runner (`uv run dblect`, `poetry run dblect`). Settle this once and use
+that form throughout; do not search the filesystem for the package.
+
+Confirm you are in a dbt project (a `dbt_project.yml` exists) and that dblect has a
+manifest to read. If `target/manifest.json` is missing, run `dbt compile` yourself,
+or let `dblect init` produce it for you (it falls back to `dbt compile`):
 
 ```text
 dblect init .
 ```
 
-`init` scaffolds the `dblect/` declaration tree and writes `dblect/_stubs/models.py`,
-generated from the manifest. **Read that stubs file.** It lists every model and its
-columns under their real names. Every type and column you bind must match a name in
-there, so use it as your source of truth and never invent a column.
+`init` scaffolds the `dblect/` declaration tree and writes `dblect/_stubs/models.py`.
+
+**Get the column names right, because every binding depends on them.** dblect
+resolves a declared column against the project's compiled columns. Two sources feed
+that resolution, and they differ in coverage:
+
+- `schema.yml` lists only the columns a human documented. The generated stubs are
+  built from it, so they can be blind to undocumented columns (a `stg_payments.amount`
+  that no one wrote a description for) and can carry a stale name (a column renamed in
+  the SQL but not in `schema.yml`). Treat the stubs as a starting hint, not gospel.
+- `target/catalog.json` is the warehouse's own account of every column dbt actually
+  emitted. It is the ground truth. dblect reads it when it sits beside the manifest.
+
+So produce the catalog before you rely on resolution. If the models are built,
+`dbt docs generate` writes `target/catalog.json`; if not, `dbt build` first. Without
+it, undocumented leaf columns (seeds, sources) will not resolve and your bindings
+will look like they are missing when they are merely unseen.
 
 Read the project structure: the `models/` tree (usually split into `staging/` and
 `marts/`), each model's `.sql`, and the `schema.yml` files that carry column
@@ -104,10 +122,16 @@ confirm ...` comment so a human can check it.
 
 ## Step 4: write the declarations
 
-Put domain types in `dblect/types.py` and contracts under `dblect/contracts/`.
-`src/dblect/demo/library.py` and the runnable examples in
-`tests/fixtures/scenarios/cases/*/dblect/` are the canonical templates; copy their
-shape.
+Put domain types in `dblect/types.py` and contracts under `dblect/contracts/`. The
+examples below are the templates; copy their shape rather than reading dblect's own
+source to reverse-engineer it.
+
+**Layout and discovery.** Every `.py` module under `dblect/` is imported, and any
+`ModelContract` subclass defined anywhere in that tree registers itself. You do not
+wire up imports or a registry. A natural split is one module per model group
+(`dblect/contracts/staging.py`, `dblect/contracts/marts.py`), or one per model for a
+small project; the location does not matter, only that the class is defined under
+`dblect/`.
 
 `Money` is the worked example: an amount and the currency it is denominated in, so
 a sum that mixes currencies stops being well typed. It ships in `dblect.demo`.
@@ -156,6 +180,36 @@ class StgPayments(ModelContract):
     amount: Money.refine(currency=Currency.USD)
 ```
 
+**Know the binding rule, or your columns will silently collapse.** This is the one
+mechanic worth getting right before you write a contract. A domain type binds its
+*magnitude facet* (for `Money`, the field named `amount`) to a warehouse column, and
+by default that column is the one named the same as the facet: `amount`. The contract
+*field name* on the left does not drive the binding.
+
+So when a model has several money columns whose names are not `amount`, annotating
+each with a bare type points all of them at one phantom column called `amount`. They
+collapse together and resolve to nothing. Map each one explicitly with `.columns(...)`,
+naming the real column the magnitude lives in:
+
+```python
+from dblect import ModelContract
+from dblect.demo import Currency, Money
+
+MoneyUSD = Money.refine(currency=Currency.USD)
+
+class Orders(ModelContract):
+    dbt_model = "orders"
+    # `amount` is literally named amount, so the bare refinement binds it.
+    amount: MoneyUSD
+    # These are not named `amount`, so map the magnitude facet to the real column.
+    credit_card_amount: MoneyUSD.columns(amount="credit_card_amount")
+    coupon_amount: MoneyUSD.columns(amount="coupon_amount")
+    bank_transfer_amount: MoneyUSD.columns(amount="bank_transfer_amount")
+```
+
+The rule in one line: bind with the bare type only when the column is named after the
+facet; otherwise reach for `.columns(amount="real_column_name")`.
+
 **Add a functional-dependency fact when a rollup needs it.** A `@contract` method
 that returns a fact lets the analyzer discharge an obligation it could not see on
 its own. The canonical one: every payment on an order shares the order's currency,
@@ -187,7 +241,19 @@ Run the checker:
 dblect check .
 ```
 
-Read the findings and loop. Two kinds matter here:
+**Read the coverage line before the findings.** The check reports how much of what
+you declared actually resolved, and that is your first diagnostic. The key counter is
+the number of contract columns that resolved against the compiled SQL. If it is lower
+than the number of columns you declared, some bindings did not land, even when no
+finding fired. The two usual causes are the binding-rule collapse above (a money
+column not mapped with `.columns(...)`, so it pointed at a phantom `amount`) and a
+missing `catalog.json` (an undocumented column that cannot resolve until the catalog
+exists). A grounding count like `domain_type 7/27` is expected and fine: it means you
+typed 7 of 27 columns, which is the point, you type only the columns that carry
+meaning. Chase the resolved-columns count up to the number you declared; do not chase
+grounding up to the total.
+
+Then read the findings and loop. Two kinds matter here:
 
 - **Contract issues** mean a declaration does not line up with the manifest:
   `unresolved_model` (a misspelled or renamed model), `unknown_column` (a column

--- a/src/dblect/bootstrap/skill.md
+++ b/src/dblect/bootstrap/skill.md
@@ -12,33 +12,55 @@ test becomes a key fact; a `relationships` test becomes a foreign-key edge; an
 that.** Re-declaring keys and foreign keys that a dbt test already states adds
 noise and no signal.
 
-What no dbt test can express, and what you are here to add, is *semantics*: that a
-column is money in some currency, that a revenue figure is net of tax rather than
-gross, that two amounts are the same kind of quantity and may be summed together.
-That is the layer dblect propagates along the DAG to catch a meaning shift (a
-currency creeping in upstream, a net figure flowing into a gross contract) before
-it reaches a dashboard.
+What no dbt test can express, and what you are here to add, is *meaning*: the column
+whose type is richer than its SQL type, so that two values which are both
+numerically valid still are not interchangeable. dblect propagates that meaning
+along the DAG and reports where it shifts (a value changing kind upstream so a
+downstream column no longer holds what it claims) before it reaches a dashboard.
+
+Money is the clearest case (a revenue figure quietly going from net to gross, a
+currency creeping in), and it is the example most of this guide is written around.
+It is one instance of a general idea, not the whole of it.
 
 ## What is in scope
 
-Declare these, and nothing more:
+Two kinds of meaning propagate along the DAG today. They are what you declare:
 
-- **Domain types** on the columns whose meaning matters: money, rates, anything
-  where two numerically valid values are not comparable.
-- **Refinements** that fix a meaning-bearing parameter (single currency, net vs
-  gross, tax inclusive or not).
-- **Functional-dependency facts** that let a rollup stay well typed (for example,
-  every payment on an order shares the order's currency).
+- **A magnitude carrying a unit.** A summable quantity together with the tag that
+  says what it is measured in, so two values in different units stop being
+  interchangeable. Money in a currency is the canonical case, and the one most of
+  this guide is written around; a physical quantity in a unit, or a rate, is the same
+  shape. Expressed as a `DomainType` (a magnitude facet plus a `UnitEnum` or
+  `NominalEnum` tag facet), with **refinements** that fix a meaning-bearing parameter
+  (single currency, net vs gross, tax inclusive or not). This is what catches a unit
+  changing upstream (`domain_type_contradiction`) and a mixed-unit sum
+  (`aggregation_not_well_typed`).
+- **A structural invariant over columns.** A functional dependency (an
+  `ad -> adset -> campaign` hierarchy where one identifier determines another, or
+  every payment on an order sharing the order's currency) or the grain. These let a
+  rollup stay well typed. Expressed as `determines` and `grain` facts, **not** as
+  types.
 
-Leave out anything you cannot ground in the project's real semantics. A vouched
-declaration that the data does not support is worse than no declaration: dblect
-trusts it and propagates it. When you are unsure what a column means, ask the user
-rather than guess (see "Interview the user").
+A note on closed categories (a `status`, `channel`, `platform`, `country` drawn from
+a fixed set). The membership check you would reach for is already covered for free:
+an `accepted_values` dbt test on the column becomes a value domain with no
+declaration from you. A standalone category column does not yet propagate as a tag on
+its own (only a magnitude's tag facet does), so do not mint a bare enum type on a
+status column expecting it to catch a meaning shift. A category earns a declaration
+only when it rides on a magnitude as that magnitude's unit, as `currency` does on
+`Money`.
 
-Two surfaces are deliberately out of scope for this pass, because they do not yet
-run on the `dblect check` path: configuration flags (`DomainFlag`) and runnable
-contract predicates (an equality with `.within(...)`). Stick to domain types,
-refinements, and the fact-returning contracts below.
+Restraint is part of the job. Type a column only when one of the two kinds above
+genuinely lives in it. A bare identifier is not a type; a key or foreign key is
+already read from your dbt test; an unconstrained free-text or one-off numeric column
+is just its SQL type. A vouched declaration the data does not support is worse than
+none, because dblect trusts it and propagates it. When in doubt, leave it, or ask the
+user rather than guess (see "Interview the user").
+
+Two further surfaces are out of scope for this pass, because they do not run on the
+`dblect check` path yet: configuration flags (`DomainFlag`) and runnable contract
+predicates (an equality with `.within(...)`). Stick to domain types, refinements, and
+the fact-returning contracts below.
 
 ## Step 1: orient
 
@@ -81,25 +103,30 @@ what a column means.
 ## Step 2: find the loaded columns
 
 Walk the models and macros looking for columns whose meaning is richer than their
-SQL type. The high-value candidates:
+SQL type, across the two kinds that propagate. The high-value candidates:
 
-- **Money and revenue.** Any `amount`, `price`, `revenue`, `cost`, `total`, or
-  `value` column. The meaning that matters is the hidden parameters: which currency,
-  net or gross, tax inclusive or exclusive, before or after discounts. A `Decimal`
-  tells you none of this.
-- **Currencies and units.** A `currency` column, or a money column that should carry
-  one. This is the tag that makes a mixed-currency sum ill typed.
-- **Rates and percentages.** A `rate`, `pct`, or `ratio` column. What is the base,
-  and what window does it cover.
-- **Keys and grain, only where semantics add something.** The grain (one row per
-  order, or per order line) when a rollup depends on it. Skip keys and foreign keys
-  a dbt test already declares.
+- **Magnitudes and their units.** Any `amount`, `price`, `revenue`, `cost`, `spend`,
+  `total`, or `value` column, and the unit that qualifies it: the `currency` it is
+  in, whether it is net or gross, tax inclusive or exclusive, before or after
+  discounts. A `Decimal` records none of this. Rates and ratios (`cpc`, `ctr`,
+  `rate`, `pct`) are magnitudes too: ask what the base is and what window it covers.
+- **Hierarchies and grain.** A containment chain such as `ad` within `adset` within
+  `campaign`, or `order_line` within `order`, where one identifier determines
+  another. And the grain itself (one row per order, or per order line) when a rollup
+  depends on it. Skip plain keys and foreign keys a dbt test already declares; the
+  value here is the functional dependency the hierarchy implies, not the keys.
+
+Closed-set columns (`status`, `channel`, `platform`, `country`) are worth noticing
+but usually not worth declaring: an `accepted_values` test already guards the set for
+free, and a standalone category does not propagate on its own. Spend the effort on
+the two kinds above.
 
 Read the SQL to form a hypothesis. A `sum(amount)` grouped by `order_id` tells you
 the author believes an order's payments are summable. A currency conversion macro
-tells you money flows across currencies. Trace a money column from its source
-through staging into the marts, and watch for the point where its meaning could
-change without the type following.
+tells you money flows across currencies. A `group by campaign_id` over an
+`ad`-grained model relies on each ad belonging to one campaign. Trace a loaded
+column from its source through staging into the marts, and watch for the point where
+its meaning could change without the type following.
 
 ## Step 3: infer what you can, interview for the rest
 
@@ -211,9 +238,9 @@ The rule in one line: bind with the bare type only when the column is named afte
 facet; otherwise reach for `.columns(amount="real_column_name")`.
 
 **Add a functional-dependency fact when a rollup needs it.** A `@contract` method
-that returns a fact lets the analyzer discharge an obligation it could not see on
-its own. The canonical one: every payment on an order shares the order's currency,
-so summing an order's payments is well defined.
+that returns a fact lets the analyzer discharge an obligation it could not see on its
+own. The canonical one: every payment on an order shares the order's currency, so
+summing an order's payments is well defined.
 
 ```python
 from dblect import ModelContract, contract
@@ -227,6 +254,27 @@ class StgPayments(ModelContract):
     def one_currency_per_order(self):
         # The order_id determines the currency, so the per-order rollup is sound.
         return self.order_id.determines(self.currency)
+```
+
+A containment hierarchy is the same fact, applied to identifiers. If each ad belongs
+to one adset and each adset to one campaign, then spend summed at the ad level keeps
+its campaign, and a `group by campaign_id` stays well defined:
+
+```python
+from dblect import ModelContract, contract
+
+class FctAdSpend(ModelContract):
+    dbt_model = "fct_ad_spend"
+
+    # One fact per method: each step of ad -> adset -> campaign is its own
+    # functional dependency.
+    @contract
+    def ad_in_one_adset(self):
+        return self.ad_id.determines(self.adset_id)
+
+    @contract
+    def adset_in_one_campaign(self):
+        return self.adset_id.determines(self.campaign_id)
 ```
 
 The fact vocabulary you can return is small and structural: `determines` (a

--- a/src/dblect/bootstrap/skill.md
+++ b/src/dblect/bootstrap/skill.md
@@ -1,192 +1,143 @@
 # Bootstrap dblect types and contracts for a dbt project
 
-Your job is to read a dbt project, work out which columns carry meaning that plain
-validation cannot see, and draft the dblect declaration layer that pins that
-meaning. Then run `dblect check` and correct the draft until it resolves cleanly.
+Read a dbt project, work out which columns carry meaning plain validation cannot
+see, draft the dblect declaration layer that pins it, then run `dblect check` and
+correct the draft until it resolves cleanly.
 
-dblect already earns its keep with zero declarations: a dozen structural detectors
-read the compiled SQL and flag ordering, join, and NULL hazards on their own. It
-also reads your existing dbt tests directly. A `unique` or `dbt_utils.unique_combination_of_columns`
-test becomes a key fact; a `relationships` test becomes a foreign-key edge; an
-`accepted_values` test becomes a value domain. **You do not need to restate any of
-that.** Re-declaring keys and foreign keys that a dbt test already states adds
+dblect already earns its keep with zero declarations: its structural detectors read
+the compiled SQL and flag ordering, join, and NULL hazards on their own, and it
+reads your existing dbt tests directly. A `unique` (or
+`dbt_utils.unique_combination_of_columns`) test becomes a key fact, a
+`relationships` test a foreign-key edge, an `accepted_values` test a value domain.
+**Do not restate any of that.** Re-declaring keys a dbt test already states adds
 noise and no signal.
 
-What no dbt test can express, and what you are here to add, is *meaning*: the column
-whose type is richer than its SQL type, so that two values which are both
-numerically valid still are not interchangeable. dblect propagates that meaning
-along the DAG and reports where it shifts (a value changing kind upstream so a
-downstream column no longer holds what it claims) before it reaches a dashboard.
-
-Money is the clearest case (a revenue figure quietly going from net to gross, a
-currency creeping in), and it is the example most of this guide is written around.
-It is one instance of a general idea, not the whole of it.
+What no dbt test can express, and what you add, is *meaning*: a column whose type is
+richer than its SQL type, so two numerically valid values still are not
+interchangeable. dblect propagates that meaning along the DAG and reports where it
+shifts before it reaches a dashboard. Money is the running example (a revenue figure
+sliding from net to gross, a currency creeping in), but it is one instance of a
+general idea.
 
 ## What is in scope
 
-Two kinds of meaning propagate along the DAG today. They are what you declare:
+Two kinds of meaning propagate today:
 
-- **A magnitude carrying a unit.** A summable quantity together with the tag that
-  says what it is measured in, so two values in different units stop being
-  interchangeable. Money in a currency is the canonical case, and the one most of
-  this guide is written around; a physical quantity in a unit, or a rate, is the same
-  shape. Expressed as a `DomainType` (a magnitude facet plus a `UnitEnum` or
-  `NominalEnum` tag facet), with **refinements** that fix a meaning-bearing parameter
-  (single currency, net vs gross, tax inclusive or not). This is what catches a unit
-  changing upstream (`domain_type_contradiction`) and a mixed-unit sum
-  (`aggregation_not_well_typed`).
+- **A magnitude carrying a unit.** A summable quantity plus the tag saying what it is
+  measured in, so values in different units stop being interchangeable. Money in a
+  currency is canonical; a physical quantity in a unit, or a rate, is the same shape.
+  Expressed as a `DomainType` (a magnitude facet plus a `UnitEnum` or `NominalEnum`
+  tag), with **refinements** fixing a meaning-bearing parameter (single currency, net
+  vs gross, tax inclusive). This catches a unit changing upstream
+  (`domain_type_contradiction`) and a mixed-unit sum (`aggregation_not_well_typed`).
 - **A structural invariant over columns.** A functional dependency (an
-  `ad -> adset -> campaign` hierarchy where one identifier determines another, or
-  every payment on an order sharing the order's currency) or the grain. These let a
-  rollup stay well typed. Expressed as `determines` and `grain` facts, **not** as
-  types.
+  `ad -> adset -> campaign` hierarchy, or every payment on an order sharing the
+  order's currency) or the grain, which keep a rollup well typed. Expressed as
+  `determines` and `grain` facts, **not** as types.
 
-A note on closed categories (a `status`, `channel`, `platform`, `country` drawn from
-a fixed set). The membership check you would reach for is already covered for free:
-an `accepted_values` dbt test on the column becomes a value domain with no
-declaration from you. A standalone category column does not yet propagate as a tag on
-its own (only a magnitude's tag facet does), so do not mint a bare enum type on a
-status column expecting it to catch a meaning shift. A category earns a declaration
-only when it rides on a magnitude as that magnitude's unit, as `currency` does on
-`Money`.
+Closed categories (`status`, `channel`, `platform`, `country`) usually need no
+declaration: an `accepted_values` test already guards the set for free, and a
+standalone category does not yet propagate on its own. A category earns a type only
+when it rides on a magnitude as its unit, as `currency` does on `Money`.
 
-Restraint is part of the job. Type a column only when one of the two kinds above
-genuinely lives in it. A bare identifier is not a type; a key or foreign key is
-already read from your dbt test; an unconstrained free-text or one-off numeric column
-is just its SQL type. One more case earns a deliberate skip: a **data-dependent
-unit**, where the parameter that fixes a magnitude's meaning lives in the data rather
-than in code or a companion column. A "season wins" figure whose basis is 80 games
-some seasons and 82 others, set by the schedule, cannot be honestly pinned to either,
-and there is no column carrying the basis to bind to. Pinning it would be a vouched
-claim that is wrong half the time, so leave it untyped. A vouched declaration the
-data does not support is worse than none, because dblect trusts it and propagates it.
-When in doubt, leave it, or ask the user rather than guess (see "Interview the user").
+Restraint is part of the job. Type a column only when one of those two kinds
+genuinely lives in it. A bare identifier, a key already read from a dbt test, a
+free-text or one-off numeric column: leave them as their SQL type. Skip a
+**data-dependent unit** too, where the parameter fixing a magnitude's meaning lives
+in the data rather than in code or a companion column: a "season wins" figure whose
+basis is 80 games some seasons and 82 others has no column to bind to, and pinning it
+would vouch a claim that is wrong half the time. A vouched declaration the data does
+not support is worse than none, because dblect trusts it and propagates it. When in
+doubt, leave it or ask (Step 3).
 
-Two further surfaces are out of scope for this pass, because they do not run on the
-`dblect check` path yet: configuration flags (`DomainFlag`) and runnable contract
-predicates (an equality with `.within(...)`). Stick to domain types, refinements, and
-the fact-returning contracts below.
+Out of scope this pass, because they do not run on the `dblect check` path yet:
+configuration flags (`DomainFlag`) and runnable contract predicates (`.within(...)`).
+Stick to domain types, refinements, and fact-returning contracts.
 
 ## Step 1: orient
 
-First confirm how dblect is invoked here. Run `dblect --help`. If it is not on the
-PATH, it may live in the project's virtualenv (`.venv/bin/dblect`) or be run through
-the project's runner (`uv run dblect`, `poetry run dblect`). Settle this once and use
-that form throughout; do not search the filesystem for the package.
+Confirm how dblect is invoked: run `dblect --help`. If it is not on PATH it may live
+in `.venv/bin/dblect` or run through `uv run dblect` / `poetry run dblect`. Settle
+this once; do not search the filesystem for the package.
 
-Confirm you are in a dbt project (a `dbt_project.yml` exists) and that dblect has a
-manifest to read. If `target/manifest.json` is missing, run `dbt compile` yourself,
-or let `dblect init` produce it for you (it falls back to `dbt compile`):
+Confirm a `dbt_project.yml` exists and dblect has a manifest. If
+`target/manifest.json` is missing, `dblect init` produces one (it falls back to
+`dbt compile`):
 
 ```text
 dblect init .
 ```
 
-`init` scaffolds the `dblect/` declaration tree and writes `dblect/_stubs/models.py`.
+`init` scaffolds the `dblect/` tree and writes `dblect/_stubs/models.py`.
 
-**Check `target-path` first.** dblect looks for the manifest and catalog under
-`<project>/target/` by default. If `dbt_project.yml` sets a non-default `target-path`
-(for example `target-path: ../docs`), `init` and `check` will not find the artifacts
-there and `init` fails with "dbt compile succeeded but target/manifest.json is
-missing." Read `target-path` from `dbt_project.yml`, and if it is not `target`, pass
-`--manifest <path>/manifest.json` and `--catalog <path>/catalog.json` on **every**
-`init` and `check`. Settle this once.
+**Check `target-path` first.** dblect looks under `<project>/target/` by default. If
+`dbt_project.yml` sets a non-default `target-path` (e.g. `../docs`), `init` and
+`check` will not find the artifacts and `init` fails with "target/manifest.json is
+missing." Read `target-path`, and if it is not `target`, pass
+`--manifest <path>/manifest.json` and `--catalog <path>/catalog.json` on every call.
 
-**List the Python models, because dblect cannot see them.** dblect analyzes a model
-by parsing its compiled SQL, so a dbt Python model (`.py`, `language: python`) cannot
-be parsed and is reported under `skipped:` with a parse-error reason. This matters
-beyond those models: a column whose lineage passes through a skipped model loses its
-provenance, which can turn a real check into a conservative artifact (see Step 5).
-Note which models are Python up front so you recognize the gap when a finding lands
-on a column downstream of one.
+**Note the Python models, because dblect cannot read them.** dblect parses compiled
+SQL, so a dbt Python model is reported under `skipped:`. This matters downstream: a
+column whose lineage passes through a skipped model loses its provenance, which can
+turn a real check into a conservative artifact (Step 5). Note them up front so you
+recognize the gap.
 
-**Get the column names right, because every binding depends on them.** dblect
-resolves a declared column against the project's compiled columns. Two sources feed
-that resolution, and they differ in coverage:
+**Get column names right; every binding depends on them.** Two sources feed
+resolution and differ in coverage. `schema.yml` lists only documented columns, so the
+generated stubs can be blind to an undocumented `stg_payments.amount` or carry a name
+stale against the SQL: treat them as a hint. `target/catalog.json` is the warehouse's
+account of every column dbt emitted, the ground truth, read when it sits beside the
+manifest. Produce it before relying on resolution: `dbt docs generate` writes it (or
+`dbt build` first if the models are not built). Without it, undocumented leaf columns
+(seeds, sources) will not resolve and bindings look missing when they are merely
+unseen. When stubs look thin, read a model's real columns from `catalog.json`
+(`nodes.<unique_id>.columns`).
 
-- `schema.yml` lists only the columns a human documented. The generated stubs are
-  built from it, so they can be blind to undocumented columns (a `stg_payments.amount`
-  that no one wrote a description for) and can carry a stale name (a column renamed in
-  the SQL but not in `schema.yml`). Treat the stubs as a starting hint, not gospel.
-- `target/catalog.json` is the warehouse's own account of every column dbt actually
-  emitted. It is the ground truth. dblect reads it when it sits beside the manifest.
-
-So produce the catalog before you rely on resolution. If the models are built,
-`dbt docs generate` writes `target/catalog.json`; if not, `dbt build` first. Without
-it, undocumented leaf columns (seeds, sources) will not resolve and your bindings
-will look like they are missing when they are merely unseen. When the stubs look
-thin or stale, read a model's real columns straight from `catalog.json`
-(`nodes.<unique_id>.columns`) rather than trusting the stub.
-
-Read the project structure: the `models/` tree (usually split into `staging/` and
-`marts/`), each model's `.sql`, and the `schema.yml` files that carry column
-descriptions and tests. The descriptions are often where a human already wrote down
-what a column means.
+Then read the structure: the `models/` tree, each `.sql`, and the `schema.yml`
+descriptions, which are often where a human already wrote down what a column means.
 
 ## Step 2: find the loaded columns
 
-Walk the models and macros looking for columns whose meaning is richer than their
-SQL type, across the two kinds that propagate. The high-value candidates:
+Walk models and macros for columns whose meaning is richer than their SQL type:
 
 - **Magnitudes and their units.** Any `amount`, `price`, `revenue`, `cost`, `spend`,
-  `total`, or `value` column, and the unit that qualifies it: the `currency` it is
-  in, whether it is net or gross, tax inclusive or exclusive, before or after
-  discounts. A `Decimal` records none of this. Rates and ratios (`cpc`, `ctr`,
-  `rate`, `pct`) are magnitudes too: ask what the base is and what window it covers.
-- **Hierarchies and grain.** A containment chain such as `ad` within `adset` within
-  `campaign`, or `order_line` within `order`, where one identifier determines
-  another. And the grain itself (one row per order, or per order line) when a rollup
-  depends on it. Skip plain keys and foreign keys a dbt test already declares; the
-  value here is the functional dependency the hierarchy implies, not the keys.
+  `total`, `value` column and the unit qualifying it: currency, net vs gross, tax in
+  or out, pre- or post-discount. A `Decimal` records none of this. Rates (`cpc`,
+  `ctr`, `rate`, `pct`) are magnitudes too: ask the base and the window.
+- **Hierarchies and grain.** A containment chain (`ad` within `adset` within
+  `campaign`, `order_line` within `order`) where one identifier determines another,
+  and the grain itself when a rollup depends on it. Skip the plain keys a dbt test
+  already declares; the value is the functional dependency, not the keys.
 
-Closed-set columns (`status`, `channel`, `platform`, `country`) are worth noticing
-but usually not worth declaring: an `accepted_values` test already guards the set for
-free, and a standalone category does not propagate on its own. Spend the effort on
-the two kinds above.
-
-Read the SQL to form a hypothesis. A `sum(amount)` grouped by `order_id` tells you
-the author believes an order's payments are summable. A currency conversion macro
-tells you money flows across currencies. A `group by campaign_id` over an
-`ad`-grained model relies on each ad belonging to one campaign. Trace a loaded
-column from its source through staging into the marts, and watch for the point where
-its meaning could change without the type following.
+Read the SQL to form a hypothesis: `sum(amount)` grouped by `order_id` says the
+author believes an order's payments are summable; a conversion macro says money
+crosses currencies; `group by campaign_id` over an ad-grained model relies on each ad
+belonging to one campaign. Trace a loaded column from source through staging to
+marts, watching for where its meaning could change without the type following.
 
 ## Step 3: infer what you can, interview for the rest
 
-Some meaning is readable from the code. A model that filters `where currency = 'USD'`
-is single currency by construction. A macro named `to_usd` converts. Lean on the
-SQL, the column descriptions, and the dbt test metadata.
+Some meaning is readable: `where currency = 'USD'` is single-currency by
+construction, a macro named `to_usd` converts. Lean on the SQL, the descriptions, and
+dbt test metadata.
 
-The rest you cannot read off the code, and you should not guess it:
-
-- Is this `amount` always one currency, or did the source go multi-currency?
-- Is `revenue` net of tax and discounts, or gross?
-- Is the grain one row per order, or per order line?
-
-**Interview the user.** Propose your reading of each ambiguous column and ask for
-confirmation before you write a vouched fact. For example: "I read `stg_payments.amount`
-as USD because the model filters to US orders. Is that still true now that the
-source carries a `currency` column?" If you are running in a setting where you
-cannot ask, draft the declaration anyway and mark the assumption with a `# TODO:
-confirm ...` comment so a human can check it.
+The rest you should not guess: is this `amount` still one currency, or did the source
+go multi-currency? Is `revenue` net or gross? Is the grain one row per order or per
+order line? **Interview the user**: propose your reading and ask before writing a
+vouched fact ("I read `stg_payments.amount` as USD because the model filters to US
+orders; still true now that the source carries a `currency` column?"). If you cannot
+ask, draft it and mark the assumption with `# TODO: confirm ...`.
 
 ## Step 4: write the declarations
 
-Put domain types in `dblect/types.py` and contracts under `dblect/contracts/`. The
-examples below are the templates; copy their shape rather than reading dblect's own
-source to reverse-engineer it.
+Put domain types in `dblect/types.py` and contracts under `dblect/contracts/`. Copy
+the shapes below rather than reverse-engineering dblect's source. Every `.py` module
+under `dblect/` is imported and any `ModelContract` subclass registers itself, so you
+wire up no imports or registry; split one module per model group or per model as you
+like.
 
-**Layout and discovery.** Every `.py` module under `dblect/` is imported, and any
-`ModelContract` subclass defined anywhere in that tree registers itself. You do not
-wire up imports or a registry. A natural split is one module per model group
-(`dblect/contracts/staging.py`, `dblect/contracts/marts.py`), or one per model for a
-small project; the location does not matter, only that the class is defined under
-`dblect/`.
-
-`Money` is the worked example: an amount and the currency it is denominated in, so
-a sum that mixes currencies stops being well typed. It ships in `dblect.demo`.
-Declare your own domain type the same way, by subclassing `DomainType` and giving
-each facet a typed field:
+Declare a domain type by subclassing `DomainType`, one typed field per facet. `Money`
+(an amount and its currency) ships in `dblect.demo`:
 
 ```python
 from dblect.types import Decimal, DomainType, UnitEnum
@@ -200,12 +151,11 @@ class Money(DomainType):
     currency: Currency
 ```
 
-A `UnitEnum` is a tag that must agree when values combine; a `NominalEnum` is a tag
-that rides along without that constraint. Use the shipped `dblect.demo.Currency`
-slice, or declare your project's own categories as above.
+A `UnitEnum` tag must agree when values combine; a `NominalEnum` tag rides along
+without that constraint.
 
-**Refine to fix a meaning-bearing parameter.** A single-currency column pins the
-currency; a multi-currency column binds the currency to the column that records it:
+**Refine to fix a meaning-bearing parameter.** Pin a single-currency column's tag;
+bind a multi-currency column's facet to the column recording it:
 
 ```python
 from dblect.demo import Currency, Money
@@ -217,14 +167,13 @@ RevenueUSD = Money.refine(currency=Currency.USD)
 PaymentMoney = Money.columns(amount="amount", currency="currency")
 ```
 
-**A magnitude on a fixed scale is the same shape, with a one-member unit.** Money is
-the multi-unit case (the currency varies). Many loaded columns are magnitudes on a
-single fixed scale: an Elo rating, a probability on a `0..10000` integer scale, a
-score. They are not plain `Decimal`s, because an Elo is not interchangeable with a
-probability even though both are numbers. Give the magnitude its own identity with a
-`UnitEnum` that has one member, and `refine` to pin that sole unit (the same move as
-pinning a single currency). Pinning is what sources the unit facet; leave it open and
-the facet has no column behind it, which surfaces as `unsourced_field`.
+**A fixed-scale magnitude is the same shape with a one-member unit.** An Elo rating, a
+probability on a `0..10000` scale, a score: not plain `Decimal`s, since an Elo and a
+probability are not interchangeable though both are numbers. Give the magnitude its
+own one-member `UnitEnum` and `refine` to pin it (pinning is what sources the unit
+facet; leave it open and the facet has no column behind it, which surfaces as a
+contract issue). For a dimensionless count, use the built-in `Count`, always safe to
+sum.
 
 ```python
 from dblect.types import Decimal, DomainType, UnitEnum
@@ -236,37 +185,16 @@ class Rating(DomainType):
     value: Decimal(10, 2)
     scale: RatingScale
 
-# Pin the sole unit. An Elo rating and a probability are now distinct types that do
-# not unify, even though both are just numbers underneath.
 EloRating = Rating.refine(scale=RatingScale.ELO)
 ```
 
-For a dimensionless count (a number of games, rows, attempts), use the built-in
-`Count` magnitude rather than inventing a unit; it is always safe to sum.
-
-**Bind types to a model with a `ModelContract`.** Name the model with `dbt_model`
-and annotate each column you are typing. A contract with only column bindings and
-no methods is valid and already buys type propagation:
-
-```python
-from dblect import ModelContract
-from dblect.demo import Currency, Money
-
-class StgPayments(ModelContract):
-    dbt_model = "stg_payments"
-    amount: Money.refine(currency=Currency.USD)
-```
-
-**Know the binding rule, or your columns will silently collapse.** This is the one
-mechanic worth getting right before you write a contract. A domain type binds its
-*magnitude facet* (for `Money`, the field named `amount`) to a warehouse column, and
-by default that column is the one named the same as the facet: `amount`. The contract
-*field name* on the left does not drive the binding.
-
-So when a model has several money columns whose names are not `amount`, annotating
-each with a bare type points all of them at one phantom column called `amount`. They
-collapse together and resolve to nothing. Map each one explicitly with `.columns(...)`,
-naming the real column the magnitude lives in:
+**Bind types with a `ModelContract`, and know the binding rule.** A contract names its
+model with `dbt_model` and annotates each typed column; bindings alone, with no
+methods, already buy propagation. The one mechanic to get right: a domain type binds
+its *magnitude facet* (for `Money`, the field `amount`) to the warehouse column of the
+*same name*, not to the contract field on the left. So several money columns not named
+`amount`, each annotated with a bare type, all point at one phantom `amount`,
+collapse, and resolve to nothing. Map each with `.columns(...)`:
 
 ```python
 from dblect import ModelContract
@@ -276,21 +204,22 @@ MoneyUSD = Money.refine(currency=Currency.USD)
 
 class Orders(ModelContract):
     dbt_model = "orders"
-    # `amount` is literally named amount, so the bare refinement binds it.
-    amount: MoneyUSD
-    # These are not named `amount`, so map the magnitude facet to the real column.
+    amount: MoneyUSD  # named `amount`, so the bare refinement binds it
     credit_card_amount: MoneyUSD.columns(amount="credit_card_amount")
     coupon_amount: MoneyUSD.columns(amount="coupon_amount")
     bank_transfer_amount: MoneyUSD.columns(amount="bank_transfer_amount")
 ```
 
-The rule in one line: bind with the bare type only when the column is named after the
-facet; otherwise reach for `.columns(amount="real_column_name")`.
+Bare type only when the column is named after the facet; otherwise
+`.columns(amount="real_column")`.
 
-**Add a functional-dependency fact when a rollup needs it.** A `@contract` method
-that returns a fact lets the analyzer discharge an obligation it could not see on its
-own. The canonical one: every payment on an order shares the order's currency, so
-summing an order's payments is well defined.
+**Add a fact when a rollup needs it.** A `@contract` method returning a fact
+discharges an obligation the analyzer cannot see on its own. The vocabulary is small
+and structural: `determines` (a functional dependency), `key`, `references`, `grain`.
+The canonical case: every payment on an order shares the order's currency, so the
+per-order sum is well defined. A containment hierarchy is the same `determines` fact
+applied per step (`ad_id.determines(adset_id)`, then
+`adset_id.determines(campaign_id)`).
 
 ```python
 from dblect import ModelContract, contract
@@ -302,87 +231,49 @@ class StgPayments(ModelContract):
 
     @contract
     def one_currency_per_order(self):
-        # The order_id determines the currency, so the per-order rollup is sound.
         return self.order_id.determines(self.currency)
 ```
 
-A containment hierarchy is the same fact, applied to identifiers. If each ad belongs
-to one adset and each adset to one campaign, then spend summed at the ad level keeps
-its campaign, and a `group by campaign_id` stays well defined:
-
-```python
-from dblect import ModelContract, contract
-
-class FctAdSpend(ModelContract):
-    dbt_model = "fct_ad_spend"
-
-    # One fact per method: each step of ad -> adset -> campaign is its own
-    # functional dependency.
-    @contract
-    def ad_in_one_adset(self):
-        return self.ad_id.determines(self.adset_id)
-
-    @contract
-    def adset_in_one_campaign(self):
-        return self.adset_id.determines(self.campaign_id)
-```
-
-The fact vocabulary you can return is small and structural: `determines` (a
-functional dependency), `key`, `references`, and `grain`. Reach for one only when a
-real invariant in the project supports it.
-
 ## Step 5: check and self-correct
-
-Run the checker:
 
 ```text
 dblect check .
 ```
 
-**Read the coverage line before the findings.** The check reports how much of what
-you declared actually resolved, and that is your first diagnostic. The key counter is
-the number of contract columns that resolved against the compiled SQL. If it is lower
-than the number of columns you declared, some bindings did not land, even when no
-finding fired. The two usual causes are the binding-rule collapse above (a money
-column not mapped with `.columns(...)`, so it pointed at a phantom `amount`) and a
-missing `catalog.json` (an undocumented column that cannot resolve until the catalog
-exists). A grounding count like `domain_type 7/27` is expected and fine: it means you
-typed 7 of 27 columns, which is the point, you type only the columns that carry
-meaning. Chase the resolved-columns count up to the number you declared; do not chase
-grounding up to the total.
+**Read the coverage line before the findings.** The key counter is how many contract
+columns resolved against the compiled SQL. If it is below the number you declared,
+some bindings did not land even with no finding firing: usually the binding-rule
+collapse above, or a missing `catalog.json`. A grounding count like `domain_type 7/27`
+is expected and right (you type only the columns that carry meaning). Chase the
+resolved-columns count up to what you declared; do not chase grounding up to the
+total.
 
-Then read the findings and loop. Two kinds matter here:
+Then read the findings. Three kinds matter:
 
-- **Contract issues** mean a declaration does not line up with the manifest:
-  `unresolved_model` (a misspelled or renamed model), `unknown_column` (a column
-  that is not on the model), `unsourced_field` (a type facet with no column behind
-  it), `out_of_domain_value` (a value outside an enum). Each names the contract and
-  field. Fix the declaration so it matches the real names in `_stubs/models.py`.
-- **`domain_type_contradiction`** means the meaning you declared conflicts with what
-  the DAG carries: a currency creeping in where you pinned USD, a net figure flowing
-  into a gross contract. This is the headline catch. Decide whether the declaration
-  is stale (the data legitimately changed and the type should open up) or the SQL
-  introduced a real bug, and fix the half that is wrong.
-- **`aggregation_not_well_typed`** means a sum or other aggregate combined values the
-  analyzer could not prove are the same kind. Often that is the real catch (a
-  mixed-currency sum). But it can also be a conservative artifact: when the group
-  shape is unresolved, or the column's lineage routes through a **skipped Python
-  model** (Step 1), the analyzer cannot prove per-group constancy and fires rather
-  than stay silent. Before acting on one, test whether it is real: does it fire
+- **`contract_issue`**: a declaration does not line up with the manifest. The message
+  names the cause and the field, one of: an unresolved model (misspelled or renamed),
+  an unknown column (not on the model), an unsourced field (a type facet with no
+  column behind it), or an out-of-domain value. Fix the declaration to match the real
+  names in `_stubs/models.py`.
+- **`domain_type_contradiction`**: the meaning you declared conflicts with what the
+  DAG carries (a currency creeping in where you pinned USD, a net figure flowing into
+  a gross contract). The headline catch. Decide whether the declaration is stale (open
+  it up) or the SQL has a real bug (fix it).
+- **`aggregation_not_well_typed`**: an aggregate combined values the analyzer could
+  not prove are the same kind. Often the real catch (a mixed-currency sum), but it can
+  be a conservative artifact when the group shape is unresolved or the lineage routes
+  through a skipped Python model (Step 1). Test before acting: does it fire
   independent of the column it supposedly conflicts with, and does the lineage trace
-  back through a skipped model or an unresolved group? If so, it is a can't-prove
-  artifact from a lineage gap, not a meaning conflict; note it and move on rather than
-  contorting the declarations to chase it.
+  through a skipped model or unresolved group? If so it is a can't-prove artifact from
+  a lineage gap; note it and move on rather than contorting declarations to chase it.
 
-Iterate until the contract issues are gone. A remaining `domain_type_contradiction`
-may be a true finding worth surfacing to the user rather than silencing; explain it
-and let them decide.
+Iterate until contract issues are gone. A remaining `domain_type_contradiction` may
+be a true finding worth surfacing to the user; explain it and let them decide.
 
 ## What good looks like
 
-A small, honest declaration layer: domain types on the magnitudes that carry a unit
-(money, rates, fixed-scale quantities), refinements that pin the unit or the
-net/gross reading you confirmed with the user, and a functional-dependency fact or
-two where a rollup needs it. A handful of contracts, not a wall of them. Every
-binding grounded in a real column name and every vouched fact grounded in a real
-invariant of the project.
+A small, honest declaration layer: domain types on the magnitudes that carry a unit,
+refinements that pin the unit or the net/gross reading you confirmed, and a
+functional-dependency fact or two where a rollup needs it. A handful of contracts, not
+a wall of them. Every binding grounded in a real column name, every vouched fact in a
+real invariant.

--- a/src/dblect/bootstrap/skill.md
+++ b/src/dblect/bootstrap/skill.md
@@ -1,0 +1,213 @@
+# Bootstrap dblect types and contracts for a dbt project
+
+Your job is to read a dbt project, work out which columns carry meaning that plain
+validation cannot see, and draft the dblect declaration layer that pins that
+meaning. Then run `dblect check` and correct the draft until it resolves cleanly.
+
+dblect already earns its keep with zero declarations: a dozen structural detectors
+read the compiled SQL and flag ordering, join, and NULL hazards on their own. It
+also reads your existing dbt tests directly. A `unique` or `dbt_utils.unique_combination_of_columns`
+test becomes a key fact; a `relationships` test becomes a foreign-key edge; an
+`accepted_values` test becomes a value domain. **You do not need to restate any of
+that.** Re-declaring keys and foreign keys that a dbt test already states adds
+noise and no signal.
+
+What no dbt test can express, and what you are here to add, is *semantics*: that a
+column is money in some currency, that a revenue figure is net of tax rather than
+gross, that two amounts are the same kind of quantity and may be summed together.
+That is the layer dblect propagates along the DAG to catch a meaning shift (a
+currency creeping in upstream, a net figure flowing into a gross contract) before
+it reaches a dashboard.
+
+## What is in scope
+
+Declare these, and nothing more:
+
+- **Domain types** on the columns whose meaning matters: money, rates, anything
+  where two numerically valid values are not comparable.
+- **Refinements** that fix a meaning-bearing parameter (single currency, net vs
+  gross, tax inclusive or not).
+- **Functional-dependency facts** that let a rollup stay well typed (for example,
+  every payment on an order shares the order's currency).
+
+Leave out anything you cannot ground in the project's real semantics. A vouched
+declaration that the data does not support is worse than no declaration: dblect
+trusts it and propagates it. When you are unsure what a column means, ask the user
+rather than guess (see "Interview the user").
+
+Two surfaces are deliberately out of scope for this pass, because they do not yet
+run on the `dblect check` path: configuration flags (`DomainFlag`) and runnable
+contract predicates (an equality with `.within(...)`). Stick to domain types,
+refinements, and the fact-returning contracts below.
+
+## Step 1: orient
+
+Confirm you are in a dbt project (a `dbt_project.yml` exists) and that dblect has
+a manifest to read. If `target/manifest.json` is missing, run `dbt compile`
+yourself, or let `dblect init` produce it for you (it falls back to `dbt compile`):
+
+```text
+dblect init .
+```
+
+`init` scaffolds the `dblect/` declaration tree and writes `dblect/_stubs/models.py`,
+generated from the manifest. **Read that stubs file.** It lists every model and its
+columns under their real names. Every type and column you bind must match a name in
+there, so use it as your source of truth and never invent a column.
+
+Read the project structure: the `models/` tree (usually split into `staging/` and
+`marts/`), each model's `.sql`, and the `schema.yml` files that carry column
+descriptions and tests. The descriptions are often where a human already wrote down
+what a column means.
+
+## Step 2: find the loaded columns
+
+Walk the models and macros looking for columns whose meaning is richer than their
+SQL type. The high-value candidates:
+
+- **Money and revenue.** Any `amount`, `price`, `revenue`, `cost`, `total`, or
+  `value` column. The meaning that matters is the hidden parameters: which currency,
+  net or gross, tax inclusive or exclusive, before or after discounts. A `Decimal`
+  tells you none of this.
+- **Currencies and units.** A `currency` column, or a money column that should carry
+  one. This is the tag that makes a mixed-currency sum ill typed.
+- **Rates and percentages.** A `rate`, `pct`, or `ratio` column. What is the base,
+  and what window does it cover.
+- **Keys and grain, only where semantics add something.** The grain (one row per
+  order, or per order line) when a rollup depends on it. Skip keys and foreign keys
+  a dbt test already declares.
+
+Read the SQL to form a hypothesis. A `sum(amount)` grouped by `order_id` tells you
+the author believes an order's payments are summable. A currency conversion macro
+tells you money flows across currencies. Trace a money column from its source
+through staging into the marts, and watch for the point where its meaning could
+change without the type following.
+
+## Step 3: infer what you can, interview for the rest
+
+Some meaning is readable from the code. A model that filters `where currency = 'USD'`
+is single currency by construction. A macro named `to_usd` converts. Lean on the
+SQL, the column descriptions, and the dbt test metadata.
+
+The rest you cannot read off the code, and you should not guess it:
+
+- Is this `amount` always one currency, or did the source go multi-currency?
+- Is `revenue` net of tax and discounts, or gross?
+- Is the grain one row per order, or per order line?
+
+**Interview the user.** Propose your reading of each ambiguous column and ask for
+confirmation before you write a vouched fact. For example: "I read `stg_payments.amount`
+as USD because the model filters to US orders. Is that still true now that the
+source carries a `currency` column?" If you are running in a setting where you
+cannot ask, draft the declaration anyway and mark the assumption with a `# TODO:
+confirm ...` comment so a human can check it.
+
+## Step 4: write the declarations
+
+Put domain types in `dblect/types.py` and contracts under `dblect/contracts/`.
+`src/dblect/demo/library.py` and the runnable examples in
+`tests/fixtures/scenarios/cases/*/dblect/` are the canonical templates; copy their
+shape.
+
+`Money` is the worked example: an amount and the currency it is denominated in, so
+a sum that mixes currencies stops being well typed. It ships in `dblect.demo`.
+Declare your own domain type the same way, by subclassing `DomainType` and giving
+each facet a typed field:
+
+```python
+from dblect.types import Decimal, DomainType, UnitEnum
+
+class Currency(UnitEnum):
+    USD = "USD"
+    EUR = "EUR"
+
+class Money(DomainType):
+    amount: Decimal(18, 2)
+    currency: Currency
+```
+
+A `UnitEnum` is a tag that must agree when values combine; a `NominalEnum` is a tag
+that rides along without that constraint. Use the shipped `dblect.demo.Currency`
+slice, or declare your project's own categories as above.
+
+**Refine to fix a meaning-bearing parameter.** A single-currency column pins the
+currency; a multi-currency column binds the currency to the column that records it:
+
+```python
+from dblect.demo import Currency, Money
+
+# Single currency: pin the tag, so a mixed-currency sum stops being well typed.
+RevenueUSD = Money.refine(currency=Currency.USD)
+
+# Multi-currency: bind the currency facet to the column that records it.
+PaymentMoney = Money.columns(amount="amount", currency="currency")
+```
+
+**Bind types to a model with a `ModelContract`.** Name the model with `dbt_model`
+and annotate each column you are typing. A contract with only column bindings and
+no methods is valid and already buys type propagation:
+
+```python
+from dblect import ModelContract
+from dblect.demo import Currency, Money
+
+class StgPayments(ModelContract):
+    dbt_model = "stg_payments"
+    amount: Money.refine(currency=Currency.USD)
+```
+
+**Add a functional-dependency fact when a rollup needs it.** A `@contract` method
+that returns a fact lets the analyzer discharge an obligation it could not see on
+its own. The canonical one: every payment on an order shares the order's currency,
+so summing an order's payments is well defined.
+
+```python
+from dblect import ModelContract, contract
+from dblect.demo import Money
+
+class StgPayments(ModelContract):
+    dbt_model = "stg_payments"
+    value: Money.columns(amount="amount", currency="currency")
+
+    @contract
+    def one_currency_per_order(self):
+        # The order_id determines the currency, so the per-order rollup is sound.
+        return self.order_id.determines(self.currency)
+```
+
+The fact vocabulary you can return is small and structural: `determines` (a
+functional dependency), `key`, `references`, and `grain`. Reach for one only when a
+real invariant in the project supports it.
+
+## Step 5: check and self-correct
+
+Run the checker:
+
+```text
+dblect check .
+```
+
+Read the findings and loop. Two kinds matter here:
+
+- **Contract issues** mean a declaration does not line up with the manifest:
+  `unresolved_model` (a misspelled or renamed model), `unknown_column` (a column
+  that is not on the model), `unsourced_field` (a type facet with no column behind
+  it), `out_of_domain_value` (a value outside an enum). Each names the contract and
+  field. Fix the declaration so it matches the real names in `_stubs/models.py`.
+- **`domain_type_contradiction`** means the meaning you declared conflicts with what
+  the DAG carries: a currency creeping in where you pinned USD, a net figure flowing
+  into a gross contract. This is the headline catch. Decide whether the declaration
+  is stale (the data legitimately changed and the type should open up) or the SQL
+  introduced a real bug, and fix the half that is wrong.
+
+Iterate until the contract issues are gone. A remaining `domain_type_contradiction`
+may be a true finding worth surfacing to the user rather than silencing; explain it
+and let them decide.
+
+## What good looks like
+
+A small, honest declaration layer: domain types on the money and rate columns that
+matter, refinements that pin the currency or the net/gross reading you confirmed
+with the user, and a functional-dependency fact or two where a rollup needs it. A
+handful of contracts, not a wall of them. Every binding grounded in a real column
+name and every vouched fact grounded in a real invariant of the project.

--- a/src/dblect/cli/__init__.py
+++ b/src/dblect/cli/__init__.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING, Annotated
 
 import typer
 
+from dblect.bootstrap import SetupTarget
+
 if TYPE_CHECKING:
     from dblect.adapters import AdapterProfile
     from dblect.manifest import Manifest
@@ -197,6 +199,39 @@ def init(
     for path in (*created, stubs_path):
         typer.echo(f"init: wrote {path}")
     typer.echo("init: scaffolding complete; add contracts and run `dblect check`.")
+
+
+@app.command()
+def setup(
+    target: Annotated[
+        SetupTarget,
+        typer.Argument(  # pyright: ignore[reportUnknownMemberType]
+            help="The AI coding agent to install the bootstrap skill into.",
+        ),
+    ],
+    project_dir: Annotated[
+        Path,
+        typer.Argument(  # pyright: ignore[reportUnknownMemberType]
+            help="Project to install into (where .claude/, .cursor/, or AGENTS.md lives).",
+        ),
+    ] = Path("."),
+    print_only: Annotated[
+        bool,
+        typer.Option(  # pyright: ignore[reportUnknownMemberType]
+            "--print",
+            help="Write the adapted skill to stdout instead of installing it.",
+        ),
+    ] = False,
+) -> None:
+    """Install the dblect bootstrap skill into an AI coding agent's project surface."""
+    from dblect.bootstrap import install, render
+
+    if print_only:
+        typer.echo(render(target))
+        return
+    path = install(target, project_dir)
+    typer.echo(f"setup: wrote {path}")
+    typer.echo(f"setup: open your {target.value} agent and run the dblect-bootstrap skill.")
 
 
 _STARTER_TYPES = '"""Project domain types: DomainType subclasses and named refinements."""\n'

--- a/tests/bootstrap/test_skill_drift.py
+++ b/tests/bootstrap/test_skill_drift.py
@@ -1,0 +1,35 @@
+"""Keep the bootstrap skill's DSL honest against the live API.
+
+The skill ships its declaration examples inline, so an example can rot silently
+when the surface it teaches moves. Every ``python`` block in ``skill.md`` is meant
+to be real, runnable-against-the-API code; this execs each one against the actual
+imports so a renamed symbol, a moved import, or a dropped method fails CI here
+instead of misleading an agent that copies from the skill.
+
+Partial or illustrative snippets belong in ``text`` blocks, not ``python`` ones.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dblect.bootstrap import python_examples
+from dblect.types import isolated_registry
+
+
+def test_skill_has_executable_examples() -> None:
+    # A vacuous guard (zero blocks) would pass while teaching nothing; pin a floor.
+    assert len(python_examples()) >= 3
+
+
+@pytest.mark.parametrize("block", python_examples(), ids=lambda b: b.splitlines()[0][:50])
+def test_skill_python_block_runs_against_live_api(block: str) -> None:
+    # Each block carries its own imports and defines its own types/contracts. An
+    # isolated registry keeps contract classes from colliding across blocks or
+    # leaking into other tests' registries.
+    with isolated_registry():
+        namespace: dict[str, object] = {}
+        # dont_inherit keeps this test module's `from __future__ import annotations`
+        # from stringizing the block's annotations, which would defer their evaluation
+        # past the class body where the block's own imports are in scope.
+        exec(compile(block, "skill.md", "exec", dont_inherit=True), namespace)

--- a/tests/cli/test_setup.py
+++ b/tests/cli/test_setup.py
@@ -1,0 +1,81 @@
+"""``dblect setup <target>`` installs the bootstrap skill into a project.
+
+The skill content is pinned in ``tests/bootstrap``; here we confirm the installer
+wiring: each target writes to its surface's path with the right wrapper, ``--print``
+writes nothing, the ``AGENTS.md`` block is idempotent and preserves the user's
+prose, and an unknown target is rejected.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from dblect.cli import app
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def test_setup_claude_writes_skill_file(runner: CliRunner, tmp_path: Path) -> None:
+    result = runner.invoke(app, ["setup", "claude", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+
+    skill = tmp_path / ".claude" / "skills" / "dblect-bootstrap" / "SKILL.md"
+    assert skill.exists()
+    body = skill.read_text()
+    assert body.startswith("---\n")
+    assert "name: dblect-bootstrap" in body
+    assert "ModelContract" in body  # the body, not just the frontmatter
+    assert str(skill) in result.output
+
+
+def test_setup_cursor_writes_rule_file(runner: CliRunner, tmp_path: Path) -> None:
+    result = runner.invoke(app, ["setup", "cursor", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+
+    rule = tmp_path / ".cursor" / "rules" / "dblect-bootstrap.mdc"
+    assert rule.exists()
+    body = rule.read_text()
+    assert body.startswith("---\n")
+    assert "alwaysApply" in body
+    assert "ModelContract" in body
+
+
+def test_setup_codex_appends_delimited_block(runner: CliRunner, tmp_path: Path) -> None:
+    agents = tmp_path / "AGENTS.md"
+    agents.write_text("# House rules\n\nBe nice.\n")
+
+    result = runner.invoke(app, ["setup", "codex", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+
+    body = agents.read_text()
+    assert "Be nice." in body  # user's prose survives
+    assert body.count("BEGIN dblect:bootstrap") == 1
+    assert "ModelContract" in body
+
+
+def test_setup_codex_is_idempotent(runner: CliRunner, tmp_path: Path) -> None:
+    # Re-running replaces dblect's own block rather than stacking a second copy.
+    runner.invoke(app, ["setup", "codex", str(tmp_path)])
+    runner.invoke(app, ["setup", "codex", str(tmp_path)])
+
+    body = (tmp_path / "AGENTS.md").read_text()
+    assert body.count("BEGIN dblect:bootstrap") == 1
+    assert body.count("END dblect:bootstrap") == 1
+
+
+def test_setup_print_writes_nothing(runner: CliRunner, tmp_path: Path) -> None:
+    result = runner.invoke(app, ["setup", "claude", str(tmp_path), "--print"])
+    assert result.exit_code == 0, result.output
+    assert "ModelContract" in result.output
+    assert not (tmp_path / ".claude").exists()
+
+
+def test_setup_rejects_unknown_target(runner: CliRunner, tmp_path: Path) -> None:
+    result = runner.invoke(app, ["setup", "emacs", str(tmp_path)])
+    assert result.exit_code != 0


### PR DESCRIPTION
Closes #121.

Ships an installable, harness-agnostic skill that drives an AI coding agent through investigating a dbt project and drafting dblect's semantic declaration layer, then running the check loop. It is an instruction file plus a reference, versioned beside the DSL it teaches, off the analysis path.

## What it does

`src/dblect/bootstrap/skill.md` walks an agent through: orient (`dblect init`, read the generated `_stubs/models.py` for real names) → find the loaded columns (money/currency, rates, net-vs-gross, grain) → infer from the SQL where possible and **interview the user** where meaning is ambiguous → draft `dblect/types.py` + contracts → run `dblect check` and self-correct off `ContractIssue` codes and `domain_type_contradiction`.

Two scoping decisions:
- **Built surface only.** Teaches `DomainType`, `.refine`, `.columns`, `ModelContract` bindings, and fact-returning `@contract`s (`determines`/`key`/`references`/`grain`). It omits `DomainFlag` worlds and runnable `.within(...)` predicates, which do not fire on the `dblect check` path yet, so the agent never writes declarations that silently no-op.
- **Semantic gap, not structure.** It steers the agent away from re-declaring keys and FKs, since dblect already ingests `unique`/`relationships`/`accepted_values`/`dbt_utils.*` tests into substrate facts with zero declarations. The value is the meaning no test expresses.

## Install path

`dblect setup <target>` adapts the one source `skill.md` into each agent surface:
- `claude` → `.claude/skills/dblect-bootstrap/SKILL.md`
- `cursor` → `.cursor/rules/dblect-bootstrap.mdc`
- `codex` → an idempotent delimited block in `AGENTS.md` (preserves the user's prose)

`--print` writes the adapted skill to stdout for review instead of installing. The markdown ships in the wheel as package data via `importlib.resources`, so it stays versioned with the DSL.

## Keeping it honest

The skill ships its DSL examples inline, so `tests/bootstrap/test_skill_drift.py` execs every `python` block against the live API (in an isolated registry). A renamed symbol or moved import fails CI here instead of misleading an agent that copies from the skill.

## Verification

- New tests: 11 (5 `setup` CLI, 6 drift-guard).
- Full suite: **850 passed** (was 822). `ruff check`, `ruff format --check`, and strict `pyright` all clean.

The Claude Code plugin namespace (`dblect:bootstrap`) is a fast-follow; `dblect setup claude` installs the project-level skill today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)