### PR TITLE
ci: run a single Python version to conserve Actions minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        # Single version to conserve Actions minutes; widen the matrix back to the
+        # full supported range (3.11-3.13) when budget allows.
+        python-version: ["3.13"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Trims the CI matrix from `["3.11", "3.12", "3.13"]` to `["3.13"]` so each push/PR runs one job instead of three, to stay within the free Actions budget.

- Newest supported version kept; the coverage-upload step already keys on `3.13`, so it is unaffected.
- Supported Python range is unchanged; a comment notes to widen the matrix back to 3.11-3.13 when budget allows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)