### PR TITLE
audit: null_group sees through COALESCE with a non-nullable fallback (#169)

### DIFF
--- a/src/dblect/sql/patterns.py
+++ b/src/dblect/sql/patterns.py
@@ -325,8 +325,16 @@ def detect_null_group_after_outer_join(tree: Expr) -> tuple[Finding, ...]:
             risky: set[str] = set()
             for c in sg.find_columns(grp_expr):
                 table = sg.column_table(c)
-                if table is not None and table in nullable:
-                    risky.add(table)
+                if table is None or table not in nullable:
+                    continue
+                # A nullable-side column wrapped in a COALESCE that has a
+                # guaranteed-present fallback (a literal, or a column from a
+                # non-nullable relation) cannot make the group key NULL, so it
+                # forms no phantom bucket. coalesce(b.k, a.k) over a left join,
+                # or coalesce(b.status, 'NONE'), is the canonical safe idiom.
+                if _coalesce_supplies_nonnull(c, nullable=nullable, until=grp_expr):
+                    continue
+                risky.add(table)
             if risky:
                 tables = ", ".join(sorted(risky))
                 out.append(
@@ -585,6 +593,37 @@ def _is_null_protected(col: exp.Column, *, until: Expr) -> bool:
     while node is not None and node is not until:
         if isinstance(node, exp.Coalesce | exp.Is):
             return True
+        node = node.parent
+    return False
+
+
+def _coalesce_has_nonnullable_fallback(co: exp.Coalesce, nullable: set[str]) -> bool:
+    """True if `co` has an argument the outer join cannot make NULL: a literal
+    (no column references at all) or an expression whose every column comes from
+    a relation not in `nullable`. Such a COALESCE is non-NULL regardless of which
+    side matched, so ``coalesce(b.k, a.k)`` or ``coalesce(b.status, 'NONE')``
+    qualifies, while ``coalesce(b.k, c.k)`` across a full outer join does not.
+    """
+    args = [a for a in (co.this, *co.expressions) if isinstance(a, Expr)]
+    for arg in args:
+        cols = sg.find_columns(arg)
+        if not cols:
+            return True
+        if all(sg.column_table(c) not in nullable for c in cols):
+            return True
+    return False
+
+
+def _coalesce_supplies_nonnull(col: exp.Column, *, nullable: set[str], until: Expr) -> bool:
+    """True if `col` sits inside a COALESCE (reached before `until`) that has a
+    guaranteed-present fallback, so the enclosing expression is never NULL from
+    an unmatched outer-join row."""
+    node: Expr | None = col
+    while node is not None:
+        if isinstance(node, exp.Coalesce) and _coalesce_has_nonnullable_fallback(node, nullable):
+            return True
+        if node is until:
+            break
         node = node.parent
     return False
 

--- a/tests/sql/test_patterns.py
+++ b/tests/sql/test_patterns.py
@@ -121,6 +121,44 @@ def test_null_group_after_right_join_flips_nullability() -> None:
     assert len(findings) == 1
 
 
+def test_null_group_coalesce_with_preserved_side_fallback_not_detected() -> None:
+    # coalesce(b.k, a.k) over a left join: a.k is the preserved (non-nullable)
+    # side, so the group key is never NULL from an unmatched row. No phantom bucket.
+    sql = """
+    select coalesce(b.k, a.k) as k, count(*) as n
+    from a left join b on a.k = b.k
+    group by coalesce(b.k, a.k)
+    """
+    findings = detect_null_group_after_outer_join(_parse(sql))
+    assert findings == ()
+
+
+def test_null_group_coalesce_with_literal_fallback_not_detected() -> None:
+    # A literal fallback also guarantees the group key is non-NULL.
+    sql = """
+    select coalesce(b.status, 'NONE') as status, count(*) as n
+    from a left join b on a.k = b.k
+    group by coalesce(b.status, 'NONE')
+    """
+    findings = detect_null_group_after_outer_join(_parse(sql))
+    assert findings == ()
+
+
+def test_null_group_coalesce_all_nullable_args_still_detected() -> None:
+    # Across a full outer join both sides are nullable, so coalesce(b.k, c.k)
+    # can still be NULL when neither side matched. The phantom bucket is real.
+    sql = """
+    select coalesce(b.k, c.k) as k, count(*) as n
+    from a
+    full outer join b on a.k = b.k
+    full outer join c on a.k = c.k
+    group by coalesce(b.k, c.k)
+    """
+    findings = detect_null_group_after_outer_join(_parse(sql))
+    assert len(findings) == 1
+    assert findings[0].kind is FindingKind.NULL_GROUP_AFTER_OUTER_JOIN
+
+
 def test_coalesce_on_join_key_detected() -> None:
     sql = """
     select coalesce(a.k, 0) as k_safe


### PR DESCRIPTION
Closes #169.

## What

`detect_null_group_after_outer_join` flagged any GROUP BY key that referenced a nullable join side, including the canonical safe idiom where the key is coalesced to a guaranteed-present value:

```sql
select coalesce(b.k, a.k) as k, count(*)
from a left join b on a.k = b.k
group by coalesce(b.k, a.k)        -- a.k is the preserved side; key is never NULL
```

Such a key cannot be NULL from an unmatched row, so it forms no phantom bucket. The detector now skips a nullable-side column when it sits inside a `COALESCE` whose fallback the join cannot make NULL: a literal, or an expression whose every column comes from a non-nullable relation.

A `COALESCE` whose arguments are all from nullable sides still fires, since it can genuinely be NULL:

```sql
select coalesce(b.k, c.k) as k, count(*)
from a
full outer join b on a.k = b.k
full outer join c on a.k = c.k
group by coalesce(b.k, c.k)        -- both sides nullable: phantom bucket is real
```

## How

Two small helpers next to the existing `_is_null_protected`:

- `_coalesce_has_nonnullable_fallback(co, nullable)`: true if any argument is a literal (no columns) or an expression whose columns are all from non-nullable relations.
- `_coalesce_supplies_nonnull(col, nullable, until)`: walks from the column up to (and including) the group expression, returning true if it passes through such a COALESCE.

## Tests

Three cases added to `tests/sql/test_patterns.py`: preserved-side fallback (silent), literal fallback (silent), all-nullable args (still fires). Full suite green (993), ruff + ruff-format + pyright strict clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
