### PR TITLE
feat(hazards): cross-model fan-out inflation detector + symmetric join-key rule

### DIFF
--- a/src/dblect/audit/walker.py
+++ b/src/dblect/audit/walker.py
@@ -44,6 +44,7 @@ from dblect.sql import (
 from dblect.uniqueness.detector import (
     make_cross_model_fanout_detectors,
     make_fact_grounded_detectors,
+    relation_uniqueness,
 )
 
 Detector = Callable[[Expr], tuple[Finding, ...]]
@@ -162,10 +163,13 @@ def run_audit(
     """
     parsed = _parse_models_for_audit(manifest, dialect=profile.sqlglot_dialect)
     trees = {uid: t for uid, t in parsed.items() if isinstance(t, Expr)}
+    # The fact-grounded and cross-model fan-out factories both rest on the relation graph's
+    # propagated uniqueness; propagate it once and share it so the fixpoint runs a single time.
+    rel_keys = relation_uniqueness(manifest, profile, parsed=trees)
     contextual: tuple[Detector, ...] = (
         make_non_determinism_detector(profile.non_deterministic_builtins),
-        *make_fact_grounded_detectors(manifest, profile, parsed=trees),
-        *make_cross_model_fanout_detectors(manifest, profile, parsed=trees),
+        *make_fact_grounded_detectors(manifest, profile, parsed=trees, relation_keys=rel_keys),
+        *make_cross_model_fanout_detectors(manifest, profile, parsed=trees, relation_keys=rel_keys),
         *make_nullability_detectors(manifest, profile, parsed=trees),
         *make_snapshot_detectors(manifest),
     )

--- a/src/dblect/audit/walker.py
+++ b/src/dblect/audit/walker.py
@@ -41,7 +41,10 @@ from dblect.sql import (
     make_non_determinism_detector,
     parse_sql,
 )
-from dblect.uniqueness.detector import make_fact_grounded_detectors
+from dblect.uniqueness.detector import (
+    make_cross_model_fanout_detectors,
+    make_fact_grounded_detectors,
+)
 
 Detector = Callable[[Expr], tuple[Finding, ...]]
 
@@ -162,6 +165,7 @@ def run_audit(
     contextual: tuple[Detector, ...] = (
         make_non_determinism_detector(profile.non_deterministic_builtins),
         *make_fact_grounded_detectors(manifest, profile, parsed=trees),
+        *make_cross_model_fanout_detectors(manifest, profile, parsed=trees),
         *make_nullability_detectors(manifest, profile, parsed=trees),
         *make_snapshot_detectors(manifest),
     )

--- a/src/dblect/lineage/properties/uniqueness.py
+++ b/src/dblect/lineage/properties/uniqueness.py
@@ -627,11 +627,13 @@ def surrogate_key_discoverer(
 #
 # The relation-algebra walk for candidate keys. It mirrors the column reducer's
 # job (turn a derivation into an inferred annotation, recursing into referenced
-# nodes) but over relation algebra: a FROM carries the source's keys, a JOIN keeps
-# the probe side's keys only when the joined-in side is unique on the join
-# columns, GROUP BY / DISTINCT introduce a key, UNION ALL keeps none, and the
-# projection remaps keys onto output names. Posture is silent-when-unproven: a
-# shape the walk does not model drops keys rather than over-claiming.
+# nodes) but over relation algebra: a FROM carries the source's keys; an INNER JOIN
+# keeps the probe side's keys when the joined-in side is unique on the join columns,
+# and carries the joined-in side's keys when the probe is (each side surviving when
+# the other cannot multiply it); GROUP BY / DISTINCT introduce a key, UNION ALL keeps
+# none, and the projection remaps keys onto output names. Posture is
+# silent-when-unproven: a shape the walk does not model drops keys rather than
+# over-claiming.
 
 # A column qualified by its FROM/JOIN source alias, tracked inside one scope so a
 # multi-source scope's join keys line up; the qualifier collapses to bare output
@@ -814,8 +816,12 @@ class _RelationWalk:
         joins = sg.joins_of(sel)
         joins_preserve = True
         for j in joins:
-            preserved = self._join_preserves(j, cte_scope=local)
-            combined = combined if preserved else frozenset[_QKey]()
+            resolved = (
+                self._resolve_source(j.this, cte_scope=local) if isinstance(j.this, Expr) else None
+            )
+            preserved = self._join_preserves(j, resolved=resolved)
+            survivors = self._joined_in_survivors(j, left_keys=combined, resolved=resolved)
+            combined = (combined if preserved else frozenset[_QKey]()) | survivors
             joins_preserve = joins_preserve and preserved
 
         group = sg.group_of(sel)
@@ -876,7 +882,7 @@ class _RelationWalk:
         # offset)`` when ``WITH OFFSET`` is present is a later precision refinement.
         return None
 
-    def _join_preserves(self, j: exp.Join, *, cte_scope: Mapping[str, _Carried]) -> bool:
+    def _join_preserves(self, j: exp.Join, *, resolved: tuple[str, _Carried] | None) -> bool:
         """Whether ``j`` cannot multiply the probe side's rows, so the probe side's
         keys (and any conditional keys riding with them) carry through unchanged.
 
@@ -887,10 +893,6 @@ class _RelationWalk:
         """
         if sg.join_side_of(j) is JoinSide.CROSS:
             return False  # explicit cartesian product: no key survives
-        target = j.this
-        if not isinstance(target, Expr):
-            return False
-        resolved = self._resolve_source(target, cte_scope=cte_scope)
         if resolved is None:
             return False
         r_alias, r_carried = resolved
@@ -903,6 +905,38 @@ class _RelationWalk:
         if right_join_cols is None:
             return False
         return any(k <= right_join_cols for k in r_carried.keys)
+
+    def _joined_in_survivors(
+        self, j: exp.Join, *, left_keys: frozenset[_QKey], resolved: tuple[str, _Carried] | None
+    ) -> frozenset[_QKey]:
+        """The keys the joined-in side contributes to an INNER join's result.
+
+        The mirror of :meth:`_join_preserves`: when the left side is unique on the join columns
+        (one of its surviving keys is covered by the left-side join columns), each joined-in row
+        matches at most one left row, so the joined-in side's keys hold on the result. Only an
+        INNER join qualifies, since an outer join NULL-pads the joined-in columns on unmatched
+        rows and the key no longer identifies them. ``left_keys`` are the keys of the result
+        built so far, so the rule composes across a chain of joins.
+        """
+        if sg.join_side_of(j) is not JoinSide.INNER:
+            return frozenset()
+        if resolved is None:
+            return frozenset()
+        t_alias, t_carried = resolved
+        if not t_carried.keys:
+            return frozenset()
+        on = sg.on_of(j)
+        if on is None:
+            return frozenset()
+        by_alias = sg.equality_cols_by_alias(on)
+        if by_alias is None:
+            return frozenset()
+        left_join_cols: set[_QCol] = {
+            (alias, col) for alias, cols in by_alias.items() if alias != t_alias for col in cols
+        }
+        if not any(k <= left_join_cols for k in left_keys):
+            return frozenset()
+        return _qualify(t_alias, t_carried.keys)
 
 
 def _qualify(alias: str, keys: frozenset[Key]) -> frozenset[_QKey]:

--- a/src/dblect/lineage/properties/uniqueness.py
+++ b/src/dblect/lineage/properties/uniqueness.py
@@ -627,13 +627,14 @@ def surrogate_key_discoverer(
 #
 # The relation-algebra walk for candidate keys. It mirrors the column reducer's
 # job (turn a derivation into an inferred annotation, recursing into referenced
-# nodes) but over relation algebra: a FROM carries the source's keys; an INNER JOIN
-# keeps the probe side's keys when the joined-in side is unique on the join columns,
-# and carries the joined-in side's keys when the probe is (each side surviving when
-# the other cannot multiply it); GROUP BY / DISTINCT introduce a key, UNION ALL keeps
-# none, and the projection remaps keys onto output names. Posture is
-# silent-when-unproven: a shape the walk does not model drops keys rather than
-# over-claiming.
+# nodes) but over relation algebra: a FROM carries the source's keys; a JOIN that
+# neither multiplies nor NULL-pads the probe side (INNER and LEFT, and the SEMI/ANTI
+# filters, but not RIGHT/FULL) keeps the probe side's keys when the joined-in side is
+# unique on the join columns, and an INNER JOIN additionally carries the joined-in
+# side's keys when the probe is unique on them (each side surviving when the other
+# cannot multiply it); GROUP BY / DISTINCT introduce a key, UNION ALL keeps none, and
+# the projection remaps keys onto output names. Posture is silent-when-unproven: a
+# shape the walk does not model drops keys rather than over-claiming.
 
 # A column qualified by its FROM/JOIN source alias, tracked inside one scope so a
 # multi-source scope's join keys line up; the qualifier collapses to bare output
@@ -819,8 +820,13 @@ class _RelationWalk:
             resolved = (
                 self._resolve_source(j.this, cte_scope=local) if isinstance(j.this, Expr) else None
             )
-            preserved = self._join_preserves(j, resolved=resolved)
-            survivors = self._joined_in_survivors(j, left_keys=combined, resolved=resolved)
+            # One walk of the ON predicate's equalities serves both join-key rules below.
+            on = sg.on_of(j)
+            by_alias = sg.equality_cols_by_alias(on) if on is not None else None
+            preserved = self._join_preserves(j, resolved=resolved, by_alias=by_alias)
+            survivors = self._joined_in_survivors(
+                j, left_keys=combined, resolved=resolved, by_alias=by_alias
+            )
             combined = (combined if preserved else frozenset[_QKey]()) | survivors
             joins_preserve = joins_preserve and preserved
 
@@ -882,32 +888,44 @@ class _RelationWalk:
         # offset)`` when ``WITH OFFSET`` is present is a later precision refinement.
         return None
 
-    def _join_preserves(self, j: exp.Join, *, resolved: tuple[str, _Carried] | None) -> bool:
-        """Whether ``j`` cannot multiply the probe side's rows, so the probe side's
-        keys (and any conditional keys riding with them) carry through unchanged.
+    def _join_preserves(
+        self,
+        j: exp.Join,
+        *,
+        resolved: tuple[str, _Carried] | None,
+        by_alias: dict[str, frozenset[str]] | None,
+    ) -> bool:
+        """Whether ``j`` neither multiplies nor NULL-pads the probe side's rows, so the
+        probe side's keys (and any conditional keys riding with them) carry through unchanged.
 
-        The joined-in side cannot multiply probe rows exactly when its join columns
-        cover one of its keys. A CROSS join, an unresolved target, a keyless joined-in
-        side, or a missing / non-covering ON all leave fanout possible, so none of the
-        probe side's keys can be trusted to survive.
+        The joined-in side cannot multiply probe rows exactly when its join columns cover one
+        of its keys. A CROSS join always multiplies, and a RIGHT or FULL join NULL-pads the
+        probe columns on unmatched rows (so a probe key no longer identifies them); all three
+        drop the probe keys. An unresolved target, a keyless joined-in side, or a missing /
+        non-covering ON also leave fanout possible. ``by_alias`` is the ON predicate's
+        per-alias equality columns, parsed once by the caller.
         """
-        if sg.join_side_of(j) is JoinSide.CROSS:
-            return False  # explicit cartesian product: no key survives
+        if sg.join_side_of(j) in (JoinSide.CROSS, JoinSide.RIGHT, JoinSide.FULL):
+            return False  # multiplies (CROSS) or NULL-pads the probe side (RIGHT/FULL)
         if resolved is None:
             return False
         r_alias, r_carried = resolved
         if not r_carried.keys:
             return False  # joined-in side has no known key: can't rule out fanout
-        on = sg.on_of(j)
-        if on is None:
-            return False
-        right_join_cols = sg.equality_cols_on_alias(on, r_alias)
+        if by_alias is None:
+            return False  # ON is missing or not a clean conjunction of column equalities
+        right_join_cols = by_alias.get(r_alias)
         if right_join_cols is None:
             return False
         return any(k <= right_join_cols for k in r_carried.keys)
 
     def _joined_in_survivors(
-        self, j: exp.Join, *, left_keys: frozenset[_QKey], resolved: tuple[str, _Carried] | None
+        self,
+        j: exp.Join,
+        *,
+        left_keys: frozenset[_QKey],
+        resolved: tuple[str, _Carried] | None,
+        by_alias: dict[str, frozenset[str]] | None,
     ) -> frozenset[_QKey]:
         """The keys the joined-in side contributes to an INNER join's result.
 
@@ -916,7 +934,8 @@ class _RelationWalk:
         matches at most one left row, so the joined-in side's keys hold on the result. Only an
         INNER join qualifies, since an outer join NULL-pads the joined-in columns on unmatched
         rows and the key no longer identifies them. ``left_keys`` are the keys of the result
-        built so far, so the rule composes across a chain of joins.
+        built so far, so the rule composes across a chain of joins. ``by_alias`` is the ON
+        predicate's per-alias equality columns, parsed once by the caller.
         """
         if sg.join_side_of(j) is not JoinSide.INNER:
             return frozenset()
@@ -925,10 +944,6 @@ class _RelationWalk:
         t_alias, t_carried = resolved
         if not t_carried.keys:
             return frozenset()
-        on = sg.on_of(j)
-        if on is None:
-            return frozenset()
-        by_alias = sg.equality_cols_by_alias(on)
         if by_alias is None:
             return frozenset()
         left_join_cols: set[_QCol] = {

--- a/src/dblect/severity.py
+++ b/src/dblect/severity.py
@@ -84,6 +84,7 @@ def _structural_severity(kind: FindingKind) -> Severity:
             | FindingKind.WHERE_ON_OUTER_JOINED_NULLABLE
             | FindingKind.NON_UNIQUE_WINDOW_ORDER_KEYS
             | FindingKind.JOIN_FANOUT
+            | FindingKind.CROSS_MODEL_FANOUT
             | FindingKind.NULL_GROUP_ON_NULLABLE_KEY
             | FindingKind.JOIN_ON_NULLABLE_KEY
             | FindingKind.NOT_IN_NULLABLE_SUBQUERY

--- a/src/dblect/sql/patterns.py
+++ b/src/dblect/sql/patterns.py
@@ -48,6 +48,7 @@ class FindingKind(StrEnum):
     NON_DETERMINISTIC_FUNCTION = "non_deterministic_function"
     NON_UNIQUE_WINDOW_ORDER_KEYS = "non_unique_window_order_keys"
     JOIN_FANOUT = "join_fanout"
+    CROSS_MODEL_FANOUT = "cross_model_fanout"
     NULL_GROUP_ON_NULLABLE_KEY = "null_group_on_nullable_key"
     JOIN_ON_NULLABLE_KEY = "join_on_nullable_key"
     NOT_IN_NULLABLE_SUBQUERY = "not_in_nullable_subquery"

--- a/src/dblect/uniqueness/detector.py
+++ b/src/dblect/uniqueness/detector.py
@@ -1,7 +1,7 @@
-"""Fact-grounded audit detectors that consume relation-scoped uniqueness keys.
+"""Fact-grounded audit detectors that consume propagated lineage properties.
 
-Two opportunistic detectors (they fire only when the project gives enough
-information to make a claim, and stay silent otherwise):
+Opportunistic detectors (they fire only when the project gives enough information
+to make a claim, and stay silent otherwise):
 
 * ``detect_non_unique_window_order_keys``: window functions whose combined
   (partition, order) columns are not covered by any candidate key of the scope's
@@ -9,32 +9,41 @@ information to make a claim, and stay silent otherwise):
 * ``detect_join_fanout``: JOINs whose joined-in side has known keys, none of
   which is covered by the join's equality predicate columns, so the join can
   multiply rows.
+* ``detect_cross_model_fanout``: a duplicate-sensitive aggregate that folds a
+  magnitude an upstream fan-out replicated, over a relation no longer keyed at the
+  magnitude's grain. This one also reads ``where_provenance`` to find the origin a
+  magnitude traces to, the grain ``grain_preserved`` is asked about.
 
-Both read keys from the lineage.facts uniqueness substrate: per-model keys come
-from cross-model propagation (``uniqueness_property`` over the relation graph),
+The first two read keys from the lineage.facts uniqueness substrate: per-model keys
+come from cross-model propagation (``uniqueness_property`` over the relation graph),
 and a per-tree scope index (``relation_scope_keys``) supplies the keys of CTE and
 inline-subquery scopes, which are not relations the propagator annotates.
 """
 
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterator, Mapping
 from typing import TypeVar
 
 import sqlglot.expressions as exp
 from sqlglot import Expr
 
 from dblect.adapters import AdapterProfile
-from dblect.lineage.builder import build_relation_graph
-from dblect.lineage.graph import SourceKind, SourceRef
+from dblect.lineage.builder import build_manifest_graph, build_relation_graph
+from dblect.lineage.facts.model import Annotation
+from dblect.lineage.graph import ColumnRef, SourceKind, SourceRef
+from dblect.lineage.properties import where_provenance
 from dblect.lineage.properties.predicate_flow import (
     predicate_flow_property,
     relation_scope_filters,
 )
 from dblect.lineage.properties.uniqueness import (
+    NO_KEYS,
+    CandidateKeySet,
     Key,
     activate_conditional,
     activated_scope_keys,
+    grain_preserved,
     relation_scope_keys,
     uniqueness_property,
 )
@@ -236,6 +245,216 @@ def make_fact_grounded_detectors(
     return (window_keys, fanout)
 
 
+# Per-relation views the cross-model fan-out detector reads, all keyed by the relation's
+# ``SourceRef`` so an origin recovered from a provenance ``ColumnRef`` needs no name lookup.
+KeysBySource = Mapping[SourceRef, CandidateKeySet]
+ProvenanceBySource = Mapping[SourceRef, Mapping[str, frozenset[ColumnRef]]]
+NameToRef = Mapping[str, SourceRef]
+
+
+def detect_cross_model_fanout(
+    tree: Expr,
+    *,
+    name_to_ref: NameToRef,
+    keys_by_source: KeysBySource,
+    provenance_by_source: ProvenanceBySource,
+    duplicate_safe_builtins: frozenset[str] = frozenset(),
+) -> tuple[Finding, ...]:
+    """Flag a duplicate-sensitive aggregate that folds a magnitude an upstream fan-out
+    replicated, over a relation no longer keyed at the magnitude's grain.
+
+    The local ``detect_join_fanout`` fires at the join that multiplies rows; it cannot see a
+    downstream model that then sums a replicated magnitude. Here, for a single-source SELECT
+    whose FROM is a ref'd relation ``R``, each duplicate-sensitive aggregate's argument
+    columns trace (via ``R``'s where-provenance) back to their origin sources. The magnitude
+    is single-counted only when ``R`` is still unique at the grain of the origin it came
+    from: ``grain_preserved`` over ``R``'s propagated uniqueness, with the origin's key
+    translated into ``R``'s column names through provenance. When no origin candidate key
+    survives in ``R``, the fold can double count and we flag.
+
+    Silent when the FROM is not a single ref'd relation (a join or a CTE/subquery needs
+    column-level reasoning kept for later), when the aggregate is duplicate-safe, and when the
+    origin relation has no known key, the firewall posture: with no grain to name there is no
+    positive fact to fire on.
+    """
+    cte_names = {cte.alias_or_name for cte in tree.find_all(exp.CTE)}
+    out: list[Finding] = []
+    for sel in sg.find_all_selects(tree):
+        ref = _single_from_ref(sel, name_to_ref, cte_names)
+        if ref is None:
+            continue
+        rel_prov = provenance_by_source.get(ref, {})
+        rel_keys = keys_by_source.get(ref, NO_KEYS)
+        for agg in _sensitive_aggregate_consumers(sel, safe_builtins=duplicate_safe_builtins):
+            origin = _replicated_origin(
+                agg, rel_keys=rel_keys, rel_prov=rel_prov, keys_by_source=keys_by_source
+            )
+            if origin is not None:
+                out.append(
+                    Finding(
+                        kind=FindingKind.CROSS_MODEL_FANOUT,
+                        message=(
+                            f"{sg.render_sql(agg)} folds a magnitude from {origin.unique_id} "
+                            f"that an upstream fan-out can replicate, over a relation not keyed "
+                            f"at that grain, so the result can double count. Collapse the "
+                            f"fan-out to the origin grain before this aggregate (GROUP BY a key "
+                            f"that covers it, or pre-aggregate the producing model)."
+                        ),
+                        sql_snippet=sg.render_sql(agg),
+                        line_start=_line_start(agg),
+                        line_end=_line_end(agg),
+                    )
+                )
+    return tuple(out)
+
+
+def make_cross_model_fanout_detectors(
+    manifest: Manifest,
+    profile: AdapterProfile,
+    *,
+    parsed: Mapping[str, Expr] | None = None,
+) -> tuple[Detector, ...]:
+    """Curry the cross-model fan-out detector against two propagated properties.
+
+    Uniqueness comes from the relation graph (which relation is keyed at which grain) and
+    where-provenance from the column graph (which source a magnitude traces to). Both are
+    propagated once over the whole manifest; ``parsed`` shares the audit's already-parsed
+    trees so neither graph re-parses.
+    """
+    rel_graph = build_relation_graph(manifest, dialect=profile.sqlglot_dialect, parsed=parsed).graph
+    keys = propagate(rel_graph, uniqueness_property(manifest, profile, parsed=parsed))
+    keys_by_source: dict[SourceRef, CandidateKeySet] = {ref: ann.value for ref, ann in keys.items()}
+
+    col_graph = build_manifest_graph(manifest, dialect=profile.sqlglot_dialect, parsed=parsed).graph
+    provenance = propagate(col_graph, where_provenance)
+    provenance_by_source = _provenance_by_source(provenance)
+    name_to_ref = _name_to_ref(manifest, keys_by_source)
+
+    def fanout(tree: Expr) -> tuple[Finding, ...]:
+        return detect_cross_model_fanout(
+            tree,
+            name_to_ref=name_to_ref,
+            keys_by_source=keys_by_source,
+            provenance_by_source=provenance_by_source,
+            duplicate_safe_builtins=profile.duplicate_safe_aggregate_builtins,
+        )
+
+    return (fanout,)
+
+
+def _single_from_ref(
+    sel: exp.Select, name_to_ref: NameToRef, cte_names: frozenset[str] | set[str]
+) -> SourceRef | None:
+    """The ``SourceRef`` of ``sel``'s FROM when it is a single ref'd relation with no joins.
+
+    A join or a non-table FROM (subquery) needs column-level reasoning we keep for later, and
+    a name shadowed by a local CTE is a per-query scope the propagator does not annotate, so
+    all three return ``None`` and the detector stays silent.
+    """
+    if sg.joins_of(sel):
+        return None
+    from_ = sg.from_of(sel)
+    if from_ is None or not isinstance(from_.this, exp.Table):
+        return None
+    name = from_.this.name
+    if name in cte_names:
+        return None
+    return name_to_ref.get(name)
+
+
+def _replicated_origin(
+    agg: Expr,
+    *,
+    rel_keys: CandidateKeySet,
+    rel_prov: Mapping[str, frozenset[ColumnRef]],
+    keys_by_source: KeysBySource,
+) -> SourceRef | None:
+    """The origin source whose grain the aggregated relation does not preserve, or ``None``.
+
+    The aggregate's argument columns trace to one or more origins. For each origin with a
+    known key, the magnitude is single-counted only when the relation keeps a key refining
+    that origin's grain (translated into the relation's columns). The first origin that fails
+    is the replicated side the fold double counts; an origin with no known key is skipped
+    (nothing to claim).
+    """
+    origin_refs: set[ColumnRef] = set()
+    for c in {sg.column_name(c) for c in sg.find_columns(agg)}:
+        origin_refs |= set(rel_prov.get(c, frozenset()))
+    by_source: dict[SourceRef, set[str]] = {}
+    for col_ref in origin_refs:
+        by_source.setdefault(col_ref.source, set()).add(col_ref.column)
+    for origin in sorted(by_source, key=lambda s: s.unique_id):
+        origin_keys = keys_by_source.get(origin)
+        if origin_keys is None or not origin_keys.keys:
+            continue
+        if not _origin_grain_preserved(rel_keys, rel_prov, origin, origin_keys):
+            return origin
+    return None
+
+
+def _origin_grain_preserved(
+    rel_keys: CandidateKeySet,
+    rel_prov: Mapping[str, frozenset[ColumnRef]],
+    origin: SourceRef,
+    origin_keys: CandidateKeySet,
+) -> bool:
+    """True when the aggregated relation stays unique at some candidate grain of ``origin``.
+
+    Each of the origin's candidate keys is translated into the relation's column names through
+    provenance; the relation preserves the grain when a surviving key refines any translated
+    origin key. A key whose columns the relation does not carry cannot witness the grain and
+    is skipped.
+    """
+    for okey in origin_keys.keys:
+        translated = _translate_key(okey, origin, rel_prov)
+        if translated is not None and grain_preserved(rel_keys, translated):
+            return True
+    return False
+
+
+def _translate_key(
+    origin_key: Key, origin: SourceRef, rel_prov: Mapping[str, frozenset[ColumnRef]]
+) -> Key | None:
+    """``origin_key`` rewritten in the aggregated relation's column names, or ``None`` when the
+    relation carries no column tracing to one of the origin key's columns (so the relation
+    cannot be unique at that grain). A column is a carrier when the origin key column is in its
+    where-provenance; the lexicographically first carrier is chosen when several alias it."""
+    translated: set[str] = set()
+    for origin_col in origin_key:
+        target = ColumnRef(origin, origin_col)
+        carriers = sorted(name for name, prov in rel_prov.items() if target in prov)
+        if not carriers:
+            return None
+        translated.add(carriers[0])
+    return frozenset(translated)
+
+
+def _provenance_by_source(
+    provenance: Mapping[ColumnRef, Annotation[frozenset[ColumnRef]]],
+) -> dict[SourceRef, dict[str, frozenset[ColumnRef]]]:
+    """Group the per-column where-provenance by its relation, ``column -> source columns``."""
+    by_source: dict[SourceRef, dict[str, frozenset[ColumnRef]]] = {}
+    for col_ref, ann in provenance.items():
+        by_source.setdefault(col_ref.source, {})[col_ref.column] = ann.value
+    return by_source
+
+
+def _name_to_ref(manifest: Manifest, refs: KeysBySource) -> dict[str, SourceRef]:
+    """Index every annotated relation's ``SourceRef`` by the name it carries in compiled SQL,
+    mirroring :func:`_by_name`: a source under ``identifier or name``, a model under ``name``,
+    models winning a collision (a ``ref`` resolves to the model)."""
+    by_name: dict[str, SourceRef] = {}
+    models: dict[str, SourceRef] = {}
+    for ref in refs:
+        node = manifest.nodes.get(ref.unique_id)
+        if node is None:
+            continue
+        target = models if ref.kind is SourceKind.MODEL else by_name
+        target[node.identifier or node.name] = ref
+    by_name.update(models)
+    return by_name
+
+
 _V = TypeVar("_V")
 _R = TypeVar("_R")
 
@@ -353,20 +572,30 @@ def _collapsed_before_sensitive_consumer(sel: exp.Select, *, safe_builtins: froz
     known to be duplicate-safe: an idempotent fold, a ``DISTINCT`` aggregate, or a UDF the
     adapter named in ``safe_builtins``. An aggregate UDF sqlglot leaves as ``exp.Anonymous``
     is sensitive by default, so an unknown fold keeps the finding firing. A scope with no
-    GROUP BY (the fan-out flows straight to the rows) is never collapsed here. Only
-    projections and HAVING are scanned; a function in a GROUP BY key or the join's own ON
-    clause is not a consumer of the multiplied rows.
-
-    Two scoping rules keep the consumer set honest. A node is read only when it belongs to
-    ``sel`` itself, never a nested sub-SELECT, whose aggregate folds different rows. And an
-    ``exp.Anonymous`` call is weighed as a possible aggregate only when it reads a column
-    outside the grouping keys: a function over grouping keys alone is a grouped scalar
-    projection (valid SQL guarantees grouped non-aggregates), constant within a group, so a
-    fan-out that duplicates rows cannot move it. A typed aggregate is always weighed, since
-    even ``sum`` of a grouping key scales with the duplicated row count.
+    GROUP BY (the fan-out flows straight to the rows) is never collapsed here. The collapse
+    clears exactly when ``sel`` has no duplicate-sensitive consumer (see
+    :func:`_sensitive_aggregate_consumers` for which nodes count).
     """
     if sg.group_of(sel) is None:
         return False
+    return next(_sensitive_aggregate_consumers(sel, safe_builtins=safe_builtins), None) is None
+
+
+def _sensitive_aggregate_consumers(
+    sel: exp.Select, *, safe_builtins: frozenset[str]
+) -> Iterator[Expr]:
+    """The duplicate-sensitive aggregate consumers of ``sel``'s rows: a typed aggregate or an
+    adapter-unknown UDF, sitting in a projection or HAVING term, that belongs to ``sel`` and
+    is not a grouped scalar projection.
+
+    Two scoping rules keep the set honest. A node is read only when it belongs to ``sel``
+    itself, never a nested sub-SELECT, whose aggregate folds different rows. And an
+    ``exp.Anonymous`` call is weighed only when it reads a column outside the grouping keys: a
+    function over grouping keys alone is a grouped scalar projection (valid SQL guarantees
+    grouped non-aggregates), constant within a group, so a fan-out that duplicates rows cannot
+    move it. A typed aggregate is always weighed, since even ``sum`` of a grouping key scales
+    with the duplicated row count.
+    """
     group_keys = _group_key_columns(sel)
     consumers: list[Expr] = list(sel.expressions)
     having = sel.args.get("having")
@@ -381,8 +610,7 @@ def _collapsed_before_sensitive_consumer(sel: exp.Select, *, safe_builtins: froz
             if isinstance(node, exp.Anonymous) and not _reads_outside_grouping(node, group_keys):
                 continue
             if duplicate_sensitive(node, safe_builtins=safe_builtins):
-                return False
-    return True
+                yield node
 
 
 def _group_key_columns(sel: exp.Select) -> frozenset[tuple[str | None, str]]:

--- a/src/dblect/uniqueness/detector.py
+++ b/src/dblect/uniqueness/detector.py
@@ -31,7 +31,7 @@ from sqlglot import Expr
 from dblect.adapters import AdapterProfile
 from dblect.lineage.builder import build_manifest_graph, build_relation_graph
 from dblect.lineage.facts.model import Annotation
-from dblect.lineage.graph import ColumnRef, SourceKind, SourceRef
+from dblect.lineage.graph import ColumnRef, RelationLineageGraph, SourceKind, SourceRef
 from dblect.lineage.properties import where_provenance
 from dblect.lineage.properties.predicate_flow import (
     predicate_flow_property,
@@ -187,11 +187,34 @@ def detect_join_fanout(
     return tuple(out)
 
 
+# The relation graph and the uniqueness annotations propagated over it. The fact-grounded
+# and cross-model fan-out factories both rest on this pair, so an audit computes it once and
+# threads it into both rather than re-running the fixpoint per factory.
+RelationUniqueness = tuple[RelationLineageGraph, Mapping[SourceRef, Annotation[CandidateKeySet]]]
+
+
+def relation_uniqueness(
+    manifest: Manifest, profile: AdapterProfile, *, parsed: Mapping[str, Expr] | None = None
+) -> RelationUniqueness:
+    """Build the relation graph and propagate the uniqueness property over it.
+
+    ``propagate`` memoizes only within a single call, so the two detector factories that need
+    this pair would otherwise each rebuild the graph and re-run the whole-manifest uniqueness
+    fixpoint. :func:`dblect.audit.walker.run_audit` computes it once and passes it to both;
+    a standalone caller that omits it gets a fresh propagation. ``parsed`` shares the audit's
+    already-parsed trees so the graph build does not re-parse.
+    """
+    graph = build_relation_graph(manifest, dialect=profile.sqlglot_dialect, parsed=parsed).graph
+    keys = propagate(graph, uniqueness_property(manifest, profile, parsed=parsed))
+    return graph, keys
+
+
 def make_fact_grounded_detectors(
     manifest: Manifest,
     profile: AdapterProfile,
     *,
     parsed: Mapping[str, Expr] | None = None,
+    relation_keys: RelationUniqueness | None = None,
 ) -> tuple[Detector, ...]:
     """Curry the fact-grounded detectors against substrate-derived keys.
 
@@ -203,9 +226,14 @@ def make_fact_grounded_detectors(
 
     ``profile`` is the run's resolved target: its dialect parses the graph and its
     semantics ground the uniqueness keys, so parsing and enforcement agree.
+    ``relation_keys`` lets the audit pass an already-propagated graph/keys pair (see
+    :func:`relation_uniqueness`) so the fixpoint is not re-run.
     """
-    graph = build_relation_graph(manifest, dialect=profile.sqlglot_dialect, parsed=parsed).graph
-    keys = propagate(graph, uniqueness_property(manifest, profile, parsed=parsed))
+    graph, keys = (
+        relation_keys
+        if relation_keys is not None
+        else relation_uniqueness(manifest, profile, parsed=parsed)
+    )
     # Predicate-flow is consulted only where a conditional key waits to activate, so
     # seed the flow pass with those scopes and let it pull in their upstreams rather
     # than walking every relation in the graph. The seed must stay exactly "every
@@ -216,9 +244,9 @@ def make_fact_grounded_detectors(
     conditional_scopes = [ref for ref, ann in keys.items() if ann.value.conditional]
     flow = propagate(graph, predicate_flow_property(), subjects=conditional_scopes)
     activated = activate_conditional(keys, flow)
-    model_keys = _by_name(manifest, activated, lambda cks: cks.keys)
-    conditional_by_name = _by_name(manifest, keys, lambda ann: ann.value.conditional)
-    flow_by_name = _by_name(manifest, flow, lambda ann: ann.value)
+    model_keys = _by_name(manifest, activated, lambda _ref, cks: cks.keys)
+    conditional_by_name = _by_name(manifest, keys, lambda _ref, ann: ann.value.conditional)
+    flow_by_name = _by_name(manifest, flow, lambda _ref, ann: ann.value)
     cache: dict[int, ScopeIndex] = {}
 
     def scope_index(tree: Expr) -> ScopeIndex:
@@ -275,12 +303,14 @@ def detect_cross_model_fanout(
     Silent when the FROM is not a single ref'd relation (a join or a CTE/subquery needs
     column-level reasoning kept for later), when the aggregate is duplicate-safe, and when the
     origin relation has no known key, the firewall posture: with no grain to name there is no
-    positive fact to fire on.
+    positive fact to fire on. Also silent on a star-argument fold (``COUNT(*)``): it names no
+    column, so there is no magnitude to trace to an origin grain. A star count over a
+    fanned-out relation does double count, so closing that gap (it needs the relation's own
+    row grain rather than a traced origin) is tracked as future work, not handled here.
     """
-    cte_names = {cte.alias_or_name for cte in tree.find_all(exp.CTE)}
     out: list[Finding] = []
     for sel in sg.find_all_selects(tree):
-        ref = _single_from_ref(sel, name_to_ref, cte_names)
+        ref = _single_from_ref(sel, name_to_ref)
         if ref is None:
             continue
         rel_prov = provenance_by_source.get(ref, {})
@@ -313,22 +343,28 @@ def make_cross_model_fanout_detectors(
     profile: AdapterProfile,
     *,
     parsed: Mapping[str, Expr] | None = None,
+    relation_keys: RelationUniqueness | None = None,
 ) -> tuple[Detector, ...]:
     """Curry the cross-model fan-out detector against two propagated properties.
 
     Uniqueness comes from the relation graph (which relation is keyed at which grain) and
     where-provenance from the column graph (which source a magnitude traces to). Both are
     propagated once over the whole manifest; ``parsed`` shares the audit's already-parsed
-    trees so neither graph re-parses.
+    trees so neither graph re-parses. ``relation_keys`` lets the audit pass the
+    already-propagated uniqueness (see :func:`relation_uniqueness`) so the fixpoint, also
+    needed by :func:`make_fact_grounded_detectors`, is not run twice.
     """
-    rel_graph = build_relation_graph(manifest, dialect=profile.sqlglot_dialect, parsed=parsed).graph
-    keys = propagate(rel_graph, uniqueness_property(manifest, profile, parsed=parsed))
+    _, keys = (
+        relation_keys
+        if relation_keys is not None
+        else relation_uniqueness(manifest, profile, parsed=parsed)
+    )
     keys_by_source: dict[SourceRef, CandidateKeySet] = {ref: ann.value for ref, ann in keys.items()}
 
     col_graph = build_manifest_graph(manifest, dialect=profile.sqlglot_dialect, parsed=parsed).graph
     provenance = propagate(col_graph, where_provenance)
     provenance_by_source = _provenance_by_source(provenance)
-    name_to_ref = _name_to_ref(manifest, keys_by_source)
+    name_to_ref = _by_name(manifest, keys_by_source, lambda ref, _v: ref)
 
     def fanout(tree: Expr) -> tuple[Finding, ...]:
         return detect_cross_model_fanout(
@@ -342,14 +378,14 @@ def make_cross_model_fanout_detectors(
     return (fanout,)
 
 
-def _single_from_ref(
-    sel: exp.Select, name_to_ref: NameToRef, cte_names: frozenset[str] | set[str]
-) -> SourceRef | None:
+def _single_from_ref(sel: exp.Select, name_to_ref: NameToRef) -> SourceRef | None:
     """The ``SourceRef`` of ``sel``'s FROM when it is a single ref'd relation with no joins.
 
     A join or a non-table FROM (subquery) needs column-level reasoning we keep for later, and
-    a name shadowed by a local CTE is a per-query scope the propagator does not annotate, so
-    all three return ``None`` and the detector stays silent.
+    a name shadowed by a CTE in ``sel``'s lexical scope is a per-query scope the propagator
+    does not annotate, so all three return ``None`` and the detector stays silent. CTE
+    resolution uses :func:`_cte_body_for`, walking the enclosing WITH chain outward, so a name
+    defined only as a CTE in an unrelated sibling scope does not shadow a genuine relation read.
     """
     if sg.joins_of(sel):
         return None
@@ -357,7 +393,7 @@ def _single_from_ref(
     if from_ is None or not isinstance(from_.this, exp.Table):
         return None
     name = from_.this.name
-    if name in cte_names:
+    if _cte_body_for(name, sel) is not None:
         return None
     return name_to_ref.get(name)
 
@@ -439,28 +475,12 @@ def _provenance_by_source(
     return by_source
 
 
-def _name_to_ref(manifest: Manifest, refs: KeysBySource) -> dict[str, SourceRef]:
-    """Index every annotated relation's ``SourceRef`` by the name it carries in compiled SQL,
-    mirroring :func:`_by_name`: a source under ``identifier or name``, a model under ``name``,
-    models winning a collision (a ``ref`` resolves to the model)."""
-    by_name: dict[str, SourceRef] = {}
-    models: dict[str, SourceRef] = {}
-    for ref in refs:
-        node = manifest.nodes.get(ref.unique_id)
-        if node is None:
-            continue
-        target = models if ref.kind is SourceKind.MODEL else by_name
-        target[node.identifier or node.name] = ref
-    by_name.update(models)
-    return by_name
-
-
 _V = TypeVar("_V")
 _R = TypeVar("_R")
 
 
 def _by_name(
-    manifest: Manifest, anns: Mapping[SourceRef, _V], extract: Callable[[_V], _R]
+    manifest: Manifest, anns: Mapping[SourceRef, _V], extract: Callable[[SourceRef, _V], _R]
 ) -> dict[str, _R]:
     """Index a per-relation value by the relation name as it appears in compiled SQL.
 
@@ -469,8 +489,9 @@ def _by_name(
     a model resolves under ``name``. This must match the relation-graph builder's
     ``_build_name_to_source`` so a name the detectors look up by lands on the same
     relation the propagation annotated. Models win over sources on a name collision
-    (applied last), matching how a ``ref`` resolves. ``extract`` pulls the field the
-    caller wants (keys, conditional keys, or flow) from each annotation.
+    (applied last), matching how a ``ref`` resolves. ``extract`` pulls the value the
+    caller wants (keys, conditional keys, flow, or the ``SourceRef`` itself) from each
+    relation's ``(ref, annotation)`` pair.
     """
     by_name: dict[str, _R] = {}
     models: dict[str, _R] = {}
@@ -479,7 +500,7 @@ def _by_name(
         if node is None:
             continue
         target = models if ref.kind is SourceKind.MODEL else by_name
-        target[node.identifier or node.name] = extract(value)
+        target[node.identifier or node.name] = extract(ref, value)
     by_name.update(models)
     return by_name
 

--- a/tests/lineage/test_cardinality_cross_model.py
+++ b/tests/lineage/test_cardinality_cross_model.py
@@ -1,0 +1,225 @@
+"""End-to-end cross-model validation for the fan-out (cardinality inflation) hazard.
+
+The cross-model cardinality follow-on in ``docs/design/hazard-algebra.md`` rests on a
+hypothesis worth settling before any detector is written: that no new propagated property
+is needed. An un-collapsed fan-out already degrades the producing model's propagated
+``uniqueness`` to ``NO_KEYS`` (the join drops the key the many-side breaks), and
+``where_provenance`` already traces a downstream aggregate's column back to the source on
+the replicated side. The cross-model fan-trap finding then reads ``grain_preserved`` over
+the propagated uniqueness, with ``where_provenance`` supplying the origin column, rather
+than carrying a new replicated-side value.
+
+These pin that the two existing properties carry the signal end to end over a real
+multi-model manifest, and that they compose to the right fire/silent decision. They are the
+acceptance tests the follow-on detector is built against: if they hold, the work is a
+finding that joins two properties, not a new lattice/grounding/propagation triple.
+
+The shop has orders (keyed on ``order_id``) and order_items (many rows per order). A staging
+model that joins them without collapsing replicates each order's ``amount`` across its
+items; a downstream ``SUM(amount)`` is the fan trap. A staging model that groups back to the
+order grain, or a join whose many-side is itself unique on the key, is benign.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from dblect.adapters import profile_for_adapter
+from dblect.lineage.builder import build_manifest_graph, build_relation_graph
+from dblect.lineage.graph import ColumnRef, SourceKind, SourceRef
+from dblect.lineage.properties import where_provenance
+from dblect.lineage.properties.uniqueness import (
+    NO_KEYS,
+    CandidateKeySet,
+    Key,
+    grain_preserved,
+    uniqueness_property,
+)
+from dblect.lineage.property import propagate
+from dblect.manifest import DbtTestMetadata, Manifest, Node, ResourceType
+
+_DUCKDB = profile_for_adapter("duckdb")
+
+_ORDERS = "source.shop.raw.orders"
+_ITEMS = "source.shop.raw.order_items"
+_STG = "model.shop.stg_order_items"
+_MART = "model.shop.mart_revenue"
+
+
+def _model(uid: str, sql: str) -> Node:
+    return Node(
+        unique_id=uid,
+        name=uid.split(".")[-1],
+        resource_type=ResourceType.MODEL,
+        fqn=(uid,),
+        package_name="shop",
+        schema="analytics",
+        raw_code=None,
+        compiled_code=sql,
+        original_file_path=None,
+        columns={},
+    )
+
+
+def _source(uid: str) -> Node:
+    return Node(
+        unique_id=uid,
+        name=uid.split(".")[-1],
+        resource_type=ResourceType.SOURCE,
+        fqn=(uid,),
+        package_name="shop",
+        schema="raw",
+        raw_code=None,
+        compiled_code=None,
+        original_file_path=None,
+        columns={},
+    )
+
+
+def _unique(uid: str, *, column: str, target: str) -> Node:
+    return Node(
+        unique_id=uid,
+        name=uid.split(".")[-1],
+        resource_type=ResourceType.OTHER,
+        fqn=(uid,),
+        package_name="shop",
+        schema=None,
+        raw_code=None,
+        compiled_code=None,
+        original_file_path=None,
+        columns={},
+        depends_on=frozenset({target}),
+        test_metadata=DbtTestMetadata(name="unique", kwargs={"column_name": column}),
+        attached_node=target,
+    )
+
+
+def _manifest(*nodes: Node) -> Manifest:
+    return Manifest(
+        schema_version="v12",
+        adapter_type="duckdb",
+        nodes={n.unique_id: n for n in nodes},
+    )
+
+
+def _model_keys(manifest: Manifest) -> dict[str, CandidateKeySet]:
+    result = build_relation_graph(manifest)
+    anns = propagate(result.graph, uniqueness_property(manifest, _DUCKDB))
+    return {ref.unique_id: ann.value for ref, ann in anns.items() if ref.kind is SourceKind.MODEL}
+
+
+def _provenance(manifest: Manifest) -> Mapping[ColumnRef, frozenset[ColumnRef]]:
+    result = build_manifest_graph(manifest)
+    anns = propagate(result.graph, where_provenance)
+    return {ref: ann.value for ref, ann in anns.items()}
+
+
+def _key(*cols: str) -> Key:
+    return frozenset(cols)
+
+
+# The uncovered join: order_items carries no key, so a row per item survives.
+_UNCOLLAPSED_STG = _model(
+    _STG,
+    "SELECT o.order_id, o.amount, i.item_id "
+    "FROM orders o JOIN order_items i ON o.order_id = i.order_id",
+)
+# The same join, collapsed back to the order grain.
+_COLLAPSED_STG = _model(
+    _STG,
+    "SELECT o.order_id, SUM(o.amount) AS amount "
+    "FROM orders o JOIN order_items i ON o.order_id = i.order_id GROUP BY o.order_id",
+)
+
+
+def _orders_with_key() -> tuple[Node, Node]:
+    src = _source(_ORDERS)
+    return src, _unique("test.shop.orders_pk", column="order_id", target=_ORDERS)
+
+
+# --- the gate: an un-collapsed fan-out degrades the producing model's uniqueness ----------
+
+
+def test_uncollapsed_fanout_degrades_staging_uniqueness_to_no_keys() -> None:
+    """The join to the keyless many-side drops the order key: the staging output is provably
+    keyed on nothing, the signal a downstream sum's fan trap rests on."""
+    orders, orders_pk = _orders_with_key()
+    keys = _model_keys(_manifest(orders, orders_pk, _source(_ITEMS), _UNCOLLAPSED_STG))
+    assert keys[_STG] == NO_KEYS
+
+
+def test_covered_join_preserves_staging_uniqueness() -> None:
+    """When the many-side is itself unique on the join key the join is one-to-one, so the
+    order key survives and no fan-out is signalled."""
+    orders, orders_pk = _orders_with_key()
+    items_pk = _unique("test.shop.items_pk", column="order_id", target=_ITEMS)
+    keys = _model_keys(_manifest(orders, orders_pk, _source(_ITEMS), items_pk, _UNCOLLAPSED_STG))
+    assert keys[_STG] == CandidateKeySet.of(_key("order_id"))
+
+
+def test_groupby_collapse_restores_staging_uniqueness() -> None:
+    """Grouping back to the order grain re-introduces the order key, so the fan-out is
+    collapsed before export and nothing downstream should fire."""
+    orders, orders_pk = _orders_with_key()
+    keys = _model_keys(_manifest(orders, orders_pk, _source(_ITEMS), _COLLAPSED_STG))
+    assert keys[_STG] == CandidateKeySet.of(_key("order_id"))
+
+
+# --- the trace: where-provenance reaches the replicated source cross-model ----------------
+
+
+def test_downstream_sum_traces_to_the_replicated_source_column() -> None:
+    """``SUM(amount)`` in the mart traces, through the staging join and the mart's own
+    GROUP BY, back to ``orders.amount`` (the replicated side), the origin column the
+    discriminator needs to find the grain the magnitude was produced at."""
+    orders, orders_pk = _orders_with_key()
+    mart = _model(
+        _MART, "SELECT order_id, SUM(amount) AS total FROM stg_order_items GROUP BY order_id"
+    )
+    prov = _provenance(_manifest(orders, orders_pk, _source(_ITEMS), _UNCOLLAPSED_STG, mart))
+    total = ColumnRef(SourceRef(SourceKind.MODEL, _MART), "total")
+    assert prov[total] == frozenset({ColumnRef(SourceRef(SourceKind.SOURCE, _ORDERS), "amount")})
+
+
+def test_provenance_distinguishes_joined_in_from_replicated() -> None:
+    """The joined-in side is reachable too: a passthrough of ``item_id`` traces to
+    ``order_items``, so the discriminator can tell a replicated-side read (the fan trap)
+    from a joined-in read (the intended set aggregation)."""
+    orders, orders_pk = _orders_with_key()
+    mart = _model(_MART, "SELECT order_id, item_id FROM stg_order_items")
+    prov = _provenance(_manifest(orders, orders_pk, _source(_ITEMS), _UNCOLLAPSED_STG, mart))
+    item = ColumnRef(SourceRef(SourceKind.MODEL, _MART), "item_id")
+    assert prov[item] == frozenset({ColumnRef(SourceRef(SourceKind.SOURCE, _ITEMS), "item_id")})
+
+
+# --- the synthesis: the two properties compose to the right decision via grain_preserved --
+
+
+def test_signals_compose_to_fire_on_the_fan_trap() -> None:
+    """The end-to-end hypothesis: the propagated staging uniqueness, fed to ``grain_preserved``
+    with the origin key recovered from the replicated source, decides the fan trap with no new
+    property. Un-collapsed staging keyed on nothing, origin keyed on ``order_id`` -> not
+    preserved -> fire."""
+    orders, orders_pk = _orders_with_key()
+    mart = _model(
+        _MART, "SELECT order_id, SUM(amount) AS total FROM stg_order_items GROUP BY order_id"
+    )
+    manifest = _manifest(orders, orders_pk, _source(_ITEMS), _UNCOLLAPSED_STG, mart)
+
+    staging_keys = _model_keys(manifest)[_STG]
+    origin_key = _key("order_id")  # orders' propagated key, where SUM(amount) is single-counted
+    assert not grain_preserved(staging_keys, origin_key)
+
+
+def test_signals_compose_to_stay_silent_after_collapse() -> None:
+    """The benign counterpart: collapsed staging is keyed on ``order_id``, which refines the
+    origin key, so the same composition stays silent."""
+    orders, orders_pk = _orders_with_key()
+    mart = _model(
+        _MART, "SELECT order_id, SUM(amount) AS total FROM stg_order_items GROUP BY order_id"
+    )
+    manifest = _manifest(orders, orders_pk, _source(_ITEMS), _COLLAPSED_STG, mart)
+
+    staging_keys = _model_keys(manifest)[_STG]
+    origin_key = _key("order_id")
+    assert grain_preserved(staging_keys, origin_key)

--- a/tests/lineage/test_uniqueness_propagation.py
+++ b/tests/lineage/test_uniqueness_propagation.py
@@ -208,6 +208,43 @@ def test_join_preserves_probe_keys_when_joined_side_is_unique_on_the_key() -> No
     assert keys["model.shop.enriched"] == CandidateKeySet.of(_key("id"))
 
 
+def test_right_join_does_not_preserve_probe_keys() -> None:
+    """A RIGHT JOIN NULL-pads the probe (left) side on joined-in rows with no match, so the
+    probe key can repeat as NULL and does not survive, even when the joined-in side is unique
+    on the join column."""
+    orders = _source("source.shop.raw.orders")
+    customers = _source("source.shop.raw.customers")
+    keys = _keys(
+        orders,
+        customers,
+        _unique("test.shop.o", column="id", target=orders.unique_id),
+        _unique("test.shop.c", column="id", target=customers.unique_id),
+        _model(
+            "model.shop.enriched",
+            "SELECT o.id, c.region FROM orders o RIGHT JOIN customers c ON o.customer_id = c.id",
+        ),
+    )
+    assert keys["model.shop.enriched"] == CandidateKeySet.of()
+
+
+def test_full_join_does_not_preserve_probe_keys() -> None:
+    """A FULL JOIN NULL-pads both sides on unmatched rows, so neither side's key identifies
+    the result and no key survives."""
+    orders = _source("source.shop.raw.orders")
+    customers = _source("source.shop.raw.customers")
+    keys = _keys(
+        orders,
+        customers,
+        _unique("test.shop.o", column="id", target=orders.unique_id),
+        _unique("test.shop.c", column="id", target=customers.unique_id),
+        _model(
+            "model.shop.enriched",
+            "SELECT o.id, c.region FROM orders o FULL JOIN customers c ON o.customer_id = c.id",
+        ),
+    )
+    assert keys["model.shop.enriched"] == CandidateKeySet.of()
+
+
 def test_join_drops_keys_when_joined_side_is_not_unique_on_the_key() -> None:
     """The joined-in side is not known unique on the join column, so the join can
     fan out and no key is proven."""

--- a/tests/lineage/test_uniqueness_propagation.py
+++ b/tests/lineage/test_uniqueness_propagation.py
@@ -225,6 +225,64 @@ def test_join_drops_keys_when_joined_side_is_not_unique_on_the_key() -> None:
     assert keys["model.shop.joined"] == CandidateKeySet.of()  # no key proven
 
 
+def test_inner_join_carries_joined_in_key_when_probe_is_unique_on_the_join_cols() -> None:
+    """The symmetric rule. ``orders`` is unique on the join column, so each ``order_items`` row
+    matches at most one order and the result is keyed at the line grain. The probe key
+    ``order_id`` does not survive (an order spans many items), so the joined-in ``item_id`` is
+    the proven key."""
+    orders = _source("source.shop.raw.orders")
+    items = _source("source.shop.raw.order_items")
+    keys = _keys(
+        orders,
+        items,
+        _unique("test.shop.o", column="order_id", target=orders.unique_id),
+        _unique("test.shop.i", column="item_id", target=items.unique_id),
+        _model(
+            "model.shop.lines",
+            "SELECT o.order_id, i.item_id FROM orders o "
+            "JOIN order_items i ON o.order_id = i.order_id",
+        ),
+    )
+    assert keys["model.shop.lines"] == CandidateKeySet.of(_key("item_id"))
+
+
+def test_left_join_does_not_carry_the_joined_in_key() -> None:
+    """An outer join NULL-pads the joined-in columns on unmatched probe rows, so ``item_id``
+    no longer identifies them and the rule must not fire."""
+    orders = _source("source.shop.raw.orders")
+    items = _source("source.shop.raw.order_items")
+    keys = _keys(
+        orders,
+        items,
+        _unique("test.shop.o", column="order_id", target=orders.unique_id),
+        _unique("test.shop.i", column="item_id", target=items.unique_id),
+        _model(
+            "model.shop.lines",
+            "SELECT o.order_id, i.item_id FROM orders o "
+            "LEFT JOIN order_items i ON o.order_id = i.order_id",
+        ),
+    )
+    assert keys["model.shop.lines"] == CandidateKeySet.of()
+
+
+def test_inner_join_drops_joined_in_key_when_probe_not_unique_on_the_join_cols() -> None:
+    """Without a known key on ``orders`` the probe is not proven unique on the join column, so
+    a single item could match several orders and ``item_id`` is not a proven key."""
+    orders = _source("source.shop.raw.orders")
+    items = _source("source.shop.raw.order_items")
+    keys = _keys(
+        orders,
+        items,
+        _unique("test.shop.i", column="item_id", target=items.unique_id),
+        _model(
+            "model.shop.lines",
+            "SELECT o.order_id, i.item_id FROM orders o "
+            "JOIN order_items i ON o.order_id = i.order_id",
+        ),
+    )
+    assert keys["model.shop.lines"] == CandidateKeySet.of()
+
+
 def test_union_all_proves_no_key() -> None:
     a = _source("source.shop.raw.a")
     b = _source("source.shop.raw.b")

--- a/tests/uniqueness/test_cross_model_fanout.py
+++ b/tests/uniqueness/test_cross_model_fanout.py
@@ -1,0 +1,190 @@
+"""Cross-model fan-out: a downstream additive aggregate over a magnitude an upstream
+fan-out replicated, with the grain never collapsed back.
+
+The local ``detect_join_fanout`` fires at the join that can multiply rows. It cannot see a
+*downstream* model that then sums a replicated magnitude: that mart has no join of its own,
+so nothing flags the double count today. ``detect_cross_model_fanout`` closes that gap by
+reading two propagated properties at the consumer: the aggregated relation's ``uniqueness``
+(is it still keyed at the magnitude's grain) and ``where_provenance`` (which source the
+magnitude traces to, so the grain it is single-counted at can be recovered). The decision is
+``grain_preserved`` over the propagated keys, with the origin key translated into the
+aggregated relation's column names through provenance.
+
+These pin the contract at the boundary, including the discriminator's two edges: an additive
+aggregate of a *replicated-side* magnitude over a relation no longer keyed at that grain
+fires; the same aggregate of a *joined-in-side* magnitude, whose grain the relation does
+preserve, stays silent. The firewall edge (no known origin grain to claim) stays silent too.
+"""
+
+from __future__ import annotations
+
+from dblect.adapters import profile_for_adapter
+from dblect.manifest import DbtTestMetadata, Manifest, Node, ResourceType
+from dblect.sql import Finding, FindingKind, parse_sql
+from dblect.uniqueness.detector import make_cross_model_fanout_detectors
+
+_DUCKDB = profile_for_adapter("duckdb")
+
+_ORDERS = "source.shop.raw.orders"
+_ITEMS = "source.shop.raw.order_items"
+_STG = "model.shop.stg_order_items"
+_MART = "model.shop.mart"
+
+# Staging joins orders (one row per order) to order_items (many per order) and projects a
+# column from each side: ``amount`` is replicated across an order's items, ``qty`` sits at
+# the line grain. How order_items is keyed decides staging's grain, so the fixtures vary it.
+_STG_SQL = (
+    "SELECT o.order_id, o.amount, i.item_id, i.qty "
+    "FROM orders o JOIN order_items i ON o.order_id = i.order_id"
+)
+# Staging that collapses back to the order grain before exporting.
+_STG_COLLAPSED_SQL = (
+    "SELECT o.order_id, SUM(o.amount) AS amount "
+    "FROM orders o JOIN order_items i ON o.order_id = i.order_id GROUP BY o.order_id"
+)
+
+
+def _model(uid: str, sql: str) -> Node:
+    return Node(
+        unique_id=uid,
+        name=uid.split(".")[-1],
+        resource_type=ResourceType.MODEL,
+        fqn=(uid,),
+        package_name="shop",
+        schema="analytics",
+        raw_code=None,
+        compiled_code=sql,
+        original_file_path=None,
+        columns={},
+    )
+
+
+def _source(uid: str) -> Node:
+    return Node(
+        unique_id=uid,
+        name=uid.split(".")[-1],
+        resource_type=ResourceType.SOURCE,
+        fqn=(uid,),
+        package_name="shop",
+        schema="raw",
+        raw_code=None,
+        compiled_code=None,
+        original_file_path=None,
+        columns={},
+    )
+
+
+def _unique(uid: str, *, column: str, target: str) -> Node:
+    return Node(
+        unique_id=uid,
+        name=uid.split(".")[-1],
+        resource_type=ResourceType.OTHER,
+        fqn=(uid,),
+        package_name="shop",
+        schema=None,
+        raw_code=None,
+        compiled_code=None,
+        original_file_path=None,
+        columns={},
+        depends_on=frozenset({target}),
+        test_metadata=DbtTestMetadata(name="unique", kwargs={"column_name": column}),
+        attached_node=target,
+    )
+
+
+def _findings(manifest: Manifest, consumer_uid: str) -> tuple[Finding, ...]:
+    """Run the cross-model fan-out detectors over one consumer model's compiled SQL."""
+    detectors = make_cross_model_fanout_detectors(manifest, _DUCKDB)
+    node = manifest.nodes[consumer_uid]
+    assert node.compiled_code is not None
+    tree = parse_sql(node.compiled_code, dialect="duckdb")
+    return tuple(f for detect in detectors for f in detect(tree))
+
+
+def _shop(*extra: Node, items_unique_on: str | None, mart_sql: str, stg_sql: str = _STG_SQL):
+    """The orders/order_items/staging/mart manifest, varying the order_items key and the
+    mart's aggregate. Orders is keyed on ``order_id`` unless overridden via ``extra``."""
+    nodes: list[Node] = [
+        _source(_ORDERS),
+        _unique("test.shop.orders_pk", column="order_id", target=_ORDERS),
+        _source(_ITEMS),
+        _model(_STG, stg_sql),
+        _model(_MART, mart_sql),
+        *extra,
+    ]
+    if items_unique_on is not None:
+        nodes.append(_unique("test.shop.items_pk", column=items_unique_on, target=_ITEMS))
+    return Manifest(
+        schema_version="v12", adapter_type="duckdb", nodes={n.unique_id: n for n in nodes}
+    )
+
+
+_SUM_AMOUNT = "SELECT order_id, SUM(amount) AS total FROM stg_order_items GROUP BY order_id"
+_SUM_QTY = "SELECT order_id, SUM(qty) AS total_qty FROM stg_order_items GROUP BY order_id"
+_MAX_AMOUNT = "SELECT order_id, MAX(amount) AS top FROM stg_order_items GROUP BY order_id"
+
+
+# --- fires: an additive aggregate of a replicated magnitude over a broken grain ----------
+
+
+def test_sum_of_replicated_magnitude_over_keyless_staging_fires() -> None:
+    """order_items carries no key, so staging is keyed on nothing; ``SUM(amount)`` folds the
+    replicated order amount and double counts."""
+    manifest = _shop(items_unique_on=None, mart_sql=_SUM_AMOUNT)
+    findings = _findings(manifest, _MART)
+    assert [f.kind for f in findings] == [FindingKind.CROSS_MODEL_FANOUT]
+
+
+def test_sum_of_replicated_magnitude_over_line_grain_staging_fires() -> None:
+    """The sharper case: order_items is keyed on ``item_id``, so staging is perfectly unique,
+    but at the *line* grain. ``SUM(amount)`` still double counts the order amount, since the
+    surviving key does not refine the order grain the amount is single-counted at."""
+    manifest = _shop(items_unique_on="item_id", mart_sql=_SUM_AMOUNT)
+    findings = _findings(manifest, _MART)
+    assert [f.kind for f in findings] == [FindingKind.CROSS_MODEL_FANOUT]
+
+
+# --- stays silent: the joined-in magnitude, the collapse, the covered join, the safe fold -
+
+
+def test_sum_of_joined_in_magnitude_at_its_own_grain_is_silent() -> None:
+    """``qty`` traces to order_items, whose ``item_id`` key staging preserves, so summing it
+    per order is the intended set aggregation, not a fan trap."""
+    manifest = _shop(items_unique_on="item_id", mart_sql=_SUM_QTY)
+    assert _findings(manifest, _MART) == ()
+
+
+def test_groupby_collapse_in_staging_is_silent() -> None:
+    """Staging groups back to the order grain, so its export is keyed on ``order_id`` and the
+    downstream ``SUM(amount)`` reads one row per order."""
+    manifest = _shop(items_unique_on=None, mart_sql=_SUM_AMOUNT, stg_sql=_STG_COLLAPSED_SQL)
+    assert _findings(manifest, _MART) == ()
+
+
+def test_covered_join_is_silent() -> None:
+    """order_items is itself unique on the join key, so the join is one-to-one and staging
+    stays keyed on ``order_id``."""
+    manifest = _shop(items_unique_on="order_id", mart_sql=_SUM_AMOUNT)
+    assert _findings(manifest, _MART) == ()
+
+
+def test_duplicate_safe_aggregate_is_silent() -> None:
+    """``MAX`` is idempotent under duplication, so replicating rows cannot change it."""
+    manifest = _shop(items_unique_on=None, mart_sql=_MAX_AMOUNT)
+    assert _findings(manifest, _MART) == ()
+
+
+def test_no_known_origin_grain_is_silent() -> None:
+    """The firewall: with no key on orders we cannot name the grain ``amount`` is
+    single-counted at, so there is no positive fact to fire on."""
+    nodes = [
+        _source(_ORDERS),  # no unique test on orders
+        _source(_ITEMS),
+        _unique("test.shop.items_pk", column="item_id", target=_ITEMS),
+        _model(_STG, _STG_SQL),
+        _model(_MART, _SUM_AMOUNT),
+    ]
+    manifest = Manifest(
+        schema_version="v12", adapter_type="duckdb", nodes={n.unique_id: n for n in nodes}
+    )
+    assert _findings(manifest, _MART) == ()

--- a/tests/uniqueness/test_cross_model_fanout.py
+++ b/tests/uniqueness/test_cross_model_fanout.py
@@ -188,3 +188,28 @@ def test_no_known_origin_grain_is_silent() -> None:
         schema_version="v12", adapter_type="duckdb", nodes={n.unique_id: n for n in nodes}
     )
     assert _findings(manifest, _MART) == ()
+
+
+def test_local_cte_shadowing_the_relation_is_silent() -> None:
+    """The consumer's own WITH defines a CTE named like the model, so the FROM reads that
+    per-query scope, which the propagator does not annotate, and the detector stays silent."""
+    mart_sql = (
+        "WITH stg_order_items AS (SELECT order_id, 1 AS amount FROM orders) "
+        "SELECT order_id, SUM(amount) AS total FROM stg_order_items GROUP BY order_id"
+    )
+    manifest = _shop(items_unique_on=None, mart_sql=mart_sql)
+    assert _findings(manifest, _MART) == ()
+
+
+def test_unrelated_nested_cte_does_not_shadow_a_real_read() -> None:
+    """A CTE named like the fanned-out relation but declared only inside an unrelated nested
+    scope does not silence the genuine read of that relation in the outer query: CTE shadowing
+    is lexical, not tree-wide."""
+    mart_sql = (
+        "WITH unrelated AS ("
+        "WITH stg_order_items AS (SELECT 1 AS x) SELECT x FROM stg_order_items"
+        ") "
+        "SELECT order_id, SUM(amount) AS total FROM stg_order_items GROUP BY order_id"
+    )
+    manifest = _shop(items_unique_on=None, mart_sql=mart_sql)
+    assert [f.kind for f in _findings(manifest, _MART)] == [FindingKind.CROSS_MODEL_FANOUT]


### PR DESCRIPTION
Implements the cross-model cardinality **inflation** case from `docs/design/hazard-algebra.md` (the documented follow-on to #175), and the substrate fix it depends on.

## The gap

The local `detect_join_fanout` fires at the join that can multiply rows. It cannot see a *downstream* model that then sums a magnitude an upstream fan-out replicated: that mart has no join of its own, so nothing flagged the double count.

## The detector

`detect_cross_model_fanout` (`uniqueness/detector.py`, wired into `audit/walker.py`) reads two already-propagating properties at the consumer:

- the aggregated relation's `uniqueness` — is it still keyed at the magnitude's grain;
- `where_provenance` — which source the magnitude traces to.

The decision is `grain_preserved` over the propagated keys, with the origin key translated into the aggregated relation's column names through provenance. **No new property** — the cross-model follow-on reduces to a finding that joins two existing properties. New `FindingKind.CROSS_MODEL_FANOUT` (error: a double count is wrong numbers).

It fires on an additive aggregate of a *replicated-side* magnitude over a relation no longer keyed at that grain, and stays silent on a *joined-in-side* magnitude whose grain the relation preserves, on a GROUP BY collapse, on a covered join, on a duplicate-safe aggregate, and when no origin grain is known (the firewall).

## The substrate fix it forced

Writing the joined-in counterexample first (validation-first) surfaced a real gap: the uniqueness walk tracked only the **probe side's** keys, dropping the joined-in key through an N:1 join, so a fanned-out staging read as `NO_KEYS` and a benign joined-in `SUM` could not be told from a replicated one.

`_joined_in_survivors` (`properties/uniqueness.py`) adds the **symmetric rule**: an INNER join carries the joined-in side's keys when the probe is unique on the join columns (each joined-in row then matches at most one probe row). INNER only, since an outer join NULL-pads the joined-in key; it composes across a join chain because the carried key set is the accumulated result's keys. The always-valid union key `{Ka∪Kb}` is intentionally not modeled (not needed for `grain_preserved`).

## Reuse

The #175 consumer scan is reused by extracting `_sensitive_aggregate_consumers`, shared with the local collapse guard.

## Scope (documented in the detector docstring, future work)

Single-source consumers only: a consuming model that itself joins stays silent pending column-level reasoning. Cross-model **deflation** (the row-drop side) is not in this PR.

## Gate

`ruff check` + `ruff format --check` clean, `pyright` (strict) clean, `uv run pytest` 1046 passed (18 new), no regressions from the join-rule change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)