### PR TITLE
feat(audit): recommend an upstream not_null test for join_on_nullable_key and name why the key is nullable (#141)

### DIFF
--- a/src/dblect/lineage/properties/nullability.py
+++ b/src/dblect/lineage/properties/nullability.py
@@ -514,6 +514,100 @@ def taint_outer_joins(
     return ColumnLineageGraph(edges=graph.edges, expressions=new_expressions)
 
 
+def _optional_alias_sides(select: exp.Select) -> dict[str, JoinSide]:
+    """Each optional-side alias mapped to the join kind that makes it optional.
+
+    The same reading as :func:`_optional_join_aliases`, retaining the side so a consumer can
+    name *which* outer join padded the column. A LEFT join's joined-in side reports LEFT, a
+    RIGHT join's accumulated left side reports RIGHT, a FULL join reports FULL for both. When
+    an alias becomes optional through more than one join, the last to taint it wins; the side
+    is descriptive, the optionality itself is what the taint relies on."""
+    from_ = sg.from_of(select)
+    left: set[str] = set()
+    if from_ is not None:
+        base = _relation_alias(from_.this)
+        if base is not None:
+            left.add(base)
+    optional: dict[str, JoinSide] = {}
+    for join in sg.joins_of(select):
+        side = sg.join_side_of(join)
+        alias = _relation_alias(join.this)
+        if side is JoinSide.LEFT and alias is not None:
+            optional[alias] = JoinSide.LEFT
+        elif side is JoinSide.RIGHT:
+            for a in left:
+                optional[a] = JoinSide.RIGHT
+        elif side is JoinSide.FULL:
+            if alias is not None:
+                optional[alias] = JoinSide.FULL
+            for a in left:
+                optional[a] = JoinSide.FULL
+        if alias is not None:
+            left.add(alias)
+    return optional
+
+
+def _outer_join_output_columns(
+    select: exp.Select, optional: Mapping[str, JoinSide]
+) -> dict[str, JoinSide]:
+    """The model's *output* columns produced from an outer-join optional side, each mapped
+    to the join kind that made it nullable.
+
+    A top-level projection contributes its output name when its expression is a bare column
+    qualified by an optional-side alias. ``COALESCE`` and other guards clear the optionality,
+    so a projection that wraps the column reports no outer-join cause. A projection whose
+    source we cannot read as a bare optional-side column reports nothing (the
+    silent-when-unsure posture), so the cause is a sufficient, never speculative, condition.
+    Output names are case-folded to match the detectors' lowercased keys."""
+    out: dict[str, JoinSide] = {}
+    for proj in select.selects:
+        inner = proj.this if isinstance(proj, exp.Alias) else proj
+        if not isinstance(inner, exp.Column):
+            continue
+        side = optional.get(inner.table.lower()) if inner.table else None
+        if side is not None:
+            out[sg.name_of(proj).lower()] = side
+    return out
+
+
+def outer_join_nullable_columns(
+    manifest: Manifest, *, parsed: Mapping[str, Expr] | None = None
+) -> Mapping[str, Mapping[str, JoinSide]]:
+    """Per model name, the output columns whose nullability the substrate attributes to an
+    outer join at that model's own top-level FROM/JOIN structure, each mapped to the join
+    kind (LEFT/RIGHT/FULL) that padded it.
+
+    This is the same structural reading :func:`taint_outer_joins` uses, surfaced so a
+    consumer (the join-on-nullable-key finding) can name *why* a key is nullable upstream
+    without rediscovering it. It is a sufficient condition: a model the analysis cannot
+    read (CTE-collapsed, unparseable, a projection that is not a bare optional-side column)
+    contributes nothing rather than a guess. Keyed by ``identifier or name`` to match how
+    the detectors resolve a relation in compiled SQL."""
+    out: dict[str, Mapping[str, JoinSide]] = {}
+    for node in manifest.nodes.values():
+        if node.resource_type is not ResourceType.MODEL:
+            continue
+        sql = node.compiled_code
+        if not sql:
+            continue
+        tree = parsed.get(node.unique_id) if parsed is not None else None
+        if tree is None:
+            try:
+                tree = parse_sql(sql, dialect="duckdb")
+            except SQLParseError:
+                continue
+        select = tree if isinstance(tree, exp.Select) else tree.find(exp.Select)
+        if not isinstance(select, exp.Select):
+            continue
+        optional = _optional_alias_sides(select)
+        if not optional:
+            continue
+        columns = _outer_join_output_columns(select, optional)
+        if columns:
+            out[node.identifier or node.name] = columns
+    return out
+
+
 def activated_nullability(
     manifest: Manifest, profile: AdapterProfile, *, parsed: Mapping[str, Expr] | None = None
 ) -> Mapping[ColumnRef, Annotation[Nullability]]:

--- a/src/dblect/nullability/detector.py
+++ b/src/dblect/nullability/detector.py
@@ -19,6 +19,7 @@ undeclared project sees no noise).
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
+from enum import StrEnum
 
 import sqlglot.expressions as exp
 from sqlglot import Expr
@@ -27,15 +28,39 @@ from dblect.adapters import AdapterProfile
 from dblect.lineage.facts.model import Annotation
 from dblect.lineage.graph import ColumnRef, SourceKind
 from dblect.lineage.properties import Nullability
-from dblect.lineage.properties.nullability import activated_nullability
+from dblect.lineage.properties.nullability import (
+    activated_nullability,
+    outer_join_nullable_columns,
+)
 from dblect.manifest import Manifest
 from dblect.sql import Finding, FindingKind, finding_at
 from dblect.sql import _sqlglot as sg
+from dblect.sql._sqlglot import JoinSide
 
 Detector = Callable[[Expr], tuple[Finding, ...]]
 
 # Per relation name (as it appears in compiled SQL), the columns proven NULLABLE.
 NullableByName = Mapping[str, frozenset[str]]
+
+
+class NullableCause(StrEnum):
+    """Why a column is nullable upstream, when the substrate can attribute it.
+
+    The ``*_JOIN`` causes are positive structural claims the nullability substrate already
+    derives (the column is drawn from an outer join's optional side), named by the join kind
+    that padded it. ``UNKNOWN`` is the honest fallback: the column is proven NULLABLE, but
+    the cause is not derivable here, so the finding names no cause rather than fabricating
+    one."""
+
+    LEFT_JOIN = "left_join"
+    RIGHT_JOIN = "right_join"
+    FULL_JOIN = "full_join"
+    UNKNOWN = "unknown"
+
+
+# Per relation name, the column-to-cause map for proven-NULLABLE columns whose cause the
+# substrate attributes. A column absent from the inner map reads as ``UNKNOWN``.
+CauseByName = Mapping[str, Mapping[str, NullableCause]]
 
 
 def detect_null_group_on_nullable_key(
@@ -76,7 +101,7 @@ def detect_null_group_on_nullable_key(
 
 
 def detect_join_on_nullable_key(
-    tree: Expr, *, nullable_by_name: NullableByName
+    tree: Expr, *, nullable_by_name: NullableByName, cause_by_name: CauseByName | None = None
 ) -> tuple[Finding, ...]:
     """Flag a JOIN whose equality key is a column nullable in its upstream relation.
 
@@ -87,6 +112,7 @@ def detect_join_on_nullable_key(
     structural ``coalesce_on_join_key`` and ``where_on_outer_joined_nullable``. Only
     bare-column equality keys are reasoned about.
     """
+    causes_by_relation = cause_by_name or {}
     out: list[Finding] = []
     for sel in sg.find_all_selects(tree):
         alias_to_rel = _alias_to_relation(sel)
@@ -101,8 +127,14 @@ def detect_join_on_nullable_key(
                 cols = sg.equality_cols_on_alias(on, alias)
                 if not cols:
                     continue
+                causes = causes_by_relation.get(relation, {})
                 out.extend(
-                    _join_finding(join, source=relation, column=column)
+                    _join_finding(
+                        join,
+                        source=relation,
+                        column=column,
+                        cause=causes.get(column, NullableCause.UNKNOWN),
+                    )
                     for column in sorted(cols & nullable)
                 )
     return tuple(out)
@@ -179,14 +211,33 @@ def _finding(grp_expr: exp.Column, *, source: str, column: str) -> Finding:
     )
 
 
-def _join_finding(join: exp.Join, *, source: str, column: str) -> Finding:
+def _cause_clause(cause: NullableCause) -> str:
+    """The ``why nullable`` clause, when the substrate attributes a cause. Returns an empty
+    string for ``UNKNOWN`` so the message degrades honestly rather than fabricating one."""
+    match cause:
+        case NullableCause.LEFT_JOIN:
+            return " (produced via a left join, so unmatched rows leave it NULL)"
+        case NullableCause.RIGHT_JOIN:
+            return " (produced via a right join, so unmatched rows leave it NULL)"
+        case NullableCause.FULL_JOIN:
+            return " (produced via a full join, so unmatched rows leave it NULL)"
+        case NullableCause.UNKNOWN:
+            return ""
+
+
+def _join_finding(
+    join: exp.Join, *, source: str, column: str, cause: NullableCause = NullableCause.UNKNOWN
+) -> Finding:
     return finding_at(
         FindingKind.JOIN_ON_NULLABLE_KEY,
         message=(
-            f"JOIN keys on {column}, which is nullable upstream in {source!r}; NULL never "
-            f"equals NULL, so rows with a NULL {column} never match and are silently dropped "
-            f"(inner join) or left unmatched (outer join). Filter the nulls or COALESCE to a "
-            f"sentinel if the match was intended."
+            f"JOIN keys on {column}, which is nullable upstream in {source!r}"
+            f"{_cause_clause(cause)}; NULL never equals NULL, so rows with a NULL {column} "
+            f"never match and are silently dropped (inner join) or left unmatched (outer "
+            f"join). The durable guard is a not_null test on {column} in {source!r}, which "
+            f"turns this silent row loss into a loud test failure on the producing model; "
+            f"or, locally, filter the nulls or COALESCE to a sentinel if the match was "
+            f"intended."
         ),
         node=join,
     )
@@ -227,6 +278,28 @@ def _nullable_by_name(
     return {name: frozenset(cols) for name, cols in merged.items()}
 
 
+_CAUSE_OF_SIDE: Mapping[JoinSide, NullableCause] = {
+    JoinSide.LEFT: NullableCause.LEFT_JOIN,
+    JoinSide.RIGHT: NullableCause.RIGHT_JOIN,
+    JoinSide.FULL: NullableCause.FULL_JOIN,
+}
+
+
+def _cause_by_name(
+    manifest: Manifest, *, parsed: Mapping[str, Expr] | None = None
+) -> dict[str, dict[str, NullableCause]]:
+    """Index, by relation name, the attributable ``why nullable`` cause per column.
+
+    Only the outer-join cause is attributable today, read from the same structural
+    analysis the nullability taint uses (:func:`outer_join_nullable_columns`). A column
+    the substrate cannot attribute is simply absent, so the finding reads it as
+    ``UNKNOWN`` and names no cause."""
+    out: dict[str, dict[str, NullableCause]] = {}
+    for name, columns in outer_join_nullable_columns(manifest, parsed=parsed).items():
+        out[name] = {col: _CAUSE_OF_SIDE[side] for col, side in columns.items()}
+    return out
+
+
 def make_nullability_detectors(
     manifest: Manifest,
     profile: AdapterProfile,
@@ -245,12 +318,15 @@ def make_nullability_detectors(
     nullable_by_name = _nullable_by_name(
         manifest, activated_nullability(manifest, profile, parsed=parsed)
     )
+    cause_by_name = _cause_by_name(manifest, parsed=parsed)
 
     def group_by_nullable(tree: Expr) -> tuple[Finding, ...]:
         return detect_null_group_on_nullable_key(tree, nullable_by_name=nullable_by_name)
 
     def join_on_nullable(tree: Expr) -> tuple[Finding, ...]:
-        return detect_join_on_nullable_key(tree, nullable_by_name=nullable_by_name)
+        return detect_join_on_nullable_key(
+            tree, nullable_by_name=nullable_by_name, cause_by_name=cause_by_name
+        )
 
     def not_in_nullable(tree: Expr) -> tuple[Finding, ...]:
         return detect_not_in_nullable_subquery(tree, nullable_by_name=nullable_by_name)

--- a/tests/nullability/test_detector.py
+++ b/tests/nullability/test_detector.py
@@ -24,7 +24,7 @@ import pytest
 from dblect.adapters import profile_for_adapter
 from dblect.manifest import DbtTestMetadata, Manifest, Node, ResourceType
 from dblect.nullability.detector import make_nullability_detectors
-from dblect.sql import FindingKind, parse_sql
+from dblect.sql import Finding, FindingKind, parse_sql
 
 _DUCKDB = profile_for_adapter("duckdb")
 
@@ -83,6 +83,10 @@ def _not_null(source_name: str, column: str) -> Node:
 # lkp.tag is declared not_null. stg.id comes from the required side: NON_NULL.
 _STG_SQL = "SELECT a.id AS id, b.tag AS tag FROM base a LEFT JOIN lkp b ON a.fk = b.id"
 
+# stg2.tag is NULLABLE because NULLIF can return NULL, a cause that is *not* an outer
+# join. It exercises the honest-degradation branch: the finding names no fabricated cause.
+_STG2_SQL = "SELECT a.id AS id, NULLIF(a.fk, 0) AS tag FROM base a"
+
 
 def _manifest(mart_sql: str) -> Manifest:
     nodes = [
@@ -90,21 +94,37 @@ def _manifest(mart_sql: str) -> Manifest:
         _source("lkp"),
         _source("other"),
         _not_null("base", "id"),
+        _not_null("base", "fk"),
         _not_null("lkp", "id"),
         _not_null("lkp", "tag"),
         _not_null("other", "k"),
         _model(
             "stg", _STG_SQL, depends_on=frozenset({"source.shop.raw.base", "source.shop.raw.lkp"})
         ),
+        _model("stg2", _STG2_SQL, depends_on=frozenset({"source.shop.raw.base"})),
         _model(
             "mart",
             mart_sql,
-            depends_on=frozenset({"model.shop.stg", "source.shop.raw.other"}),
+            depends_on=frozenset({"model.shop.stg", "model.shop.stg2", "source.shop.raw.other"}),
         ),
     ]
     return Manifest(
         schema_version="v12", adapter_type="duckdb", nodes={n.unique_id: n for n in nodes}
     )
+
+
+def _join_finding(mart_sql: str) -> Finding:
+    """The single ``join_on_nullable_key`` finding ``mart`` raises (asserts exactly one)."""
+    detectors = make_nullability_detectors(_manifest(mart_sql), _DUCKDB)
+    tree = parse_sql(mart_sql, dialect="duckdb")
+    findings = [
+        f
+        for detector in detectors
+        for f in detector(tree)
+        if f.kind is FindingKind.JOIN_ON_NULLABLE_KEY
+    ]
+    assert len(findings) == 1
+    return findings[0]
 
 
 def _kinds(mart_sql: str) -> list[FindingKind]:
@@ -168,3 +188,37 @@ def test_flagged_group_key_really_carries_a_null_bucket() -> None:
         assert null_groups[0] == 1  # the unmatched row formed a phantom NULL group
     finally:
         con.close()
+
+
+# The durable guard is the upstream not_null test: it turns silent row loss into a loud
+# test failure on the producing model. The finding recommends it while keeping the local
+# filter/COALESCE options, so the reader sees both the cheapest durable guard and the
+# in-place fixes.
+def test_join_finding_recommends_an_upstream_not_null_test_and_keeps_local_fixes() -> None:
+    msg = _join_finding("SELECT s.id FROM other o JOIN stg s ON o.k = s.tag").message
+    assert "not_null" in msg  # the durable upstream guard
+    assert "stg" in msg  # named on the producing model
+    lowered = msg.lower()
+    assert "filter" in lowered  # local filter still offered
+    assert "coalesce" in lowered  # local COALESCE still offered
+
+
+# When the substrate attributes the upstream nullability to an outer join, the finding
+# names that cause so the reader does not have to rediscover it. ``stg.tag`` is the
+# optional side of stg's LEFT JOIN.
+def test_join_finding_names_outer_join_cause_when_derivable() -> None:
+    msg = _join_finding("SELECT s.id FROM other o JOIN stg s ON o.k = s.tag").message
+    # The cause names *how the column was produced*, distinct from the boilerplate that
+    # explains how the local join treats a NULL key. "produced via" is the cause marker.
+    assert "produced via" in msg.lower()
+    assert "left join" in msg.lower()
+
+
+# ``stg2.tag`` is NULLABLE via NULLIF, not an outer join. The finding must not fabricate
+# an outer-join cause it cannot support from the substrate (the silent-when-unsure posture).
+def test_join_finding_does_not_fabricate_a_cause_when_not_derivable() -> None:
+    msg = _join_finding("SELECT s.id FROM other o JOIN stg2 s ON o.k = s.tag").message
+    assert "stg2" in msg
+    assert "not_null" in msg  # the durable guard is still recommended
+    assert "left join" not in msg.lower()
+    assert "produced via" not in msg.lower()


### PR DESCRIPTION
## Problem

`join_on_nullable_key` flags a JOIN whose equality key is a column proven NULLABLE in its upstream relation. The remediation had two gaps:

1. It suggested only the two local fixes (filter the nulls or COALESCE to a sentinel). It did not point at the cheapest, most durable guard: a `not_null` test on the column in the producing model, which turns silent row loss into a loud test failure where the column is actually born.
2. The message said the column is "nullable upstream in `<source>`" without saying *why*. The reader had to go discover that the column became nullable because the producing model left-joins to something that may not match.

## What this adds

**(a) The durable-guard recommendation.** The finding now recommends a `not_null` test on the column in the producing model, alongside the existing local filter / COALESCE options (both kept). This needs no new data.

**(b) The "why nullable" cause, when the substrate can attribute it.** The nullability substrate already performs the outer-join optional-side analysis that taints these columns NULLABLE. That same structural reading is surfaced as `outer_join_nullable_columns`, which maps each model output column to the join kind (`LEFT` / `RIGHT` / `FULL`) that padded it. The finding threads a typed `NullableCause` and names the cause, for example "(produced via a left join, so unmatched rows leave it NULL)".

The cause is a *sufficient* condition, never a guess. A column the analysis cannot read as a bare optional-side projection (a COALESCE-guarded projection, a CTE-collapsed or unparseable model, a NULLIF/declared-nullable column) carries no attributed cause, so the message degrades honestly and names no cause rather than fabricating one. A wrong "why" would be worse than no "why", so the silent-when-unsure posture is preserved.

## Tests

In `tests/nullability/test_detector.py`:
- The join finding recommends a `not_null` test on the producing model while still offering the local filter and COALESCE options.
- A key nullable because of an outer join names that cause ("produced via a left join").
- A key nullable for another reason (NULLIF in the producing model) does not fabricate an outer-join cause, and still gets the `not_null` recommendation.

Full suite green; ruff, ruff format, and pyright clean on the touched files.

Closes #141.

🤖 Generated with [Claude Code](https://claude.com/claude-code)