### PR TITLE
feat(cli): --base-manifest to report the findings a change introduces (#10)

### DIFF
--- a/src/dblect/baseline.py
+++ b/src/dblect/baseline.py
@@ -1,34 +1,10 @@
-"""Limit findings to the ones a change introduces, by diffing against a base manifest.
+"""Report the findings a change introduces, by diffing against a base manifest.
 
-On a pull request the findings worth a reviewer's attention are the ones the change
-*introduces*, not the ones the project already carried. ``dblect check
---base-manifest <path>`` analyses the base revision's manifest the same way it
-analyses HEAD, then reports only the findings whose stable identity is absent from
-the base.
-
-Why a finding-set diff rather than a source-line diff
------------------------------------------------------
-
-A structural finding is computed over a model's *compiled* SQL, which dbt renders
-with refs and macros expanded inline, and grounded against semantics propagated from
-upstream models (nullability, uniqueness, the fact substrate). So a finding can be
-introduced with no edit to the model's own source file: a changed macro the model
-calls, or an upstream column that turned nullable, leaves the model's file byte for
-byte identical while a new hazard appears in its compiled SQL. Scoping a report by
-edited source line cannot see those, because the file the diff touched is not the
-model the finding lands on. Diffing the finding *sets* of two compilations sees them,
-because it compares results rather than text. This is the differential mode mature
-whole-program analysers use (Infer's ``reportdiff``, the stored-baseline suppression
-of the type checkers) rather than the per-line scoping that suits a local linter.
-
-The identity that survives the diff is :func:`~dblect.analysis.cross_world_identity`:
-a finding's kind, the model it lands on, and what it is about (the offending snippet
-for a structural finding; the column and contract for a declaration one), with the
-message and line span that drift between compilations deliberately dropped. A finding
-present in both worlds under that identity is preexisting and filtered; one present
-only in HEAD is introduced and kept. The HEAD finding carries its own line numbers
-for display, always accurate to HEAD, with no compiled-to-source mapping to get
-wrong.
+``dblect check --base-manifest`` analyses the base revision's manifest the same way
+as HEAD and keeps the findings whose identity is new. The diff is over finding sets,
+not edited source lines: a finding is computed over compiled SQL grounded against
+upstream models, so a changed macro or an upstream column can introduce one with the
+model's own source file unchanged, which a source-line diff would not see.
 """
 
 from __future__ import annotations

--- a/src/dblect/baseline.py
+++ b/src/dblect/baseline.py
@@ -1,0 +1,53 @@
+"""Limit findings to the ones a change introduces, by diffing against a base manifest.
+
+On a pull request the findings worth a reviewer's attention are the ones the change
+*introduces*, not the ones the project already carried. ``dblect check
+--base-manifest <path>`` analyses the base revision's manifest the same way it
+analyses HEAD, then reports only the findings whose stable identity is absent from
+the base.
+
+Why a finding-set diff rather than a source-line diff
+-----------------------------------------------------
+
+A structural finding is computed over a model's *compiled* SQL, which dbt renders
+with refs and macros expanded inline, and grounded against semantics propagated from
+upstream models (nullability, uniqueness, the fact substrate). So a finding can be
+introduced with no edit to the model's own source file: a changed macro the model
+calls, or an upstream column that turned nullable, leaves the model's file byte for
+byte identical while a new hazard appears in its compiled SQL. Scoping a report by
+edited source line cannot see those, because the file the diff touched is not the
+model the finding lands on. Diffing the finding *sets* of two compilations sees them,
+because it compares results rather than text. This is the differential mode mature
+whole-program analysers use (Infer's ``reportdiff``, the stored-baseline suppression
+of the type checkers) rather than the per-line scoping that suits a local linter.
+
+The identity that survives the diff is :func:`~dblect.analysis.cross_world_identity`:
+a finding's kind, the model it lands on, and what it is about (the offending snippet
+for a structural finding; the column and contract for a declaration one), with the
+message and line span that drift between compilations deliberately dropped. A finding
+present in both worlds under that identity is preexisting and filtered; one present
+only in HEAD is introduced and kept. The HEAD finding carries its own line numbers
+for display, always accurate to HEAD, with no compiled-to-source mapping to get
+wrong.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from dblect.analysis import AnalysisFinding, cross_world_identity
+
+
+def introduced_findings(
+    head: Iterable[AnalysisFinding], base: Iterable[AnalysisFinding]
+) -> tuple[AnalysisFinding, ...]:
+    """The ``head`` findings whose cross-world identity is absent from ``base``.
+
+    Pure over its inputs, so the contract is exercised without compiling a manifest.
+    A finding that merely moved lines or changed wording between the two worlds keeps
+    its identity, so it reads as preexisting and drops; only a genuinely new
+    ``(kind, model, subject)`` survives. A finding that exists in the base but not in
+    HEAD (one the change *fixed*) is simply not in ``head``, so it never appears here.
+    """
+    base_identities = {cross_world_identity(f) for f in base}
+    return tuple(f for f in head if cross_world_identity(f) not in base_identities)

--- a/src/dblect/cli/__init__.py
+++ b/src/dblect/cli/__init__.py
@@ -12,7 +12,9 @@ import typer
 
 if TYPE_CHECKING:
     from dblect.adapters import AdapterProfile
+    from dblect.analysis import AnalysisReport
     from dblect.manifest import Manifest
+    from dblect.types import ContractRegistry
 
 app = typer.Typer(
     name="dblect",
@@ -118,6 +120,32 @@ def check(
             ),
         ),
     ] = None,
+    base_manifest: Annotated[
+        Path | None,
+        typer.Option(  # pyright: ignore[reportUnknownMemberType]
+            "--base-manifest",
+            help=(
+                "Path to the base revision's manifest.json (for example the stored "
+                "production manifest dbt Slim CI keeps). dblect analyses it the same "
+                "way as HEAD and reports only the findings the change introduces: a "
+                "finding whose kind, model, and subject already exist in the base is "
+                "preexisting and filtered out. Because it diffs analysis results "
+                "rather than edited source lines, it catches a hazard a change "
+                "introduces through a macro or an upstream model without touching the "
+                "model's own file. Omitted, the full report is rendered."
+            ),
+        ),
+    ] = None,
+    base_catalog: Annotated[
+        Path | None,
+        typer.Option(  # pyright: ignore[reportUnknownMemberType]
+            "--base-catalog",
+            help=(
+                "Path to the base revision's catalog.json. Defaults to a catalog.json "
+                "beside --base-manifest. Only meaningful together with --base-manifest."
+            ),
+        ),
+    ] = None,
 ) -> None:
     """Check a dbt project: structural hazards and declaration-level contracts.
 
@@ -130,9 +158,13 @@ def check(
 
     from dblect import __version__
     from dblect.analysis import analyze
+    from dblect.baseline import introduced_findings
     from dblect.loader import load_declarations
     from dblect.report import render_json, render_text
     from dblect.sarif import render_sarif
+
+    if base_catalog is not None and base_manifest is None:
+        raise typer.BadParameter("--base-catalog has no effect without --base-manifest")
 
     manifest_path = _resolve_manifest_path(
         project_dir=project_dir, explicit=manifest, dbt_executable=dbt_executable, command="check"
@@ -145,6 +177,19 @@ def check(
         loaded, profile, registry=load_result.registry, resolution_floor=resolution_floor
     )
     report = replace(report, check=replace(report.check, load_issues=load_result.issues))
+    if base_manifest is not None:
+        base = _analyze_base(
+            base_manifest=base_manifest,
+            base_catalog=base_catalog,
+            dialect_override=dialect_override,
+            registry=load_result.registry,
+            resolution_floor=resolution_floor,
+        )
+        # Narrow only the merged ``findings`` view: that is what every renderer and the
+        # exit code read. The family sub-reports keep their project-wide coverage
+        # metadata (models scanned, contracts resolved), which describes the whole run,
+        # not the introduced subset.
+        report = replace(report, findings=introduced_findings(report.findings, base.findings))
     match output_format:
         case OutputFormat.JSON:
             rendered = render_json(report)
@@ -222,6 +267,32 @@ def _scaffold_declarations(decl: Path) -> list[Path]:
         path.write_text(body)
         created.append(path)
     return created
+
+
+def _analyze_base(
+    *,
+    base_manifest: Path,
+    base_catalog: Path | None,
+    dialect_override: str | None,
+    registry: ContractRegistry,
+    resolution_floor: float | None,
+) -> AnalysisReport:
+    """Analyse the base revision's manifest the same way HEAD was analysed.
+
+    Same dialect resolution, same declarations (``registry``), and the same
+    resolution floor, so a finding's cross-world identity is comparable across the two
+    worlds. The base catalog defaults to a ``catalog.json`` beside ``base_manifest``,
+    matching the Slim CI layout where the stored manifest and catalog sit together.
+    """
+    from dblect.analysis import analyze
+
+    if not base_manifest.exists():
+        raise typer.BadParameter(f"--base-manifest path does not exist: {base_manifest}")
+    loaded = _load_manifest(
+        manifest_path=base_manifest, explicit_catalog=base_catalog, command="check (base)"
+    )
+    profile = _resolve_profile(loaded.adapter_type, dialect_override, command="check (base)")
+    return analyze(loaded, profile, registry=registry, resolution_floor=resolution_floor)
 
 
 def _resolve_profile(

--- a/tests/cli/test_check_baseline.py
+++ b/tests/cli/test_check_baseline.py
@@ -1,19 +1,14 @@
 """End-to-end tests for ``dblect check --base-manifest``, over the demo scenarios.
 
-The base-manifest diff reports the findings a change introduces: it analyses the base
-revision's manifest the same way as HEAD and keeps only the findings whose cross-world
-identity is new. The ``currency_creep`` scenario is the case that shows why this beats
-scoping a report by edited source line. Its findings are an upstream contradiction on
-``stg_payments`` (a stale USD contract against a multi-currency source) and a
-downstream one on ``order_revenue``, a rollup with no contract of its own that the
-contradiction rides the DAG into. A developer who adds that rollup never edits the
-line the downstream finding sits on, yet it is genuinely new. The manifest diff
-surfaces it while staying quiet about the upstream contradiction the project already
-carried, which is exactly the regression a source-line diff would miss.
-
-The pure diff contract (identity ignores line span and message) is pinned without a
-manifest in ``tests/test_baseline.py``; this module pins the CLI wiring and the
-honest errors.
+The diff analyses the base revision's manifest the same way as HEAD and keeps only the
+findings whose cross-world identity is new. The ``currency_creep`` scenario is the case
+that shows why this beats scoping a report by edited source line: its findings are an
+upstream contradiction on ``stg_payments`` and a downstream one on ``order_revenue``, a
+rollup with no contract of its own that the contradiction rides the DAG into. A
+developer who adds that rollup never edits the line the downstream finding sits on, yet
+it is genuinely new, and the manifest diff surfaces it while staying quiet about the
+upstream contradiction the project already carried. The pure diff contract is pinned
+without a manifest in ``tests/test_baseline.py``; this module pins the CLI wiring.
 """
 
 from __future__ import annotations
@@ -22,6 +17,7 @@ import json
 from pathlib import Path
 
 import pytest
+from click.testing import Result
 from typer.testing import CliRunner
 
 from dblect.cli import app
@@ -40,7 +36,7 @@ def runner() -> CliRunner:
 
 
 @pytest.fixture
-def base_without_mart(tmp_path: Path) -> Path:
+def base_without_mart(tmp_path: Path) -> str:
     """A base manifest equal to currency_creep's but lacking the ``order_revenue``
     mart, standing in for the revision before the developer added that rollup. Under
     the same declarations its only finding is the preexisting upstream contradiction.
@@ -49,11 +45,11 @@ def base_without_mart(tmp_path: Path) -> Path:
     raw["nodes"] = {k: v for k, v in raw["nodes"].items() if not k.endswith(".order_revenue")}
     base = tmp_path / "base_manifest.json"
     base.write_text(json.dumps(raw))
-    return base
+    return str(base)
 
 
-def _findings(runner: CliRunner, *extra: str) -> set[tuple[str, str | None, str | None]]:
-    result = runner.invoke(
+def _run(runner: CliRunner, *extra: str) -> Result:
+    return runner.invoke(
         app,
         [
             "check",
@@ -65,88 +61,37 @@ def _findings(runner: CliRunner, *extra: str) -> set[tuple[str, str | None, str 
             *extra,
         ],
     )
+
+
+def _kinds(result: Result) -> set[tuple[str, str | None, str | None]]:
     assert result.exit_code in (0, 1), result.output
     payload = json.loads(result.stdout)
     return {(f["kind"], f["model_unique_id"], f["column"]) for f in payload["findings"]}
 
 
-def test_full_report_without_base_lists_both_findings(runner: CliRunner) -> None:
-    assert _findings(runner, "--no-fail") == {_UPSTREAM, _DOWNSTREAM}
-
-
-def test_base_diff_surfaces_only_the_introduced_downstream_finding(
-    runner: CliRunner, base_without_mart: Path
+def test_diff_filters_preexisting_and_surfaces_introduced(
+    runner: CliRunner, base_without_mart: str
 ) -> None:
-    # The upstream contradiction is in the base, so it is preexisting and filtered;
-    # the new downstream blast-radius finding on order_revenue is what survives.
-    assert _findings(runner, "--no-fail", "--base-manifest", str(base_without_mart)) == {
-        _DOWNSTREAM
-    }
+    # The full report carries both findings; against a base that lacks the new mart,
+    # the preexisting upstream contradiction is filtered and only the downstream
+    # blast-radius finding (the one a source-line diff would miss) survives.
+    assert _kinds(_run(runner, "--no-fail")) == {_UPSTREAM, _DOWNSTREAM}
+    assert _kinds(_run(runner, "--no-fail", "--base-manifest", base_without_mart)) == {_DOWNSTREAM}
 
 
-def test_identical_base_reports_nothing(runner: CliRunner) -> None:
+def test_identical_base_filters_everything_and_exits_zero(runner: CliRunner) -> None:
     # Base equal to HEAD: every finding is preexisting, so the diff is empty and the
-    # run exits 0 even without --no-fail.
-    result = runner.invoke(
-        app,
-        [
-            "check",
-            str(_CURRENCY_CREEP),
-            "--manifest",
-            str(_HEAD_MANIFEST),
-            "--format",
-            "json",
-            "--base-manifest",
-            str(_HEAD_MANIFEST),
-        ],
-    )
+    # run exits 0 even without --no-fail, proving the exit code tracks the filtered set.
+    result = _run(runner, "--base-manifest", str(_HEAD_MANIFEST))
     assert result.exit_code == 0, result.output
     assert json.loads(result.stdout)["findings"] == []
 
 
-def test_introduced_finding_fails_the_run(runner: CliRunner, base_without_mart: Path) -> None:
-    # An introduced finding still fails the build like any other finding.
-    result = runner.invoke(
-        app,
-        [
-            "check",
-            str(_CURRENCY_CREEP),
-            "--manifest",
-            str(_HEAD_MANIFEST),
-            "--base-manifest",
-            str(base_without_mart),
-        ],
-    )
-    assert result.exit_code == 1, result.output
+def test_an_introduced_finding_fails_the_run(runner: CliRunner, base_without_mart: str) -> None:
+    assert _run(runner, "--base-manifest", base_without_mart).exit_code == 1
 
 
 def test_missing_base_manifest_is_an_error(runner: CliRunner, tmp_path: Path) -> None:
-    result = runner.invoke(
-        app,
-        [
-            "check",
-            str(_CURRENCY_CREEP),
-            "--manifest",
-            str(_HEAD_MANIFEST),
-            "--base-manifest",
-            str(tmp_path / "nope.json"),
-        ],
-    )
+    result = _run(runner, "--base-manifest", str(tmp_path / "nope.json"))
     assert result.exit_code != 0
     assert "--base-manifest" in result.output
-
-
-def test_base_catalog_without_base_manifest_is_an_error(runner: CliRunner, tmp_path: Path) -> None:
-    result = runner.invoke(
-        app,
-        [
-            "check",
-            str(_CURRENCY_CREEP),
-            "--manifest",
-            str(_HEAD_MANIFEST),
-            "--base-catalog",
-            str(tmp_path / "catalog.json"),
-        ],
-    )
-    assert result.exit_code != 0
-    assert "--base-catalog" in result.output

--- a/tests/cli/test_check_baseline.py
+++ b/tests/cli/test_check_baseline.py
@@ -1,0 +1,152 @@
+"""End-to-end tests for ``dblect check --base-manifest``, over the demo scenarios.
+
+The base-manifest diff reports the findings a change introduces: it analyses the base
+revision's manifest the same way as HEAD and keeps only the findings whose cross-world
+identity is new. The ``currency_creep`` scenario is the case that shows why this beats
+scoping a report by edited source line. Its findings are an upstream contradiction on
+``stg_payments`` (a stale USD contract against a multi-currency source) and a
+downstream one on ``order_revenue``, a rollup with no contract of its own that the
+contradiction rides the DAG into. A developer who adds that rollup never edits the
+line the downstream finding sits on, yet it is genuinely new. The manifest diff
+surfaces it while staying quiet about the upstream contradiction the project already
+carried, which is exactly the regression a source-line diff would miss.
+
+The pure diff contract (identity ignores line span and message) is pinned without a
+manifest in ``tests/test_baseline.py``; this module pins the CLI wiring and the
+honest errors.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from dblect.cli import app
+
+_CASES = Path(__file__).parent.parent / "fixtures" / "scenarios" / "cases"
+_CURRENCY_CREEP = _CASES / "currency_creep"
+_HEAD_MANIFEST = _CURRENCY_CREEP / "manifest.json"
+
+_UPSTREAM = ("domain_type_contradiction", "model.jaffle_shop.stg_payments", "amount")
+_DOWNSTREAM = ("domain_type_contradiction", "model.jaffle_shop.order_revenue", "revenue")
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def base_without_mart(tmp_path: Path) -> Path:
+    """A base manifest equal to currency_creep's but lacking the ``order_revenue``
+    mart, standing in for the revision before the developer added that rollup. Under
+    the same declarations its only finding is the preexisting upstream contradiction.
+    """
+    raw = json.loads(_HEAD_MANIFEST.read_text())
+    raw["nodes"] = {k: v for k, v in raw["nodes"].items() if not k.endswith(".order_revenue")}
+    base = tmp_path / "base_manifest.json"
+    base.write_text(json.dumps(raw))
+    return base
+
+
+def _findings(runner: CliRunner, *extra: str) -> set[tuple[str, str | None, str | None]]:
+    result = runner.invoke(
+        app,
+        [
+            "check",
+            str(_CURRENCY_CREEP),
+            "--manifest",
+            str(_HEAD_MANIFEST),
+            "--format",
+            "json",
+            *extra,
+        ],
+    )
+    assert result.exit_code in (0, 1), result.output
+    payload = json.loads(result.stdout)
+    return {(f["kind"], f["model_unique_id"], f["column"]) for f in payload["findings"]}
+
+
+def test_full_report_without_base_lists_both_findings(runner: CliRunner) -> None:
+    assert _findings(runner, "--no-fail") == {_UPSTREAM, _DOWNSTREAM}
+
+
+def test_base_diff_surfaces_only_the_introduced_downstream_finding(
+    runner: CliRunner, base_without_mart: Path
+) -> None:
+    # The upstream contradiction is in the base, so it is preexisting and filtered;
+    # the new downstream blast-radius finding on order_revenue is what survives.
+    assert _findings(runner, "--no-fail", "--base-manifest", str(base_without_mart)) == {
+        _DOWNSTREAM
+    }
+
+
+def test_identical_base_reports_nothing(runner: CliRunner) -> None:
+    # Base equal to HEAD: every finding is preexisting, so the diff is empty and the
+    # run exits 0 even without --no-fail.
+    result = runner.invoke(
+        app,
+        [
+            "check",
+            str(_CURRENCY_CREEP),
+            "--manifest",
+            str(_HEAD_MANIFEST),
+            "--format",
+            "json",
+            "--base-manifest",
+            str(_HEAD_MANIFEST),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout)["findings"] == []
+
+
+def test_introduced_finding_fails_the_run(runner: CliRunner, base_without_mart: Path) -> None:
+    # An introduced finding still fails the build like any other finding.
+    result = runner.invoke(
+        app,
+        [
+            "check",
+            str(_CURRENCY_CREEP),
+            "--manifest",
+            str(_HEAD_MANIFEST),
+            "--base-manifest",
+            str(base_without_mart),
+        ],
+    )
+    assert result.exit_code == 1, result.output
+
+
+def test_missing_base_manifest_is_an_error(runner: CliRunner, tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        [
+            "check",
+            str(_CURRENCY_CREEP),
+            "--manifest",
+            str(_HEAD_MANIFEST),
+            "--base-manifest",
+            str(tmp_path / "nope.json"),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "--base-manifest" in result.output
+
+
+def test_base_catalog_without_base_manifest_is_an_error(runner: CliRunner, tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        [
+            "check",
+            str(_CURRENCY_CREEP),
+            "--manifest",
+            str(_HEAD_MANIFEST),
+            "--base-catalog",
+            str(tmp_path / "catalog.json"),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "--base-catalog" in result.output

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -1,0 +1,121 @@
+"""Unit tests for the base-manifest finding diff, with no manifest compiled.
+
+``introduced_findings`` is pure over two finding sequences, so its contract is pinned
+here directly: a finding present in the base under its cross-world identity is
+preexisting and drops; one present only in HEAD is introduced and survives. The
+load-bearing property, the one a source-line diff cannot offer, is that the identity
+ignores line span and message, so a finding that merely moved or was reworded between
+the two compilations reads as preexisting. The end-to-end CLI behaviour over real
+manifests lives in ``tests/cli/test_check_baseline.py``.
+"""
+
+from __future__ import annotations
+
+from dblect.audit.walker import LocatedFinding
+from dblect.baseline import introduced_findings
+from dblect.check.findings import CheckFinding, CheckFindingKind
+from dblect.sql.patterns import Finding, FindingKind
+
+
+def _structural(
+    model: str,
+    snippet: str,
+    *,
+    line_start: int = 1,
+    line_end: int = 1,
+    message: str = "hazard",
+) -> LocatedFinding:
+    return LocatedFinding(
+        model_unique_id=model,
+        file_path=f"models/{model.split('.')[-1]}.sql",
+        finding=Finding(
+            kind=FindingKind.NULL_GROUP_AFTER_OUTER_JOIN,
+            message=message,
+            sql_snippet=snippet,
+            line_start=line_start,
+            line_end=line_end,
+        ),
+    )
+
+
+def _declaration(model: str, *, column: str, contract: str) -> CheckFinding:
+    return CheckFinding(
+        kind=CheckFindingKind.DOMAIN_TYPE_CONTRADICTION,
+        message="contradiction",
+        model_unique_id=model,
+        column=column,
+        contract=contract,
+    )
+
+
+def test_empty_base_keeps_every_head_finding() -> None:
+    head = (
+        _structural("model.p.a", "orders.id"),
+        _declaration("model.p.b", column="x", contract="C"),
+    )
+    assert introduced_findings(head, ()) == head
+
+
+def test_preexisting_structural_finding_is_dropped() -> None:
+    f = _structural("model.p.a", "orders.id")
+    assert introduced_findings((f,), (f,)) == ()
+
+
+def test_structural_finding_dropped_despite_moved_line() -> None:
+    # The identity ignores the line span, so the same hazard at a different compiled
+    # line is preexisting. This is the property a source-line diff cannot honor.
+    head = (_structural("model.p.a", "orders.id", line_start=44, line_end=44),)
+    base = (_structural("model.p.a", "orders.id", line_start=12, line_end=12),)
+    assert introduced_findings(head, base) == ()
+
+
+def test_structural_finding_dropped_despite_reworded_message() -> None:
+    head = (_structural("model.p.a", "orders.id", message="now phrased differently"),)
+    base = (_structural("model.p.a", "orders.id", message="hazard"),)
+    assert introduced_findings(head, base) == ()
+
+
+def test_new_snippet_on_same_model_is_introduced() -> None:
+    base = (_structural("model.p.a", "orders.id"),)
+    new = _structural("model.p.a", "payments.id")
+    assert introduced_findings((*base, new), base) == (new,)
+
+
+def test_same_snippet_on_a_different_model_is_introduced() -> None:
+    base = (_structural("model.p.a", "orders.id"),)
+    downstream = _structural("model.p.b", "orders.id")
+    assert introduced_findings((*base, downstream), base) == (downstream,)
+
+
+def test_declaration_finding_preexisting_is_dropped() -> None:
+    f = _declaration("model.p.a", column="amount", contract="Money")
+    assert introduced_findings((f,), (f,)) == ()
+
+
+def test_declaration_finding_with_changed_contract_is_introduced() -> None:
+    base = (_declaration("model.p.a", column="amount", contract="Money"),)
+    changed = _declaration("model.p.a", column="amount", contract="USD")
+    assert introduced_findings((changed,), base) == (changed,)
+
+
+def test_declaration_finding_with_changed_column_is_introduced() -> None:
+    base = (_declaration("model.p.a", column="amount", contract="Money"),)
+    changed = _declaration("model.p.a", column="revenue", contract="Money")
+    assert introduced_findings((changed,), base) == (changed,)
+
+
+def test_families_do_not_collide() -> None:
+    # A structural and a declaration finding can never share an identity (the family
+    # tag leads the tuple), so a base full of one family never masks the other.
+    struct = _structural("model.p.a", "orders.id")
+    decl = _declaration("model.p.a", column="amount", contract="Money")
+    assert introduced_findings((struct,), (decl,)) == (struct,)
+    assert introduced_findings((decl,), (struct,)) == (decl,)
+
+
+def test_fixed_finding_never_appears() -> None:
+    # A finding in the base but not in HEAD (one the change fixed) is simply absent
+    # from the introduced set; the diff reports introduced findings, not fixed ones.
+    base = (_structural("model.p.a", "orders.id"), _structural("model.p.b", "x.y"))
+    head = (_structural("model.p.a", "orders.id"),)
+    assert introduced_findings(head, base) == ()

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -1,12 +1,13 @@
 """Unit tests for the base-manifest finding diff, with no manifest compiled.
 
-``introduced_findings`` is pure over two finding sequences, so its contract is pinned
-here directly: a finding present in the base under its cross-world identity is
-preexisting and drops; one present only in HEAD is introduced and survives. The
-load-bearing property, the one a source-line diff cannot offer, is that the identity
-ignores line span and message, so a finding that merely moved or was reworded between
-the two compilations reads as preexisting. The end-to-end CLI behaviour over real
-manifests lives in ``tests/cli/test_check_baseline.py``.
+``introduced_findings`` is a set difference keyed by ``cross_world_identity``: a
+finding present in the base under that identity is preexisting and drops; one present
+only in HEAD survives. The load-bearing property, the reason this is not a naive
+whole-finding equality, is that the identity excludes the line span and message that
+drift between two compilations, so a finding that merely moved or was reworded reads
+as preexisting. The field composition of the identity itself is ``analysis``'s
+contract, not this module's; here we pin only the difference. The end-to-end CLI
+behaviour over real manifests lives in ``tests/cli/test_check_baseline.py``.
 """
 
 from __future__ import annotations
@@ -18,12 +19,7 @@ from dblect.sql.patterns import Finding, FindingKind
 
 
 def _structural(
-    model: str,
-    snippet: str,
-    *,
-    line_start: int = 1,
-    line_end: int = 1,
-    message: str = "hazard",
+    model: str, snippet: str, *, line: int = 1, message: str = "hazard"
 ) -> LocatedFinding:
     return LocatedFinding(
         model_unique_id=model,
@@ -32,8 +28,8 @@ def _structural(
             kind=FindingKind.NULL_GROUP_AFTER_OUTER_JOIN,
             message=message,
             sql_snippet=snippet,
-            line_start=line_start,
-            line_end=line_end,
+            line_start=line,
+            line_end=line,
         ),
     )
 
@@ -48,74 +44,45 @@ def _declaration(model: str, *, column: str, contract: str) -> CheckFinding:
     )
 
 
-def test_empty_base_keeps_every_head_finding() -> None:
-    head = (
-        _structural("model.p.a", "orders.id"),
-        _declaration("model.p.b", column="x", contract="C"),
-    )
-    assert introduced_findings(head, ()) == head
-
-
-def test_preexisting_structural_finding_is_dropped() -> None:
+def test_preexisting_finding_is_dropped() -> None:
     f = _structural("model.p.a", "orders.id")
     assert introduced_findings((f,), (f,)) == ()
 
 
-def test_structural_finding_dropped_despite_moved_line() -> None:
-    # The identity ignores the line span, so the same hazard at a different compiled
-    # line is preexisting. This is the property a source-line diff cannot honor.
-    head = (_structural("model.p.a", "orders.id", line_start=44, line_end=44),)
-    base = (_structural("model.p.a", "orders.id", line_start=12, line_end=12),)
-    assert introduced_findings(head, base) == ()
-
-
-def test_structural_finding_dropped_despite_reworded_message() -> None:
-    head = (_structural("model.p.a", "orders.id", message="now phrased differently"),)
-    base = (_structural("model.p.a", "orders.id", message="hazard"),)
-    assert introduced_findings(head, base) == ()
-
-
-def test_new_snippet_on_same_model_is_introduced() -> None:
+def test_a_new_subject_is_introduced() -> None:
     base = (_structural("model.p.a", "orders.id"),)
     new = _structural("model.p.a", "payments.id")
     assert introduced_findings((*base, new), base) == (new,)
 
 
-def test_same_snippet_on_a_different_model_is_introduced() -> None:
-    base = (_structural("model.p.a", "orders.id"),)
-    downstream = _structural("model.p.b", "orders.id")
-    assert introduced_findings((*base, downstream), base) == (downstream,)
+def test_drift_in_line_and_message_does_not_resurrect_a_finding() -> None:
+    # The identity excludes the line span and message, the fields that drift between
+    # two compilations, so the same issue moved and reworded reads as preexisting.
+    # This is what separates the diff from naive whole-finding equality.
+    head = (_structural("model.p.a", "orders.id", line=44, message="now phrased differently"),)
+    base = (_structural("model.p.a", "orders.id", line=12, message="hazard"),)
+    assert introduced_findings(head, base) == ()
 
 
-def test_declaration_finding_preexisting_is_dropped() -> None:
-    f = _declaration("model.p.a", column="amount", contract="Money")
-    assert introduced_findings((f,), (f,)) == ()
-
-
-def test_declaration_finding_with_changed_contract_is_introduced() -> None:
+def test_declaration_findings_diff_by_identity() -> None:
     base = (_declaration("model.p.a", column="amount", contract="Money"),)
+    assert introduced_findings(base, base) == ()
     changed = _declaration("model.p.a", column="amount", contract="USD")
     assert introduced_findings((changed,), base) == (changed,)
 
 
-def test_declaration_finding_with_changed_column_is_introduced() -> None:
-    base = (_declaration("model.p.a", column="amount", contract="Money"),)
-    changed = _declaration("model.p.a", column="revenue", contract="Money")
-    assert introduced_findings((changed,), base) == (changed,)
-
-
-def test_families_do_not_collide() -> None:
-    # A structural and a declaration finding can never share an identity (the family
-    # tag leads the tuple), so a base full of one family never masks the other.
+def test_families_do_not_mask_each_other() -> None:
+    # The family tag leads the identity tuple, so a base full of one family never
+    # masks the other: a structural finding cannot be hidden by a declaration one.
     struct = _structural("model.p.a", "orders.id")
     decl = _declaration("model.p.a", column="amount", contract="Money")
     assert introduced_findings((struct,), (decl,)) == (struct,)
-    assert introduced_findings((decl,), (struct,)) == (decl,)
 
 
-def test_fixed_finding_never_appears() -> None:
+def test_a_fixed_finding_never_appears() -> None:
     # A finding in the base but not in HEAD (one the change fixed) is simply absent
-    # from the introduced set; the diff reports introduced findings, not fixed ones.
+    # from HEAD, so it never enters the introduced set: the diff reports introduced
+    # findings, not fixed ones.
     base = (_structural("model.p.a", "orders.id"), _structural("model.p.b", "x.y"))
     head = (_structural("model.p.a", "orders.id"),)
     assert introduced_findings(head, base) == ()


### PR DESCRIPTION
## Problem

On a pull request, the findings worth a reviewer's attention are the ones the change *introduces*, not the ones the project already carried. A whole-project report buries a new regression among the preexisting findings, so the reviewer cannot tell what this change is responsible for.

## What this adds

`dblect check --base-manifest <path>` analyses the base revision's manifest the same way it analyses HEAD (same dialect, declarations, and resolution floor) and reports only the findings whose stable identity is absent from the base. A finding whose kind, model, and subject already exist in the base is preexisting and filtered out; one present only in HEAD is introduced and kept. The base manifest is typically the stored production manifest dbt Slim CI already keeps for `state:modified`, so the base side is usually a cache hit in CI with no extra compile.

`--base-catalog` points at the base revision's catalog.json and defaults to a catalog.json beside `--base-manifest`, matching the Slim CI layout where the stored manifest and catalog sit together.

## Why a finding-set diff rather than a source-line diff

A structural finding is computed over a model's *compiled* SQL, which dbt renders with refs and macros expanded inline, and grounded against semantics propagated from upstream models (nullability, uniqueness, the fact substrate). So a finding can be introduced with no edit to the model's own source file: a changed macro the model calls, or an upstream column that turned nullable, leaves the model's file byte for byte identical while a new hazard appears in its compiled SQL. Scoping a report by edited source line cannot see those, because the file the diff touched is not the model the finding lands on.

Diffing the finding *sets* of two compilations sees them, because it compares results rather than text. This is the differential mode whole-program analysers use (Infer's `reportdiff`, the stored-baseline suppression of the type checkers, GitHub code scanning tracking an alert across commits) rather than the per-line scoping that suits a local linter. As a bonus it removes the compiled-vs-source line mapping a line-diff approach needs, since the HEAD finding carries its own line numbers, always accurate to HEAD.

## The identity that survives the diff

The diff keys on the existing `cross_world_identity` (`src/dblect/analysis.py`): a finding's kind, the model it lands on, and what it is about (the offending snippet for a structural finding; the column and contract for a declaration one), with the message and line span that drift between compilations dropped. This is the same primitive `check/incremental.py` already uses to difference findings across independently-compiled manifests of the same project, and that `sarif.py` already hashes as a cross-run fingerprint, so the reuse is aligned with the function's design rather than coincidental.

Two caveats follow from the identity, both failing in the safe direction (over-report introduced, never hide a real regression on an unchanged model):

- The structural identity includes `sql_snippet`, so editing a hazardous expression reads as introduced (a defensible "you touched this, look again").
- It keys on `model_unique_id`, so a model rename reads as introduced-and-fixed.

## Design

`src/dblect/baseline.py::introduced_findings` is a pure function over two finding sequences. The CLI narrows only the merged `findings` view, which is what every renderer and the exit code read; the family sub-reports keep their project-wide coverage metadata (models scanned, contracts resolved), which describes the whole run rather than the introduced subset. A missing `--base-manifest`, or `--base-catalog` without `--base-manifest`, is an honest CLI error rather than a silent no-op.

## Tests

- `tests/test_baseline.py`: the pure diff contract without a compiled manifest (identity ignores line span and message, so a moved or reworded finding reads as preexisting; families never collide; a fixed finding never surfaces).
- `tests/cli/test_check_baseline.py`: end to end over the `currency_creep` scenario, whose findings are an upstream contradiction on `stg_payments` and a downstream blast-radius finding on `order_revenue`, a rollup with no contract of its own. With a base that lacks that mart, the diff surfaces only the introduced downstream finding while staying quiet about the preexisting upstream one. That downstream finding is exactly the upstream-introduced case a source-line diff would miss.

Tests pin which findings survive, not message wording.

## Gate

859 tests pass; `ruff check`, `ruff format --check`, and `pyright` are clean.

## Follow-ups

- **Multi-world per revision.** The revision axis and the incremental-world axis (full-refresh vs steady-state) are orthogonal. The natural extension is a per-world diff, `introduced_w = identities(Head_w) \ identities(Base_w)` joined by the revision-stable `WorldRef`. It is sequenced behind surfacing the multi-world check in the CLI and a `--base-ref` that recompiles the base both ways, since a stored single-world manifest cannot supply both base worlds.
- **Cached analysis output.** Content-address the finding set on its full input closure (`manifest projection, catalog, registry, resolution_floor, dialect, dblect_version, world_ref`) so the base side is free to recompute. The `world_ref` is load-bearing for value-substitution worlds where the compiled SQL is identical, and the base-side key must include the registry, since the diff analyses the base under HEAD's declarations.

Closes #10. Supersedes #145, which scoped by edited source line and could not see an upstream-introduced finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)