### PR TITLE
docs(design): static hazard findings as intent seeds for the generator

### DIFF
--- a/docs/design/contract-directed-generation.md
+++ b/docs/design/contract-directed-generation.md
@@ -102,6 +102,16 @@ Nine intents. Each is a generation template that fixes shape on specific columns
 
 A typical model with 2–3 contracts ends up running 4–8 intent-driven test budgets, plus a happy-path baseline. The framework runs them in parallel; each one shrinks independently to a minimal counterexample if it fails.
 
+## Static findings as intent seeds
+
+The reframe above treats a contract as a generator specification. A static hazard finding is a second source of the same information, and it is often a sharper one. When the static layer flags `where_on_outer_joined_nullable`, `join_on_nullable_key`, or `null_group_on_nullable_key`, it has already localized the exact join or predicate, the exact columns involved, and (for the WHERE case) a concrete suggested fix. That is precisely the input an intent needs. A finding on an outer-joined nullable side selects the Orphan and NullKey intents on that specific join; a fanout finding selects Fanout; an ordering finding selects OrderingTie. The static finding picks the intent and pins its parameters, so the generator runs one targeted budget against one join rather than searching the shape space for a contract.
+
+This complements the contract-directed path rather than replacing it. Contract-directed generation searches broadly for whatever shape breaks a declared property. Finding-seeded generation starts from a specific suspect the static analyzer already surfaced and confirms it. The two share the same intent catalog, fill layer, and example memory; they differ only in what supplies the generation target.
+
+The finding-seeded path also carries the property in the zero-declaration audit case. Where contract-directed generation needs a user-declared contract to falsify, a hazard finding ships with an implicit property derived from its own suggested remediation. For `where_on_outer_joined_nullable` the property is a differential: run the model as written and again with the suggested guard applied, and compare the row sets. An outer join that the WHERE has quietly demoted to inner shows a non-empty delta under an Orphan witness; a join that was genuinely inner all along shows none. The delta is both the proof and the triage signal. A non-empty delta is an active defect with a concrete witness row; an empty delta today marks the finding as dormant, which is exactly the latent-versus-active distinction a reader otherwise has to reason out by hand. This is the same spirit as the validation-mode story of running samples against the real warehouse: the static layer proposes, and a small generated or sampled run disposes.
+
+A practical sequencing note: this path reuses the v1 intent catalog and example memory directly, so it can ship as a thin adapter from finding kind to intent selection once the generator core lands, without waiting on the full contract DSL.
+
 ## What v1 commits to
 
 The v1 scope on the generator side:

--- a/docs/design/nullability-hazards.md
+++ b/docs/design/nullability-hazards.md
@@ -71,6 +71,10 @@ The de-duplication rule keeps them from talking over each other: a property-base
 
 Flattening an array with an inner lateral (`FROM t, UNNEST(t.arr)`, `CROSS JOIN UNNEST(...)`, `CROSS JOIN LATERAL ...`) silently drops the parent row whenever the array is empty or null. That looks like a nullability bug and is worth catching, but it is a row-preservation (cardinality) hazard, the deflation twin of join fanout: fanout multiplies rows, this annihilates them. The nullability property can prove only the null-array half of it and structurally misses the more common empty-array half (`[]` is a non-null, zero-length value), so it stays out of scope here and lives as a structural detector instead. A future collection-emptiness property could gate it precisely, reusing this engine's existential shape, once the static introducers for "can be empty" are rich enough to clear the firewall. Tracked separately as a `sql/patterns.py` detector.
 
+## Confirming a hazard at runtime
+
+A static finding here states that a hazard exists; it cannot show how many rows the hazard moves today. That blast-radius question is what separates an active defect from a dormant one, and it is easy to misjudge by reading the SQL alone. The runtime layer answers it. Each of these findings doubles as a generation seed: it has already localized the join, the columns, and (for the WHERE case) a suggested guard, which is enough to pick an intent and pin its parameters. Running the model as written against the same model with the guard applied yields a row-set delta that is both the proof and the triage signal, a non-empty delta marking an active defect with a witness row and an empty delta marking the finding dormant. See "Static findings as intent seeds" in [contract-directed-generation.md](contract-directed-generation.md) for how this rides the same intent catalog and example memory as the contract-directed path.
+
 ## Implementation sketch
 
 Grounded in the current code, the work is three slices that can land in order, each independently useful.


### PR DESCRIPTION
## What

Adds a design note connecting the static hazard detectors to the contract-directed PBT generator: **static findings are a second source of generator specifications**, alongside user-declared contracts.

Motivated by a real-project shakedown (`nba-monte-carlo`) where `where_on_outer_joined_nullable` correctly flagged a bug, but two expert readers misjudged the *impact* by reading the SQL alone (a 30-line duckdb run settled it instantly). The lesson: the static layer is great at "a hazard exists," and a small generated/sampled run is what answers "how many rows does it move today."

## Changes

- **`contract-directed-generation.md`**: new section "Static findings as intent seeds." A finding localizes the join, columns, and suggested guard, so it picks an intent (Orphan/NullKey/Fanout/OrderingTie) and pins its parameters, giving one targeted budget instead of a shape-space search. Covers the zero-declaration case: the finding's suggested remediation supplies an implicit differential property (as-written vs. guarded; the row-set delta is both proof and active-vs-dormant triage). Notes it can ship as a thin finding-kind→intent adapter once the generator core lands.
- **`nullability-hazards.md`**: pointer subsection "Confirming a hazard at runtime" linking to the above.

Docs only.