### PR TITLE
feat(cli): --diff <base-ref> to limit findings to changed lines (#10)

### DIFF
--- a/src/dblect/cli/__init__.py
+++ b/src/dblect/cli/__init__.py
@@ -12,6 +12,7 @@ import typer
 
 if TYPE_CHECKING:
     from dblect.adapters import AdapterProfile
+    from dblect.analysis import AnalysisReport
     from dblect.manifest import Manifest
 
 app = typer.Typer(
@@ -118,6 +119,24 @@ def check(
             ),
         ),
     ] = None,
+    diff: Annotated[
+        str | None,
+        typer.Option(  # pyright: ignore[reportUnknownMemberType]
+            "--diff",
+            metavar="BASE_REF",
+            help=(
+                "Limit structural findings to lines changed since BASE_REF, using "
+                "`git diff --unified=0 BASE_REF...HEAD`. A finding is kept when its "
+                "model's source file was touched and, where the compiled line numbers "
+                "can be trusted, the line span intersects the change. Structural line "
+                "numbers index the compiled SQL, so for macro-heavy models (compiled "
+                "lines differ from source) the filter falls back to file-level "
+                "membership rather than drop a real finding. Declaration findings carry "
+                "no line and pass through unchanged. Falls back to the full report when "
+                "the project is not a git checkout or BASE_REF does not resolve."
+            ),
+        ),
+    ] = None,
 ) -> None:
     """Check a dbt project: structural hazards and declaration-level contracts.
 
@@ -145,6 +164,8 @@ def check(
         loaded, profile, registry=load_result.registry, resolution_floor=resolution_floor
     )
     report = replace(report, check=replace(report.check, load_issues=load_result.issues))
+    if diff is not None:
+        report = _apply_diff_filter(report, project_dir=project_dir, base_ref=diff, command="check")
     match output_format:
         case OutputFormat.JSON:
             rendered = render_json(report)
@@ -222,6 +243,43 @@ def _scaffold_declarations(decl: Path) -> list[Path]:
         path.write_text(body)
         created.append(path)
     return created
+
+
+def _apply_diff_filter(
+    report: AnalysisReport, *, project_dir: Path, base_ref: str, command: str
+) -> AnalysisReport:
+    """Narrow ``report`` to findings on lines changed since ``base_ref``.
+
+    Degrades honestly: when the project is not a git checkout or ``base_ref`` does
+    not resolve, the changed-line map is unavailable and the full report is returned
+    unchanged, with a note on stderr so the operator knows the filter was a no-op.
+    The structural family is filtered (declaration findings carry no line and pass
+    through); both the merged ``findings`` view and the audit family's own
+    ``findings`` are narrowed so the report stays coherent.
+    """
+    from dataclasses import replace
+
+    from dblect.diff_filter import (
+        changed_lines_from_git,
+        filter_located_to_changed_lines,
+        filter_to_changed_lines,
+    )
+
+    changed = changed_lines_from_git(project_dir, base_ref)
+    if changed is None:
+        typer.echo(
+            f"{command}: --diff base ref `{base_ref}` could not be resolved against a git "
+            f"checkout at {project_dir}; reporting the full result.",
+            err=True,
+        )
+        return report
+    filtered = filter_to_changed_lines(report.findings, changed)
+    audit_findings = filter_located_to_changed_lines(report.audit.findings, changed)
+    return replace(
+        report,
+        findings=filtered,
+        audit=replace(report.audit, findings=audit_findings),
+    )
 
 
 def _resolve_profile(

--- a/src/dblect/diff_filter.py
+++ b/src/dblect/diff_filter.py
@@ -1,0 +1,193 @@
+"""Limit structural findings to the lines a pull request touches.
+
+On a PR, the findings worth a reviewer's attention are the ones on lines the PR
+changed. ``dblect check --diff <base-ref>`` computes the per-file changed-line set
+from ``git diff --unified=0 <base-ref>...HEAD`` and keeps only the structural
+findings that land on a touched source file (and, where line provenance is
+trustworthy, a touched line). This is the same idea code-coverage and lint tools use
+to scope their output to a diff.
+
+The compiled-vs-source line subtlety
+------------------------------------
+
+A structural :class:`~dblect.sql.patterns.Finding` carries ``line_start`` /
+``line_end`` that index the model's *compiled* SQL (``compiled_code``), which dbt
+renders with refs and macros expanded inline. A git diff, by contrast, hunks the
+on-disk *source* file. For a ref-only model the two line up (``{{ ref(...) }}``
+expands to one relation on the same line), but a macro that emits several lines from
+one source line shifts every line below it, so a naive intersection of compiled-line
+spans against source hunks would mislocate findings in macro-heavy models.
+
+The honest contract this filter enforces keeps every real finding and uses line
+numbers only where they can be trusted:
+
+* A finding whose model source file has no changed line is dropped: the PR did not
+  touch that model's file at all.
+* Within a touched file, a finding is kept when its compiled span intersects the
+  file's changed lines. When the span misses every changed line, it is kept only if
+  the span lies *outside* the file's diffed extent (the lowest..highest changed
+  line). A span beyond that extent signals compiled-vs-source skew, where the line
+  numbers cannot be trusted, so we fall back to file-level membership rather than
+  drop a finding that may be real. A span inside the diffed extent that still misses
+  every changed line is a trustworthy miss, so it is dropped.
+* A finding with no line span (``line_start == 0``, "model scope, line unknown") is
+  kept whenever its file has any changed line, since there is no span to test.
+* A finding with no source file (``file_path is None``) is dropped under ``--diff``:
+  it cannot be located against any hunk.
+
+A precise compiled-line to source-line back-map (so macro-heavy models filter at
+line granularity too) is tracked separately as issue #124. This filter stays at
+file-level plus best-effort line intersection.
+
+Declaration-level findings (:class:`~dblect.check.findings.CheckFinding`) carry no
+line number, so ``--diff`` leaves them untouched.
+
+Falling back honestly
+----------------------
+
+When the working directory is not a git checkout, or the base ref does not resolve,
+:func:`changed_lines_from_git` returns ``None`` and the caller renders the full
+report. ``--diff`` narrows output when it can and degrades to the unfiltered report
+when it cannot, never crashing the run over a missing ``.git`` or a bad ref.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import assert_never
+
+from dblect.analysis import AnalysisFinding
+from dblect.audit.walker import LocatedFinding
+from dblect.check.findings import CheckFinding
+
+# A source file path (relative, as dbt stores ``original_file_path`` and as git
+# prints it) to the set of 1-indexed line numbers the diff added or changed on the
+# post-image (new) side. A file present with an empty set was touched only by
+# deletions, so it has no reachable changed line.
+ChangedLines = Mapping[str, frozenset[int]]
+
+# `@@ -<old> +<new> @@`, where each side is `start` or `start,count`. We read only
+# the new side: the post-image is where surviving findings live.
+_HUNK_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+# `+++ b/path` names the post-image file. Renames and adds carry the new path here.
+_NEW_FILE_RE = re.compile(r"^\+\+\+ (?:b/)?(.+)$")
+
+
+def parse_unified_diff(text: str) -> ChangedLines:
+    """Parse ``git diff --unified=0`` output into a per-file changed-line map.
+
+    Reads each file's ``+++`` header for the post-image path and each ``@@`` hunk
+    for the new-side line range, collecting the 1-indexed lines the hunk added. A
+    deletion-only hunk (new count ``0``) contributes no lines, so a file changed
+    only by deletions maps to an empty set. ``/dev/null`` post-images (a full file
+    deletion) are skipped, since there is no surviving file to attribute findings to.
+    """
+    changed: dict[str, set[int]] = {}
+    current: str | None = None
+    for line in text.splitlines():
+        new_file = _NEW_FILE_RE.match(line)
+        if new_file is not None:
+            path: str = new_file.group(1).strip()
+            if path == "/dev/null":
+                current = None
+                continue
+            current = path
+            changed.setdefault(path, set())
+            continue
+        hunk = _HUNK_RE.match(line)
+        if hunk is not None and current is not None:
+            start = int(hunk.group(1))
+            count = 1 if hunk.group(2) is None else int(hunk.group(2))
+            changed[current].update(range(start, start + count))
+    return {path: frozenset(lines) for path, lines in changed.items()}
+
+
+def filter_to_changed_lines(
+    findings: Sequence[AnalysisFinding], changed: ChangedLines
+) -> tuple[AnalysisFinding, ...]:
+    """Keep the findings a ``--diff`` run should report, per the module contract.
+
+    Declaration findings pass through unchanged. Structural findings are kept by
+    file membership and best-effort line intersection. Pure over its inputs, so the
+    contract is exercised without invoking git.
+    """
+    return tuple(f for f in findings if _survives(f, changed))
+
+
+def filter_located_to_changed_lines(
+    findings: Sequence[LocatedFinding], changed: ChangedLines
+) -> tuple[LocatedFinding, ...]:
+    """Keep the structural findings a ``--diff`` run should report.
+
+    The structural-only counterpart to :func:`filter_to_changed_lines`, so a caller
+    holding the audit family alone keeps the narrower ``LocatedFinding`` element type
+    rather than widening to the sealed union.
+    """
+    return tuple(f for f in findings if _located_survives(f, changed))
+
+
+def _survives(finding: AnalysisFinding, changed: ChangedLines) -> bool:
+    match finding:
+        case CheckFinding():
+            return True
+        case LocatedFinding():
+            return _located_survives(finding, changed)
+    assert_never(finding)
+
+
+def _located_survives(finding: LocatedFinding, changed: ChangedLines) -> bool:
+    if finding.file_path is None:
+        return False
+    touched = changed.get(finding.file_path)
+    if not touched:
+        # File untouched, or touched only by deletions: no post-image line to land
+        # on, so nothing the diff added carries this finding.
+        return False
+    span = finding.finding.line_start, finding.finding.line_end
+    if span[0] == 0:
+        # Line unknown (model scope): a touched file is the only signal we have.
+        return True
+    lo, hi = span
+    if any(line in touched for line in range(lo, hi + 1)):
+        return True
+    # The span misses every changed line. Trust the miss only when the span sits
+    # inside the file's diffed extent; a span beyond it is compiled-vs-source skew,
+    # where we fall back to file membership rather than drop a possibly real finding.
+    extent_lo, extent_hi = min(touched), max(touched)
+    within_extent = lo >= extent_lo and hi <= extent_hi
+    return not within_extent
+
+
+def changed_lines_from_git(project_dir: Path, base_ref: str) -> ChangedLines | None:
+    """The per-file changed-line map for ``base_ref...HEAD``, or ``None`` to fall back.
+
+    Runs ``git diff --unified=0 <base-ref>...HEAD`` rooted at ``project_dir`` so the
+    paths it returns are relative to the repository, matching dbt's
+    ``original_file_path``. Returns ``None`` when the directory is not a git checkout
+    or the ref does not resolve, so the caller renders the full report instead of
+    crashing. The merge-base form (``...``) scopes the diff to what HEAD changed
+    since it forked from the base, which is what a PR review wants.
+    """
+    try:
+        completed = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(project_dir),
+                "diff",
+                "--unified=0",
+                "--no-color",
+                f"{base_ref}...HEAD",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except (OSError, ValueError):
+        return None
+    if completed.returncode != 0:
+        return None
+    return parse_unified_diff(completed.stdout)

--- a/tests/cli/test_check_diff.py
+++ b/tests/cli/test_check_diff.py
@@ -1,0 +1,156 @@
+"""End-to-end tests for ``dblect check --diff <base-ref>`` over a real git repo.
+
+These drive the whole path: materialise the vendored jaffle project (manifest plus
+its model source files reconstructed from each node's ``raw_code``) into a throwaway
+git checkout, edit a model across a commit, and assert that ``--diff`` keeps only the
+findings on touched lines while leaving declaration findings and skips alone. The
+diff parsing and the intersection contract are pinned without git in
+``tests/test_diff_filter.py``; this module pins the git integration and the
+honest-fallback behaviour.
+
+Jaffle is ref-only: ``{{ ref(...) }}`` expands to a single quoted relation on the
+same line, so the compiled SQL and the on-disk source keep the same line numbers.
+That alignment is what lets a source-file diff intersect a compiled-line span
+honestly. The lone jaffle structural finding (``null_group_after_outer_join``) lands
+on line 44 of ``models/customers.sql``.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from dblect.cli import app
+from dblect.manifest import Manifest
+
+_FINDING_FILE = "models/customers.sql"
+_FINDING_LINE = 44
+_FINDING_KIND = "null_group_after_outer_join"
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
+
+
+def _materialise_jaffle(project: Path, manifest_path: Path) -> None:
+    """Write the jaffle manifest into ``project/target`` and reconstruct each
+    model's source file from its ``raw_code`` at its ``original_file_path`` so the
+    on-disk tree matches what the manifest and a git diff see."""
+    (project / "target").mkdir(parents=True, exist_ok=True)
+    (project / "dbt_project.yml").write_text("name: jaffle_shop\nprofile: jaffle_shop\n")
+    shutil.copy(manifest_path, project / "target" / "manifest.json")
+    manifest = Manifest.from_file(manifest_path)
+    for node in manifest.models.values():
+        if node.original_file_path is None or node.raw_code is None:
+            continue
+        dest = project / node.original_file_path
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(node.raw_code)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def repo(tmp_path: Path, jaffle_manifest_path: Path) -> Path:
+    """A git checkout of the jaffle project committed on ``main``."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    _materialise_jaffle(project, jaffle_manifest_path)
+    _git(project, "init", "-b", "main")
+    _git(project, "config", "user.email", "t@t.test")
+    _git(project, "config", "user.name", "t")
+    _git(project, "add", "-A")
+    _git(project, "commit", "-m", "base")
+    return project
+
+
+def _edit_line(repo: Path, rel: str, line_no: int, new_text: str) -> None:
+    path = repo / rel
+    lines = path.read_text().splitlines()
+    lines[line_no - 1] = new_text
+    path.write_text("\n".join(lines) + "\n")
+
+
+def _check_kinds(runner: CliRunner, repo: Path, *extra: str) -> set[str]:
+    result = runner.invoke(app, ["check", str(repo), "--format", "json", "--no-fail", *extra])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    return {f["kind"] for f in payload["findings"] if f["family"] == "structural"}
+
+
+def test_baseline_without_diff_reports_the_hazard(runner: CliRunner, repo: Path) -> None:
+    assert _FINDING_KIND in _check_kinds(runner, repo)
+
+
+def test_change_on_the_hazard_line_keeps_it(runner: CliRunner, repo: Path) -> None:
+    # Edit the very line the finding lands on; the touched line carries the hazard.
+    _edit_line(repo, _FINDING_FILE, _FINDING_LINE, "    group by orders.customer_id  -- grp")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "annotate group-by")
+    assert _FINDING_KIND in _check_kinds(runner, repo, "--diff", "main~1")
+
+
+def test_added_line_above_hazard_shifts_and_keeps_via_intersection(
+    runner: CliRunner, repo: Path
+) -> None:
+    # Insert a comment line right above the hazard. The diff records the inserted
+    # line, and the hazard slides down onto it on the post-image side, so it stays.
+    path = repo / _FINDING_FILE
+    lines = path.read_text().splitlines()
+    lines.insert(_FINDING_LINE - 1, "    -- group customers")
+    path.write_text("\n".join(lines) + "\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "comment above group-by")
+    # The on-disk source no longer matches the committed manifest's compiled line,
+    # but the inserted line is exactly where the hazard now sits, so file+line keep
+    # it. (The manifest still pins the hazard at line 44, which is now the inserted
+    # changed line.)
+    assert _FINDING_KIND in _check_kinds(runner, repo, "--diff", "main~1")
+
+
+def test_change_in_another_file_filters_the_untouched_hazard(runner: CliRunner, repo: Path) -> None:
+    # Touch a staging model; customers.sql is untouched, so its hazard is filtered.
+    _edit_line(repo, "models/staging/stg_customers.sql", 1, "-- staging customers")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "touch staging only")
+    assert _FINDING_KIND not in _check_kinds(runner, repo, "--diff", "main~1")
+
+
+def test_change_same_file_off_the_hazard_line_filters_it(runner: CliRunner, repo: Path) -> None:
+    # Edit two lines that straddle the hazard line (the join above it and a column
+    # below it) while leaving line 44 itself untouched. The file is touched and the
+    # hazard's compiled span sits inside the diffed extent yet on none of the changed
+    # lines, so the honest contract reads the miss as real and drops it.
+    _edit_line(repo, _FINDING_FILE, 41, "    left join orders  -- joined")
+    _edit_line(repo, _FINDING_FILE, 50, "    select  -- final projection")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "annotate around group-by")
+    assert _FINDING_KIND not in _check_kinds(runner, repo, "--diff", "main~1")
+
+
+def test_not_a_git_checkout_falls_back_to_full_output(
+    runner: CliRunner, tmp_path: Path, jaffle_manifest_path: Path
+) -> None:
+    project = tmp_path / "nogit"
+    project.mkdir()
+    _materialise_jaffle(project, jaffle_manifest_path)
+    result = runner.invoke(
+        app, ["check", str(project), "--format", "json", "--no-fail", "--diff", "main"]
+    )
+    assert result.exit_code == 0, result.output
+    kinds = {
+        f["kind"] for f in json.loads(result.stdout)["findings"] if f["family"] == "structural"
+    }
+    assert _FINDING_KIND in kinds
+
+
+def test_unresolvable_base_ref_falls_back_to_full_output(runner: CliRunner, repo: Path) -> None:
+    assert _FINDING_KIND in _check_kinds(runner, repo, "--diff", "does-not-exist")

--- a/tests/test_diff_filter.py
+++ b/tests/test_diff_filter.py
@@ -1,0 +1,181 @@
+"""Unit tests for the ``--diff`` change-line filter, with no git involved.
+
+Two pure surfaces are pinned here: ``parse_unified_diff`` (the changed-line map
+extracted from ``git diff --unified=0`` text) and ``filter_to_changed_lines`` (the
+intersection of structural findings with that map). The end-to-end git behaviour
+lives in ``tests/cli/test_check_diff.py``; keeping the pure logic here lets the
+contracts be exercised deterministically.
+"""
+
+from __future__ import annotations
+
+from dblect.audit.walker import LocatedFinding
+from dblect.check.findings import CheckFinding, CheckFindingKind
+from dblect.diff_filter import (
+    ChangedLines,
+    filter_to_changed_lines,
+    parse_unified_diff,
+)
+from dblect.sql.patterns import Finding, FindingKind
+
+
+def _structural(path: str | None, *, line_start: int, line_end: int) -> LocatedFinding:
+    return LocatedFinding(
+        model_unique_id="model.p.m",
+        file_path=path,
+        finding=Finding(
+            kind=FindingKind.UNORDERED_RANKING_WINDOW,
+            message="x",
+            sql_snippet="row_number()",
+            line_start=line_start,
+            line_end=line_end,
+        ),
+    )
+
+
+# --- parse_unified_diff ------------------------------------------------------
+
+
+def test_parse_added_lines_single_hunk() -> None:
+    text = (
+        "diff --git a/models/a.sql b/models/a.sql\n"
+        "--- a/models/a.sql\n"
+        "+++ b/models/a.sql\n"
+        "@@ -3,0 +4,2 @@\n"
+        "+select 1\n"
+        "+from t\n"
+    )
+    changed = parse_unified_diff(text)
+    assert changed["models/a.sql"] == frozenset({4, 5})
+
+
+def test_parse_single_added_line_omits_count() -> None:
+    # `@@ -1 +2 @@` with no comma means a one-line span.
+    text = "diff --git a/m.sql b/m.sql\n--- a/m.sql\n+++ b/m.sql\n@@ -1 +2 @@\n+changed\n"
+    assert parse_unified_diff(text)["m.sql"] == frozenset({2})
+
+
+def test_parse_pure_deletion_contributes_no_new_lines() -> None:
+    # `+0,0` means nothing was added on the new side; a deletion-only hunk leaves
+    # no reachable changed line on the post-image, so the file maps to an empty set.
+    text = (
+        "diff --git a/d.sql b/d.sql\n"
+        "--- a/d.sql\n"
+        "+++ b/d.sql\n"
+        "@@ -5,2 +4,0 @@\n"
+        "-gone one\n"
+        "-gone two\n"
+    )
+    changed = parse_unified_diff(text)
+    assert changed.get("d.sql", frozenset()) == frozenset()
+
+
+def test_parse_rename_uses_new_path() -> None:
+    text = (
+        "diff --git a/old.sql b/new.sql\n"
+        "similarity index 90%\n"
+        "rename from old.sql\n"
+        "rename to new.sql\n"
+        "--- a/old.sql\n"
+        "+++ b/new.sql\n"
+        "@@ -1,0 +2,1 @@\n"
+        "+added\n"
+    )
+    changed = parse_unified_diff(text)
+    assert "new.sql" in changed
+    assert changed["new.sql"] == frozenset({2})
+    assert "old.sql" not in changed
+
+
+def test_parse_multiple_files_and_hunks() -> None:
+    text = (
+        "diff --git a/one.sql b/one.sql\n"
+        "--- a/one.sql\n"
+        "+++ b/one.sql\n"
+        "@@ -1 +1 @@\n"
+        "+a\n"
+        "@@ -10,0 +11,2 @@\n"
+        "+b\n"
+        "+c\n"
+        "diff --git a/two.sql b/two.sql\n"
+        "--- a/two.sql\n"
+        "+++ b/two.sql\n"
+        "@@ -1,0 +5,1 @@\n"
+        "+d\n"
+    )
+    changed = parse_unified_diff(text)
+    assert changed["one.sql"] == frozenset({1, 11, 12})
+    assert changed["two.sql"] == frozenset({5})
+
+
+# --- filter_to_changed_lines -------------------------------------------------
+
+
+def test_declaration_findings_always_survive() -> None:
+    decl = CheckFinding(
+        kind=CheckFindingKind.CONTRACT_ISSUE,
+        message="x",
+        model_unique_id="model.p.m",
+        column="c",
+        contract="C",
+        file_path="models/a.sql",
+    )
+    changed: ChangedLines = {"models/other.sql": frozenset({1})}
+    assert filter_to_changed_lines((decl,), changed) == (decl,)
+
+
+def test_finding_in_untouched_file_dropped() -> None:
+    f = _structural("models/a.sql", line_start=3, line_end=3)
+    changed: ChangedLines = {"models/b.sql": frozenset({3})}
+    assert filter_to_changed_lines((f,), changed) == ()
+
+
+def test_finding_on_changed_line_survives() -> None:
+    f = _structural("models/a.sql", line_start=4, line_end=5)
+    changed: ChangedLines = {"models/a.sql": frozenset({5, 6})}
+    assert filter_to_changed_lines((f,), changed) == (f,)
+
+
+def test_finding_on_unchanged_line_within_diff_extent_dropped() -> None:
+    # The file was touched, the span has real line provenance, and it sits inside
+    # the diffed extent (lines 4..20) yet hits none of the changed lines. The
+    # provenance lines up, so the miss is real: drop it.
+    f = _structural("models/a.sql", line_start=8, line_end=9)
+    changed: ChangedLines = {"models/a.sql": frozenset({4, 5, 20})}
+    assert filter_to_changed_lines((f,), changed) == ()
+
+
+def test_finding_outside_diff_extent_kept_as_file_membership() -> None:
+    # Compiled-vs-source skew: the finding's compiled span (lines 80..81) lies
+    # beyond the source file's diffed extent (4..20), so line provenance is
+    # ambiguous. Fall back to file membership and keep it rather than drop a
+    # possibly real finding.
+    f = _structural("models/a.sql", line_start=80, line_end=81)
+    changed: ChangedLines = {"models/a.sql": frozenset({4, 5, 20})}
+    assert filter_to_changed_lines((f,), changed) == (f,)
+
+
+def test_unknown_line_span_kept_when_file_touched() -> None:
+    # line_start == 0 means "model scope, line unknown"; a touched file keeps it.
+    f = _structural("models/a.sql", line_start=0, line_end=0)
+    changed: ChangedLines = {"models/a.sql": frozenset({4})}
+    assert filter_to_changed_lines((f,), changed) == (f,)
+
+
+def test_finding_with_no_file_path_dropped() -> None:
+    # A structural finding with no source file cannot be located against any diff,
+    # so under a --diff filter it has no claim to a changed line.
+    f = _structural(None, line_start=4, line_end=4)
+    changed: ChangedLines = {"models/a.sql": frozenset({4})}
+    assert filter_to_changed_lines((f,), changed) == ()
+
+
+def test_touched_file_with_only_deletions_drops_located_findings() -> None:
+    # A file whose only change is deletions has an empty changed-line set: there is
+    # no post-image line a finding can land on, so located findings drop. An
+    # unknown-span finding (line 0) also drops because there is no changed line to
+    # anchor file membership to.
+    located = _structural("models/a.sql", line_start=4, line_end=4)
+    unknown = _structural("models/a.sql", line_start=0, line_end=0)
+    changed: ChangedLines = {"models/a.sql": frozenset()}
+    assert filter_to_changed_lines((located, unknown), changed) == ()


### PR DESCRIPTION
## Problem

On a pull request, the structural findings worth a reviewer's attention are the ones on lines the PR actually touched. A whole-project report buries new regressions in pre-existing findings.

## What this adds

`dblect check --diff <base-ref>` computes the per-file changed-line set from `git diff --unified=0 <base-ref>...HEAD` (the merge-base form, scoping the diff to what HEAD changed since it forked from the base, which is what a PR review wants) and keeps only the structural findings on lines the diff touched.

## The compiled-vs-source line contract (the load-bearing design decision)

A structural `Finding` carries `line_start` / `line_end` that index the model's **compiled** SQL (`compiled_code`), which dbt renders with refs and macros expanded inline. A git diff, by contrast, hunks the on-disk **source** file. For a ref-only model the two line up (`{{ ref(...) }}` expands to one relation on the same line), but a macro that emits several lines from one source line shifts every line below it, so a naive intersection of compiled-line spans against source hunks would mislocate findings in macro-heavy models.

Rather than silently dropping real findings, the filter uses line numbers only where they can be trusted:

- A finding whose model source file has **no** changed line is dropped (the PR did not touch that file).
- Within a touched file, a finding is kept when its compiled span **intersects** the changed lines. When the span misses every changed line, it is kept only if the span lies **outside** the file's diffed extent (lowest..highest changed line): a span beyond that extent signals compiled-vs-source skew, so we fall back to file-level membership. A span **inside** the diffed extent that still misses every changed line is a trustworthy miss, so it is dropped.
- A finding with no line span (`line_start == 0`, "model scope, line unknown") is kept whenever its file has any changed line.
- A finding with no source file (`file_path is None`) is dropped under `--diff` (it cannot be located against any hunk).

This keeps every real finding while still narrowing output for the common ref-only case. A precise compiled-line to source-line back-map (so macro-heavy models filter at line granularity too) is left to #124.

**Declaration-level findings** (`CheckFinding`) carry no line number, so `--diff` leaves them untouched. This is stated in the flag help text.

## Falling back honestly

When the project is not a git checkout, or the base ref does not resolve, the changed-line map is unavailable and the full report is rendered (with a note on stderr). `--diff` narrows output when it can and degrades to the unfiltered report when it cannot, never crashing over a missing `.git` or a bad ref.

## Design

The logic is split into small, well-typed pure pieces in `src/dblect/diff_filter.py`:

- `parse_unified_diff(text)` -> per-file `{path: frozenset[line]}` changed-line map, reading the post-image side of each `@@` hunk and the `+++` header (rename/add aware, `/dev/null` deletions skipped).
- `filter_to_changed_lines(findings, changed)` / `filter_located_to_changed_lines(...)` -> the intersection contract, pure over their inputs so they are exercised without git.
- `changed_lines_from_git(project_dir, base_ref)` -> the thin git shell that returns `None` on a non-checkout or unresolvable ref.

## Tests

- `tests/test_diff_filter.py`: pure unit tests of the diff parser (added lines, single-line hunks, deletion-only hunks, renames, multi-file/multi-hunk) and the intersection contract (declaration pass-through, untouched file, on-line keep, within-extent miss drop, outside-extent skew keep, unknown span, no file path, deletion-only).
- `tests/cli/test_check_diff.py`: end-to-end over the jaffle fixture in a temporary git checkout (ref-only, so compiled lines equal source lines; the lone hazard sits on line 44 of `models/customers.sql`). Covers on-line change kept, inserted-line shift kept, other-file change filtered, same-file off-line change filtered, not-a-git-checkout fallback, and unresolvable-ref fallback.

Tests pin which findings survive, not message wording.

## Gate

862 tests pass; `ruff check`, `ruff format --check`, and `pyright` are clean.

Closes #10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)