### PR TITLE
audit: where_on_outer_joined_nullable treats a both-sides OR as join-preserving (#168)

### DIFF
--- a/src/dblect/sql/patterns.py
+++ b/src/dblect/sql/patterns.py
@@ -454,21 +454,29 @@ def detect_where_on_outer_joined_nullable(tree: Expr) -> tuple[Finding, ...]:
                 table = sg.column_table(c)
                 if table is not None and table in nullable:
                     risky_tables.add(table)
-            if risky_tables:
-                tables = ", ".join(sorted(risky_tables))
-                out.append(
-                    finding_at(
-                        FindingKind.WHERE_ON_OUTER_JOINED_NULLABLE,
-                        message=(
-                            f"WHERE predicate {sg.render_sql(cmp)} compares a column from "
-                            f"nullable join side ({tables}); rows where the join didn't match "
-                            "are filtered out, silently inverting the OUTER JOIN to INNER. "
-                            "Move the predicate into the ON clause, or guard the column "
-                            "with COALESCE / IS [NOT] NULL."
-                        ),
-                        node=cmp,
-                    )
+            if not risky_tables:
+                continue
+            # A nullable-side predicate inside a top-level OR does not invert the
+            # join when a sibling disjunct keeps the rows where this side is NULL
+            # alive: `a.x > 0 OR b.y > 0` on a left join, or the full-outer
+            # `l.v > 0 OR r.v > 0` idiom. The disjunction is join-preserving, so
+            # the predicate is not the inverting culprit.
+            if _rescued_by_or_disjunction(cmp, risky_tables, where):
+                continue
+            tables = ", ".join(sorted(risky_tables))
+            out.append(
+                finding_at(
+                    FindingKind.WHERE_ON_OUTER_JOINED_NULLABLE,
+                    message=(
+                        f"WHERE predicate {sg.render_sql(cmp)} compares a column from "
+                        f"nullable join side ({tables}); rows where the join didn't match "
+                        "are filtered out, silently inverting the OUTER JOIN to INNER. "
+                        "Move the predicate into the ON clause, or guard the column "
+                        "with COALESCE / IS [NOT] NULL."
+                    ),
+                    node=cmp,
                 )
+            )
     return tuple(out)
 
 
@@ -586,6 +594,58 @@ def _is_null_protected(col: exp.Column, *, until: Expr) -> bool:
         if isinstance(node, exp.Coalesce | exp.Is):
             return True
         node = node.parent
+    return False
+
+
+def _top_level_disjuncts(predicate: Expr) -> list[Expr]:
+    """Flatten the top-level OR tree of `predicate` into its disjuncts. A WHERE
+    that is not an OR at its root yields a single disjunct (itself), so callers
+    see no disjunction to reason about."""
+    out: list[Expr] = []
+    stack: list[Expr] = [predicate]
+    while stack:
+        node = stack.pop()
+        if isinstance(node, exp.Or):
+            stack.extend((node.this, node.expression))
+        else:
+            out.append(node)
+    return out
+
+
+def _is_descendant(node: Expr, ancestor: Expr) -> bool:
+    cur: Expr | None = node
+    while cur is not None:
+        if cur is ancestor:
+            return True
+        cur = cur.parent
+    return False
+
+
+def _rescued_by_or_disjunction(cmp: Expr, risky: set[str], where: exp.Where) -> bool:
+    """True if `cmp` is one term of a top-level OR whose other side keeps the
+    rows where `cmp`'s nullable tables are NULL alive, so `cmp` does not invert
+    the outer join.
+
+    A sibling disjunct rescues when it references at least one column and none of
+    its columns come from a table in `risky`: it can hold for rows where those
+    tables did not match (a predicate on the preserved side, or on the other side
+    of a full outer join). A disjunct that also constrains a risky table, or one
+    with no column at all (a bare literal), does not qualify, so the genuine
+    inversions (a lone predicate, an AND, or an OR over the same nullable side)
+    still fire.
+    """
+    disjuncts = _top_level_disjuncts(where.this)
+    if len(disjuncts) <= 1:
+        return False
+    own = next((d for d in disjuncts if _is_descendant(cmp, d)), None)
+    if own is None:
+        return False
+    for d in disjuncts:
+        if d is own:
+            continue
+        cols = sg.find_columns(d)
+        if cols and all(sg.column_table(c) not in risky for c in cols):
+            return True
     return False
 
 

--- a/tests/sql/test_patterns.py
+++ b/tests/sql/test_patterns.py
@@ -296,6 +296,38 @@ def test_where_on_right_joined_left_side_detected() -> None:
     assert len(detect_where_on_outer_joined_nullable(_parse(sql))) == 1
 
 
+def test_where_or_with_preserved_side_disjunct_not_detected() -> None:
+    # `a.x > 0 OR b.y > 0`: an unmatched left row (b.* NULL) still survives via
+    # the preserved-side disjunct a.x > 0, so b.y > 0 does not invert the join.
+    sql = "select * from a left join b on a.k = b.k where a.x > 0 or b.y > 0"
+    assert detect_where_on_outer_joined_nullable(_parse(sql)) == ()
+
+
+def test_where_full_outer_or_over_both_sides_not_detected() -> None:
+    # The full-outer "keep rows where either side has signal" idiom. A row present
+    # only in l (r.* NULL) survives via l.v > 0; a row present only in r via r.v > 0.
+    # Neither disjunct inverts the join.
+    sql = "select * from l full outer join r on l.k = r.k where l.v > 0 or r.v > 0"
+    assert detect_where_on_outer_joined_nullable(_parse(sql)) == ()
+
+
+def test_where_and_with_nullable_predicate_still_detected() -> None:
+    # Conjunctive position: b.y > 0 is NULL for unmatched rows, so the AND drops
+    # every one of them. This is the genuine inversion and must still fire.
+    sql = "select * from a left join b on a.k = b.k where b.y > 0 and a.x > 0"
+    findings = detect_where_on_outer_joined_nullable(_parse(sql))
+    assert len(findings) == 1
+    assert findings[0].kind is FindingKind.WHERE_ON_OUTER_JOINED_NULLABLE
+
+
+def test_where_or_over_same_nullable_side_still_detected() -> None:
+    # Both disjuncts reference the same nullable side, so an unmatched b row has
+    # both NULL and is dropped: a real inversion. Both predicates fire.
+    sql = "select * from a left join b on a.k = b.k where b.y > 0 or b.z > 0"
+    findings = detect_where_on_outer_joined_nullable(_parse(sql))
+    assert len(findings) == 2
+
+
 # --- Non-deterministic function in load-bearing positions ---
 
 


### PR DESCRIPTION
Closes #168.

## What

`detect_where_on_outer_joined_nullable` judged each WHERE predicate on its own, so a nullable-side leaf inside an OR read as a join inversion even when a sibling disjunct keeps the unmatched rows alive. Two common, correct idioms fired as false positives:

```sql
-- left join: an unmatched left row (b.* NULL) still survives via a.x > 0
select * from a left join b on a.k = b.k
where a.x > 0 or b.y > 0

-- full outer "keep rows with signal on either side": an l-only row survives via
-- l.v > 0, an r-only row via r.v > 0
select * from l full outer join r on l.k = r.k
where l.v > 0 or r.v > 0
```

## How

A nullable-side predicate is skipped when it is one term of a **top-level OR** and a sibling disjunct references at least one column, none of them from the predicate's nullable tables. That sibling can hold for the rows where this side did not match, so the disjunction is join-preserving.

The genuine inversions still fire:

- a lone predicate (`where b.y > 0`),
- a conjunctive predicate (`where b.y > 0 and a.x > 0`), since the AND drops every unmatched row,
- an OR whose disjuncts all constrain the same nullable side (`where b.y > 0 or b.z > 0`).

Nested structure stays conservative: when the WHERE root is an AND, there is no top-level disjunction and the predicate is reported as before.

## How it works

Two helpers next to `_is_null_protected`: `_top_level_disjuncts` flattens the OR tree at the WHERE root (a non-OR yields a single disjunct, so there is nothing to rescue), and `_rescued_by_or_disjunction` locates the predicate's own disjunct and checks the siblings.

## Tests

Four cases added to `tests/sql/test_patterns.py` (left-join OR silent, full-outer OR silent, AND still fires, same-side OR still fires). The nine existing `where_*` tests are unchanged. Full suite green (994), ruff + ruff-format + pyright strict clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
