### PR TITLE
fix(check): see through inner LIMIT/DISTINCT on ordered aggregates (#158)

### DIFF
--- a/src/dblect/sql/_sqlglot.py
+++ b/src/dblect/sql/_sqlglot.py
@@ -57,6 +57,28 @@ def order_of(w: exp.Window) -> exp.Order | None:
     return cast("exp.Order | None", w.args.get("order"))
 
 
+# Modifiers that sqlglot stacks above an aggregate's ORDER BY clause. The order
+# can sit directly at the aggregate's `this`, or under a top-n LIMIT, or below a
+# DISTINCT (sqlglot has produced both `Limit -> Order` and `Order -> Distinct`),
+# so we walk transparently through these to reach the ordering itself.
+_AGGREGATE_CLAUSE_MODIFIERS: tuple[type[Expr], ...] = (exp.Limit, exp.Distinct)
+
+
+def aggregate_order_of(agg: Expr) -> exp.Order | None:
+    """The ORDER BY governing an aggregate's element order, if any.
+
+    Returns the aggregate's own ``Order`` clause, seeing through the LIMIT and
+    DISTINCT modifiers sqlglot wraps around it (``ARRAY_AGG(x ORDER BY y LIMIT n)``
+    parses as ``Limit -> Order``). Returns ``None`` when the aggregate has no
+    ordering of its own. An ``Order`` nested inside a subquery or other argument
+    expression is not the aggregate's ordering and is deliberately not returned.
+    """
+    inner = agg.this
+    while isinstance(inner, _AGGREGATE_CLAUSE_MODIFIERS):
+        inner = inner.this
+    return inner if isinstance(inner, exp.Order) else None
+
+
 def partition_of(w: exp.Window) -> list[Expr]:
     return cast("list[Expr]", w.args.get("partition_by") or [])
 

--- a/src/dblect/sql/patterns.py
+++ b/src/dblect/sql/patterns.py
@@ -392,8 +392,7 @@ def detect_unordered_aggregate(tree: Expr) -> tuple[Finding, ...]:
     for node in tree.find_all(*_ORDERED_AGGREGATE_FUNCTIONS):
         if isinstance(node.parent, exp.WithinGroup):
             continue
-        inner = node.this
-        if isinstance(inner, exp.Order):
+        if sg.aggregate_order_of(node) is not None:
             continue
         out.append(
             finding_at(

--- a/tests/sql/test_patterns.py
+++ b/tests/sql/test_patterns.py
@@ -189,6 +189,30 @@ def test_within_group_array_agg_not_flagged() -> None:
     assert detect_unordered_aggregate(p) == ()
 
 
+@pytest.mark.parametrize(
+    "sql",
+    [
+        # sqlglot wraps the ORDER BY under a Limit for the top-n idiom, and can
+        # stack a Distinct underneath. The detector must see through both.
+        "select array_agg(x order by y limit 1) as arr from t",
+        "select array_agg(distinct x order by y limit 1) as arr from t",
+        "select string_agg(name, ',' order by ts limit 3) as names from t",
+    ],
+)
+def test_ordered_aggregate_with_inner_limit_not_flagged(sql: str) -> None:
+    assert detect_unordered_aggregate(_parse(sql)) == ()
+
+
+def test_unordered_aggregate_over_ordered_subquery_arg_is_flagged() -> None:
+    # The ORDER BY here belongs to the subquery argument, not the aggregate's
+    # own ordering, so the aggregate IS unordered. Pins the contract that the
+    # detector unwraps the aggregate's clause rather than scanning the subtree.
+    p = _parse("select array_agg((select v from u order by w limit 1)) as arr from t")
+    findings = detect_unordered_aggregate(p)
+    assert len(findings) == 1
+    assert findings[0].kind is FindingKind.UNORDERED_AGGREGATE
+
+
 def test_unordered_string_agg_detected() -> None:
     # sqlglot parses both STRING_AGG and GROUP_CONCAT into exp.GroupConcat,
     # so the existing aggregate detector covers them.


### PR DESCRIPTION
Closes #158.

## Problem

`detect_unordered_aggregate` only recognized an aggregate's `ORDER BY` when it sat directly at `node.this`. sqlglot parses the common top-n idiom `ARRAY_AGG(x ORDER BY y LIMIT n)` as `Limit -> Order`, so the present ordering was missed and the aggregate was wrongly reported as having none. On a real BigQuery project this was 22 of 25 `unordered_aggregate` findings, all `ARRAY_AGG(... ORDER BY ... LIMIT 1)`.

## Approach

I mapped how sqlglot wraps the aggregate's ordering across realistic variants. Two things steered the design beyond the one-line patch in the issue:

- The wrapper chain is not a single level. Besides `Limit -> Order`, sqlglot also produces `Order -> Distinct` and `Limit -> Order -> Distinct`. The real contract is "unwrap the aggregate-clause modifiers (`LIMIT`, `DISTINCT`) to reach the ordering," which wants a bounded walk rather than one `isinstance` check.
- Scanning the subtree for any `Order` (e.g. `node.find(exp.Order)`) would be wrong. For `ARRAY_AGG((SELECT v FROM u ORDER BY w LIMIT 1))` the `ORDER BY` belongs to the subquery argument, not the aggregate, so that aggregate genuinely is unordered and must still be flagged. Walking the clause chain at `node.this` preserves that.

This adds a typed `aggregate_order_of(agg) -> exp.Order | None` accessor in `_sqlglot.py` (mirroring the existing `order_of` for windows) and routes the detector through it. The accessor is reusable by the separately-tracked tie-break check (`ORDER BY k LIMIT 1` is still nondeterministic when `k` is non-unique), which is out of scope here.

## Tests

- Parametrized case covering the three false-positive shapes (`ARRAY_AGG(... LIMIT 1)`, `DISTINCT ... LIMIT 1`, `STRING_AGG(... LIMIT 3)`), all now silent.
- A pinned test asserting `ARRAY_AGG((SELECT ... ORDER BY ... LIMIT 1))` still fires, locking the contract that distinguishes the clause walk from a naive subtree scan.

Full gate green: `ruff check`, `ruff format --check`, `pyright` (0 errors), and the full suite (900 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)