### PR TITLE
refactor(sql): extract surrogate-hash grammar into sql/vocab.py

### DIFF
--- a/src/dblect/sql/__init__.py
+++ b/src/dblect/sql/__init__.py
@@ -18,9 +18,6 @@ from dblect.sql.parse import (
 )
 from dblect.sql.patterns import (
     PORTABLE_NON_DETERMINISTIC_BUILTINS,
-    SURROGATE_HASH_FUNCTIONS,
-    SURROGATE_HASH_PASSTHROUGH,
-    SURROGATE_HASH_STRUCTURAL,
     AggregateSummary,
     Finding,
     FindingKind,
@@ -44,6 +41,11 @@ from dblect.sql.patterns import (
     scan_all,
     suppression_code,
     suppression_hint,
+)
+from dblect.sql.vocab import (
+    SURROGATE_HASH_FUNCTIONS,
+    SURROGATE_HASH_PASSTHROUGH,
+    SURROGATE_HASH_STRUCTURAL,
 )
 
 __all__ = [

--- a/src/dblect/sql/patterns.py
+++ b/src/dblect/sql/patterns.py
@@ -200,40 +200,6 @@ PORTABLE_NON_DETERMINISTIC_BUILTINS: frozenset[str] = frozenset(
 )
 
 
-# --- surrogate-hash grammar --------------------------------------------------
-#
-# The typed-node vocabulary for recognizing a surrogate-hash key: a hash of a
-# structural combination of columns. These are SQL-grammar facts (the `exp.*`
-# classes are dialect-independent even though the per-dialect parser picks them),
-# so they live here rather than in the uniqueness property. An adapter that hashes
-# via a function sqlglot parses to `exp.Anonymous` would compose a name set on top,
-# as the non-determinism builtins do; nothing demands that yet.
-#
-# These are tuples, not frozensets like the sets above, because membership is
-# tested with `isinstance`, whose subclass-awareness is load-bearing: `TO_HEX(...)`
-# parses to `exp.LowerHex`, a subclass of `exp.Hex`, so listing `Hex` looks through
-# the hex wrapper. A hash's hex and raw-digest spellings, though, are siblings, not
-# in a subclass relation (`MD5`/`MD5Digest`, `SHA2`/`SHA2Digest`), so both are
-# listed explicitly. Resolved by name for tolerance across sqlglot versions.
-SURROGATE_HASH_FUNCTIONS: tuple[type[Expr], ...] = tuple(
-    getattr(exp, n)
-    for n in ("MD5", "MD5Digest", "SHA", "SHA1Digest", "SHA2", "SHA2Digest", "FarmFingerprint")
-    if hasattr(exp, n)
-)
-# Single-argument wrappers that do not change which tuple is hashed, looked through
-# to reach the hash (e.g. `TO_HEX(MD5(...))`, `LOWER(...)`).
-SURROGATE_HASH_PASSTHROUGH: tuple[type[Expr], ...] = tuple(
-    getattr(exp, n) for n in ("Hex", "Lower", "Upper") if hasattr(exp, n)
-)
-# Structural combinators that assemble columns into the hashed value without making
-# the input anything other than those columns.
-SURROGATE_HASH_STRUCTURAL: tuple[type[Expr], ...] = tuple(
-    getattr(exp, n)
-    for n in ("Concat", "DPipe", "Cast", "TryCast", "Coalesce", "Lower", "Upper", "Trim", "Paren")
-    if hasattr(exp, n)
-)
-
-
 def finding_at(kind: FindingKind, *, message: str, node: Expr) -> Finding:
     """Build a Finding whose snippet and source span both come from `node`."""
     span = sg.line_range(node)

--- a/src/dblect/sql/vocab.py
+++ b/src/dblect/sql/vocab.py
@@ -1,0 +1,44 @@
+"""SQL-grammar vocabulary shared across the analysis layers.
+
+These are dialect-independent ``exp.*`` facts (the parser picks the concrete
+class per dialect, but the class itself is not dialect-specific), so they live in
+the ``sql`` layer rather than inside whichever property consumes them. The
+uniqueness property reads the surrogate-hash grammar to recognise a hash of a
+structural column combination as a key.
+"""
+
+from __future__ import annotations
+
+import sqlglot.expressions as exp
+from sqlglot import Expr
+
+# --- surrogate-hash grammar --------------------------------------------------
+#
+# The typed-node vocabulary for recognizing a surrogate-hash key: a hash of a
+# structural combination of columns. An adapter that hashes via a function
+# sqlglot parses to `exp.Anonymous` would compose a name set on top, as the
+# non-determinism builtins do; nothing demands that yet.
+#
+# These are tuples, not frozensets, because membership is tested with
+# `isinstance`, whose subclass-awareness is load-bearing: `TO_HEX(...)` parses to
+# `exp.LowerHex`, a subclass of `exp.Hex`, so listing `Hex` looks through the hex
+# wrapper. A hash's hex and raw-digest spellings, though, are siblings, not in a
+# subclass relation (`MD5`/`MD5Digest`, `SHA2`/`SHA2Digest`), so both are listed
+# explicitly. Resolved by name for tolerance across sqlglot versions.
+SURROGATE_HASH_FUNCTIONS: tuple[type[Expr], ...] = tuple(
+    getattr(exp, n)
+    for n in ("MD5", "MD5Digest", "SHA", "SHA1Digest", "SHA2", "SHA2Digest", "FarmFingerprint")
+    if hasattr(exp, n)
+)
+# Single-argument wrappers that do not change which tuple is hashed, looked through
+# to reach the hash (e.g. `TO_HEX(MD5(...))`, `LOWER(...)`).
+SURROGATE_HASH_PASSTHROUGH: tuple[type[Expr], ...] = tuple(
+    getattr(exp, n) for n in ("Hex", "Lower", "Upper") if hasattr(exp, n)
+)
+# Structural combinators that assemble columns into the hashed value without making
+# the input anything other than those columns.
+SURROGATE_HASH_STRUCTURAL: tuple[type[Expr], ...] = tuple(
+    getattr(exp, n)
+    for n in ("Concat", "DPipe", "Cast", "TryCast", "Coalesce", "Lower", "Upper", "Trim", "Paren")
+    if hasattr(exp, n)
+)


### PR DESCRIPTION
## What

Move the `SURROGATE_HASH_*` grammar constants out of `sql/patterns.py` into a new `sql/vocab.py`.

## Why

`patterns.py` is the largest file in the `sql/` layer and carries several overlapping responsibilities. The surrogate-hash constants are the clearest-cut tenant to evict: they're consumed only by the uniqueness property (`lineage/properties/uniqueness.py`), and nothing in `patterns.py` reads them. They sat there on a "these are SQL-grammar facts" rationale, which is true but argues for a vocabulary module in the `sql` layer rather than the detector module.

`vocab.py` keeps the constants inside `sql`, so the public `from dblect.sql import SURROGATE_HASH_*` path stays stable (the package re-export now sources from `vocab`) and `uniqueness` keeps importing *down* into `sql` rather than the `sql` package having to re-export from `lineage`.

## Not in scope

While in here we confirmed the other vocab sets (`_RANKING_FUNCTIONS`, `_NON_DETERMINISTIC_TYPED`, `_ARRAY_FLATTEN_*`, etc.) are genuine semantic curations that sqlglot does not provide: sqlglot models structure (`AggFunc`, `UDTF`, `Window` bases, `Hex`/`Explode` subclass chains, which we already lean on) but not determinism, ranking-vs-plain, order-sensitivity, or array-flatten-vs-other-table-function. So no further consolidation there.

The larger follow-up (extracting the project-wide finding type system out of `patterns.py`) is filed as #176.

## Verification

- `ruff check` + `ruff format --check` clean
- `pyright` 0 errors
- 169 related tests pass (`-k "uniqueness or surrogate or patterns"`)
- Re-export smoke-checked: `from dblect.sql import SURROGATE_HASH_FUNCTIONS, SURROGATE_HASH_PASSTHROUGH, SURROGATE_HASH_STRUCTURAL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)