### PR TITLE
feat(hazards): propagated array-non-emptiness to quiet rebuilt-then-unnested arrays (#181)

### DIFF
--- a/src/dblect/audit/walker.py
+++ b/src/dblect/audit/walker.py
@@ -25,6 +25,7 @@ from sqlglot import Expr
 from dblect.adapters import AdapterProfile
 from dblect.audit.sourcemap import LineMap, SourceSpan, build_line_map
 from dblect.audit.suppress import apply, parse_directives
+from dblect.flatten.detector import make_array_nonemptiness_detectors
 from dblect.manifest import Manifest, Node, compilation_miss_reason
 from dblect.nullability.detector import make_nullability_detectors
 from dblect.snapshot import make_snapshot_detectors
@@ -33,7 +34,6 @@ from dblect.sql import (
     FindingKind,
     SQLParseError,
     detect_coalesce_on_join_key,
-    detect_inner_flatten_row_drop,
     detect_null_group_after_outer_join,
     detect_unordered_aggregate,
     detect_unordered_window,
@@ -51,14 +51,16 @@ Detector = Callable[[Expr], tuple[Finding, ...]]
 
 # The dialect-agnostic structural detectors. Context-bound detectors (non-determinism
 # from the resolved adapter, uniqueness and nullability grounded against declared
-# facts) are built per run in `run_audit` and appended there, so they are not listed.
+# facts, inner-flatten grounded against propagated array non-emptiness) are built per
+# run in `run_audit` and appended there, so they are not listed. The inner-flatten check
+# in particular is run only through its fact-grounded factory so it sees the cross-model
+# non-emptiness map; listing the structural form here too would double-report it.
 DEFAULT_DETECTORS: tuple[Detector, ...] = (
     detect_null_group_after_outer_join,
     detect_coalesce_on_join_key,
     detect_unordered_window,
     detect_unordered_aggregate,
     detect_where_on_outer_joined_nullable,
-    detect_inner_flatten_row_drop,
 )
 
 
@@ -151,7 +153,9 @@ def run_audit(
     order-keys and join-fanout detectors (grounded against declared keys), the
     nullability hazard detectors (GROUP BY, join key, and NOT IN on an
     inherited-nullable column, grounded against the propagated nullability
-    property), and the snapshot temporal-filter detector (grounded against the
+    property), the inner-flatten row-drop detector (grounded against the
+    propagated array-non-emptiness property, so a rebuilt-then-unnested array is
+    not flagged), and the snapshot temporal-filter detector (grounded against the
     manifest's snapshots and their validity columns). The fact-grounded ones are
     opportunistic, silent on projects that declare nothing, so they need no opt-in
     flag. They share the audit's pre-parsed trees, so the SQL is parsed once.
@@ -171,6 +175,7 @@ def run_audit(
         *make_fact_grounded_detectors(manifest, profile, parsed=trees, relation_keys=rel_keys),
         *make_cross_model_fanout_detectors(manifest, profile, parsed=trees, relation_keys=rel_keys),
         *make_nullability_detectors(manifest, profile, parsed=trees),
+        *make_array_nonemptiness_detectors(manifest, profile, parsed=trees),
         *make_snapshot_detectors(manifest),
     )
     effective_detectors: tuple[Detector, ...] = (*tuple(detectors), *contextual)

--- a/src/dblect/flatten/__init__.py
+++ b/src/dblect/flatten/__init__.py
@@ -1,0 +1,13 @@
+"""Inner-flatten row-drop detection grounded against propagated array non-emptiness.
+
+The structural detector in :mod:`dblect.sql.patterns` flags an inner ``UNNEST`` that
+can drop a parent row, clearing only the locally provable cases (an outer form, a
+literal array). This package adds the cross-model layer: it propagates the
+``array_nonemptiness`` property over the manifest column graph and feeds the result
+back into the detector, so an ``UNNEST`` of an array a model rebuilt non-empty
+upstream stays quiet while an ``UNNEST`` of a raw source array keeps firing.
+"""
+
+from dblect.flatten.detector import make_array_nonemptiness_detectors
+
+__all__ = ["make_array_nonemptiness_detectors"]

--- a/src/dblect/flatten/detector.py
+++ b/src/dblect/flatten/detector.py
@@ -17,8 +17,8 @@ from collections.abc import Callable, Mapping
 from sqlglot import Expr
 
 from dblect.adapters import AdapterProfile
-from dblect.lineage.builder import build_manifest_graph
-from dblect.lineage.graph import SourceKind, SourceRef
+from dblect.lineage.builder import build_manifest_graph, index_by_name
+from dblect.lineage.graph import SourceRef
 from dblect.lineage.properties.array_nonemptiness import ArrayNonEmpty, array_nonemptiness
 from dblect.lineage.property import propagate
 from dblect.manifest import Manifest
@@ -47,31 +47,11 @@ def make_array_nonemptiness_detectors(
     for ref, ann in annotations.items():
         if ann.value is ArrayNonEmpty.NON_EMPTY:
             by_source.setdefault(ref.source, set()).add(ref.column)
-    model_nonempty = _by_name(manifest, by_source)
+    model_nonempty = index_by_name(
+        manifest, {ref: frozenset(cols) for ref, cols in by_source.items()}
+    )
 
     def flatten(tree: Expr) -> tuple[Finding, ...]:
         return detect_inner_flatten_row_drop(tree, model_nonempty=model_nonempty)
 
     return (flatten,)
-
-
-def _by_name(
-    manifest: Manifest, by_source: Mapping[SourceRef, set[str]]
-) -> dict[str, frozenset[str]]:
-    """Index the non-empty column sets by the relation name as it appears in compiled SQL.
-
-    A source resolves under ``identifier or name`` (dbt compiles ``{{ source(...) }}`` to its
-    ``identifier``), a model under ``name``, matching the column-graph builder's name
-    resolution so a name the detector looks up lands on the relation the propagation
-    annotated. Models win over sources on a name collision, the way a ``ref`` resolves.
-    """
-    by_name: dict[str, frozenset[str]] = {}
-    models: dict[str, frozenset[str]] = {}
-    for ref, columns in by_source.items():
-        node = manifest.nodes.get(ref.unique_id)
-        if node is None:
-            continue
-        target = models if ref.kind is SourceKind.MODEL else by_name
-        target[node.identifier or node.name] = frozenset(columns)
-    by_name.update(models)
-    return by_name

--- a/src/dblect/flatten/detector.py
+++ b/src/dblect/flatten/detector.py
@@ -1,0 +1,77 @@
+"""Fact-grounded inner-flatten detector: clear an ``UNNEST`` of a provably non-empty array.
+
+The structural :func:`~dblect.sql.patterns.detect_inner_flatten_row_drop` reads one tree
+at a time and cannot see that a column array was rebuilt non-empty in an upstream model.
+Here the ``array_nonemptiness`` property is propagated once over the manifest column graph,
+reduced to a per-relation set of output columns proved non-empty, and threaded back into the
+detector. An ``UNNEST`` of one of those columns drops no row and goes quiet; an ``UNNEST`` of
+a raw source array (whose emptiness is an ingestion fact) keeps firing. This is the
+opportunistic, silent-on-projects-that-declare-nothing posture the other fact-grounded
+detectors take, so it needs no opt-in flag.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+
+from sqlglot import Expr
+
+from dblect.adapters import AdapterProfile
+from dblect.lineage.builder import build_manifest_graph
+from dblect.lineage.graph import SourceKind, SourceRef
+from dblect.lineage.properties.array_nonemptiness import ArrayNonEmpty, array_nonemptiness
+from dblect.lineage.property import propagate
+from dblect.manifest import Manifest
+from dblect.sql import Finding, detect_inner_flatten_row_drop
+
+Detector = Callable[[Expr], tuple[Finding, ...]]
+
+
+def make_array_nonemptiness_detectors(
+    manifest: Manifest,
+    profile: AdapterProfile,
+    *,
+    parsed: Mapping[str, Expr] | None = None,
+) -> tuple[Detector, ...]:
+    """Curry the inner-flatten detector against propagated array non-emptiness.
+
+    The property is propagated once over the whole-manifest column graph; ``parsed``
+    shares the audit's already-parsed trees so the graph build does not re-parse.
+    ``profile`` is the run's resolved target, fixing the parse dialect. The result is a
+    per-relation-name map of output columns proved non-empty, which the detector uses to
+    clear an ``UNNEST`` of one of them.
+    """
+    graph = build_manifest_graph(manifest, dialect=profile.sqlglot_dialect, parsed=parsed).graph
+    annotations = propagate(graph, array_nonemptiness)
+    by_source: dict[SourceRef, set[str]] = {}
+    for ref, ann in annotations.items():
+        if ann.value is ArrayNonEmpty.NON_EMPTY:
+            by_source.setdefault(ref.source, set()).add(ref.column)
+    model_nonempty = _by_name(manifest, by_source)
+
+    def flatten(tree: Expr) -> tuple[Finding, ...]:
+        return detect_inner_flatten_row_drop(tree, model_nonempty=model_nonempty)
+
+    return (flatten,)
+
+
+def _by_name(
+    manifest: Manifest, by_source: Mapping[SourceRef, set[str]]
+) -> dict[str, frozenset[str]]:
+    """Index the non-empty column sets by the relation name as it appears in compiled SQL.
+
+    A source resolves under ``identifier or name`` (dbt compiles ``{{ source(...) }}`` to its
+    ``identifier``), a model under ``name``, matching the column-graph builder's name
+    resolution so a name the detector looks up lands on the relation the propagation
+    annotated. Models win over sources on a name collision, the way a ``ref`` resolves.
+    """
+    by_name: dict[str, frozenset[str]] = {}
+    models: dict[str, frozenset[str]] = {}
+    for ref, columns in by_source.items():
+        node = manifest.nodes.get(ref.unique_id)
+        if node is None:
+            continue
+        target = models if ref.kind is SourceKind.MODEL else by_name
+        target[node.identifier or node.name] = frozenset(columns)
+    by_name.update(models)
+    return by_name

--- a/src/dblect/lineage/builder.py
+++ b/src/dblect/lineage/builder.py
@@ -591,6 +591,12 @@ class _Walker:
         group = sel.args.get("group")
         if not isinstance(group, exp.Group) or not group.expressions:
             return frozenset()
+        # ``GROUP BY ()`` is the grand-total grouping set: an empty ``exp.Tuple`` that
+        # folds the whole relation into one group, exactly like no GROUP BY. It grounds
+        # the same whole-relation facts as the empty case above rather than the
+        # "unresolvable keys" ``None`` below (which marks real but opaque group keys).
+        if all(isinstance(g, exp.Tuple) and not g.expressions for g in group.expressions):
+            return frozenset()
         out: set[ColumnRef] = set()
         for g in group.expressions:
             if not isinstance(g, exp.Column) or isinstance(g.this, exp.Star):

--- a/src/dblect/lineage/builder.py
+++ b/src/dblect/lineage/builder.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
-from typing import cast
+from typing import TypeVar, cast
 
 from sqlglot import Expr
 from sqlglot import expressions as exp
@@ -124,7 +124,7 @@ def build_relation_graph(
     and seeds carry no derivation; they enter only as recursion targets that
     ground from facts.
     """
-    name_to_source = _build_name_to_source(manifest)
+    name_to_source = build_name_to_source(manifest)
     derivations: dict[SourceRef, Expr] = {}
     issues: list[BuildIssue] = []
     for uid, model in manifest.models.items():
@@ -177,7 +177,7 @@ def build_manifest_graph(
     SQL are skipped and reported in ``BuildResult.issues``. ``parsed`` lets a caller
     share already-parsed trees so the SQL is parsed once (the audit walker does).
     """
-    name_to_source = _build_name_to_source(manifest)
+    name_to_source = build_name_to_source(manifest)
     # The schema starts from documented columns (the only source for DAG leaves,
     # which have no SQL of their own) and grows as the walk proceeds: a model's
     # resolved output columns are folded in before its dependents are qualified.
@@ -820,13 +820,18 @@ def _projection_leaves(expr: Expr) -> tuple[list[exp.Column], list[exp.Subquery]
     return direct, subqueries
 
 
-def _build_name_to_source(manifest: Manifest) -> Mapping[str, SourceRef]:
+def build_name_to_source(manifest: Manifest) -> Mapping[str, SourceRef]:
     """Map every name that can appear as a table qualifier to its ``SourceRef``.
 
     Includes models (by ``name``), sources (by ``identifier or name`` since
     dbt compiles ``{{ source(...) }}`` to ``identifier``), and seeds. On a
     name collision, models win — matching the convention that ``ref('x')``
     refers to a model named ``x`` over a source that happens to share it.
+
+    This is the single owner of the compiled-SQL name resolution convention. The
+    relation-graph builder keys the propagation on the ``SourceRef``s it returns,
+    and a detector that needs name-keyed lookup composes it via :func:`index_by_name`
+    rather than re-deriving the convention, so the two cannot drift.
     """
     out: dict[str, SourceRef] = {}
     for uid, src in manifest.sources.items():
@@ -839,6 +844,26 @@ def _build_name_to_source(manifest: Manifest) -> Mapping[str, SourceRef]:
     for uid, model in manifest.models.items():
         out[model.name] = SourceRef(SourceKind.MODEL, uid)
     return out
+
+
+_ByName = TypeVar("_ByName")
+
+
+def index_by_name(manifest: Manifest, by_source: Mapping[SourceRef, _ByName]) -> dict[str, _ByName]:
+    """Re-key a per-relation map by the relation name as it appears in compiled SQL.
+
+    A detector propagates a property to a ``Mapping[SourceRef, ...]`` but looks relations
+    up by the name in a parsed tree. Rather than re-encode the name convention (the
+    fragile-cooperation hazard), it composes the one resolver, :func:`build_name_to_source`,
+    with its own ``SourceRef``-keyed facts. A name whose relation has no entry in
+    ``by_source`` is omitted, so a lookup miss reads as "no fact" exactly as a per-relation
+    absence would; on a model/source name collision the model wins, as in ``ref`` resolution.
+    """
+    return {
+        name: by_source[ref]
+        for name, ref in build_name_to_source(manifest).items()
+        if ref in by_source
+    }
 
 
 def _build_schema(manifest: Manifest) -> Mapping[str, Mapping[str, str]]:

--- a/src/dblect/lineage/graph.py
+++ b/src/dblect/lineage/graph.py
@@ -193,9 +193,11 @@ class AggregationSite:
     * ``input_source``: the single FROM relation the scope aggregates over, when
       it is one resolvable relation with no joins; ``None`` closes the dependency
       read (the FD property has no scope to answer for).
-    * ``group_refs``: the GROUP BY columns; ``None`` marks a group shape the
-      builder cannot resolve to plain columns (positional or computed group keys),
-      which a guard must treat as unprovable rather than as an empty group key.
+    * ``group_refs``: the GROUP BY columns; the empty set is the whole-relation
+      fold (no GROUP BY, or the ``GROUP BY ()`` grand-total grouping set), and
+      ``None`` marks a group shape the builder cannot resolve to plain columns
+      (positional or computed group keys), which a guard must treat as unprovable
+      rather than as an empty group key.
     * ``pinned``: columns the scope's own WHERE equates to a literal, constant
       across every group by construction.
     """

--- a/src/dblect/lineage/properties/__init__.py
+++ b/src/dblect/lineage/properties/__init__.py
@@ -14,6 +14,10 @@ dispatches it with no global registration step.
 """
 
 from dblect.lineage.properties.aggregation_depth import aggregation_depth
+from dblect.lineage.properties.array_nonemptiness import (
+    ArrayNonEmpty,
+    array_nonemptiness,
+)
 from dblect.lineage.properties.domain_type import (
     CONFLICT,
     NAKED,
@@ -52,6 +56,7 @@ __all__ = [
     "CONFLICT",
     "FD",
     "NAKED",
+    "ArrayNonEmpty",
     "CandidateKeySet",
     "Concrete",
     "Dimension",
@@ -61,6 +66,7 @@ __all__ = [
     "PerRow",
     "Tagged",
     "aggregation_depth",
+    "array_nonemptiness",
     "determines",
     "domain_type_grounding",
     "domain_type_property",

--- a/src/dblect/lineage/properties/array_nonemptiness.py
+++ b/src/dblect/lineage/properties/array_nonemptiness.py
@@ -1,0 +1,164 @@
+"""Array-non-emptiness: a per-column property over array-typed columns.
+
+The lattice is the tri-state ``{NON_EMPTY, UNKNOWN}`` (with an unreachable
+``CONTRADICTION`` bottom that only makes it bounded). ``NON_EMPTY`` refines
+``UNKNOWN``, the "no information" top; ``meet`` keeps the stronger guarantee. The
+firewall posture is the whole point: anything the walk cannot prove non-empty
+stays ``UNKNOWN``, never over-claiming, so a consumer that clears a hazard on
+``NON_EMPTY`` only ever clears what is provably safe.
+
+The value is driven entirely by intrinsic facts the transfers read off the SQL,
+not by anything a manifest declares, so the property needs no discoverer and
+every column grounds to the implicit top:
+
+* an ``ARRAY[...]`` / ``ARRAY(...)`` constructor with one or more elements is
+  ``NON_EMPTY`` (a literal array cannot be empty);
+* an ``ARRAY_AGG(expr)`` under a ``GROUP BY`` is ``NON_EMPTY`` per group, since a
+  group has at least one row and so at least one element (even a NULL element
+  counts toward non-emptiness). Without a ``GROUP BY`` the fold is over the whole
+  relation, where ``ARRAY_AGG`` of zero rows returns NULL, so it stays ``UNKNOWN``;
+* ``ARRAY_AGG(expr IGNORE NULLS)`` is ``NON_EMPTY`` only when ``expr`` is provably
+  non-null (a ``STRUCT(...)`` constructor is never null). Otherwise an all-NULL
+  group collapses to ``[]`` and the value stays ``UNKNOWN``;
+* a base-relation array column grounds ``UNKNOWN`` (its emptiness is an ingestion
+  fact the static analyser cannot see), which is just the default top.
+
+Transfer is the ordinary column walk: a passthrough or rename carries the value,
+and a ``UNION ALL`` is ``NON_EMPTY`` only when every arm is (the lattice join over
+``UNKNOWN``-as-top gives exactly that, so no semiring is needed). The consumer is
+the inner-flatten row-drop detector, which treats an ``UNNEST`` of a provably
+``NON_EMPTY`` argument as row-preserving.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+import sqlglot.expressions as exp
+from sqlglot import Expr
+
+from dblect.lineage.facts.lattice import Lattice
+from dblect.lineage.facts.model import Annotation, Opacity
+from dblect.lineage.facts.property import (
+    AggregateRule,
+    DepContext,
+    Property,
+    column_property,
+)
+from dblect.lineage.graph import ColumnRef, aggregation_site_meta
+from dblect.sql.vocab import array_literal_nonempty
+
+
+class ArrayNonEmpty(StrEnum):
+    CONTRADICTION = "contradiction"  # formal lattice bottom; unreachable in propagation
+    NON_EMPTY = "non_empty"
+    UNKNOWN = "unknown"
+
+
+# Precision rank: smaller is more precise. CONTRADICTION < NON_EMPTY < UNKNOWN.
+_RANK: dict[ArrayNonEmpty, int] = {
+    ArrayNonEmpty.CONTRADICTION: 0,
+    ArrayNonEmpty.NON_EMPTY: 1,
+    ArrayNonEmpty.UNKNOWN: 2,
+}
+
+
+def _meet(a: ArrayNonEmpty, b: ArrayNonEmpty) -> ArrayNonEmpty:
+    return a if _RANK[a] <= _RANK[b] else b
+
+
+def _join(a: ArrayNonEmpty, b: ArrayNonEmpty) -> ArrayNonEmpty:
+    return a if _RANK[a] >= _RANK[b] else b
+
+
+ARRAY_NONEMPTY_LATTICE: Lattice[ArrayNonEmpty] = Lattice(
+    meet=_meet,
+    join=_join,
+    top=ArrayNonEmpty.UNKNOWN,
+    bottom=ArrayNonEmpty.CONTRADICTION,
+)
+
+_NON_EMPTY = Annotation(ArrayNonEmpty.NON_EMPTY)
+_UNKNOWN = Annotation(ArrayNonEmpty.UNKNOWN, Opacity.IMPLICIT)
+
+
+def _is_grouped(agg: exp.AggFunc) -> bool:
+    """Whether the aggregate folds per group rather than over the whole relation.
+
+    Read off the :class:`AggregationSite` the builder stamps on every non-windowed
+    aggregate: an empty ``group_refs`` is the whole-relation fold (no GROUP BY),
+    a non-empty set is a resolved GROUP BY, and ``None`` is a GROUP BY whose keys
+    the builder could not resolve to plain columns (positional or computed). Any
+    GROUP BY at all guarantees at least one row per group, so the last two both
+    count as grouped; only the empty set, or an absent site (a windowed aggregate,
+    an unmodelled scope), is treated as whole-relation."""
+    site = aggregation_site_meta(agg)
+    if site is None:
+        return False
+    return site.group_refs != frozenset()
+
+
+def _array_agg_value(agg: exp.AggFunc, *, ignore_nulls: bool) -> Annotation[ArrayNonEmpty]:
+    """The non-emptiness an ``ARRAY_AGG`` grounds, given whether it drops nulls.
+
+    A grouped aggregate has at least one row per group. With nulls kept, that row
+    contributes at least one element (a NULL element still counts), so the array is
+    ``NON_EMPTY``. With ``IGNORE NULLS`` an all-NULL group collapses to ``[]``, so
+    it is ``NON_EMPTY`` only when the aggregated expression is provably non-null;
+    a ``STRUCT(...)`` constructor is the one such form we recognise. A
+    whole-relation fold returns NULL over zero rows, so it stays ``UNKNOWN``."""
+    if not _is_grouped(agg):
+        return _UNKNOWN
+    if not ignore_nulls:
+        return _NON_EMPTY
+    return _NON_EMPTY if isinstance(agg.this, exp.Struct) else _UNKNOWN
+
+
+def _array_literal_rule(
+    expr: Expr, _kids: tuple[Annotation[ArrayNonEmpty], ...], _ctx: DepContext
+) -> Annotation[ArrayNonEmpty]:
+    """An ``ARRAY[...]`` / ``ARRAY(...)`` constructor with one or more constructed
+    elements is non-empty by construction; an empty constructor or an array-subquery
+    (which can return zero rows) carries no guarantee."""
+    return _NON_EMPTY if array_literal_nonempty(expr) else _UNKNOWN
+
+
+def _ignore_nulls_rule(
+    expr: Expr, kids: tuple[Annotation[ArrayNonEmpty], ...], _ctx: DepContext
+) -> Annotation[ArrayNonEmpty]:
+    """``ARRAY_AGG(... IGNORE NULLS)`` parses as an ``IgnoreNulls`` wrapper around the
+    aggregate. Recompute the aggregate's value knowing nulls are dropped; the inner
+    aggregate's own (null-keeping) reduction is discarded. A wrapper over anything
+    else passes its child through unchanged."""
+    inner = expr.this
+    if isinstance(inner, exp.ArrayAgg):
+        return _array_agg_value(inner, ignore_nulls=True)
+    return kids[0] if kids else _UNKNOWN
+
+
+def _array_agg_core(
+    expr: exp.AggFunc, _child: Annotation[ArrayNonEmpty]
+) -> Annotation[ArrayNonEmpty]:
+    """The bare ``ARRAY_AGG`` (no ``IGNORE NULLS`` wrapper). Some dialects also spell
+    the null-dropping form with a ``nulls_excluded`` flag on the call itself, so read
+    it here as well as via the wrapper rule."""
+    return _array_agg_value(expr, ignore_nulls=bool(expr.args.get("nulls_excluded")))
+
+
+def _ground(_col: ColumnRef) -> Annotation[ArrayNonEmpty]:
+    """Nothing is declared non-empty: every column grounds to the implicit top, and
+    the transfers supply the only positive facts. A base-relation array column lands
+    here too, so its emptiness stays an unknown ingestion fact."""
+    return _UNKNOWN
+
+
+array_nonemptiness: Property[ArrayNonEmpty, ColumnRef] = column_property(
+    name="array_nonemptiness",
+    lattice=ARRAY_NONEMPTY_LATTICE,
+    operators={
+        exp.Array: _array_literal_rule,
+        exp.IgnoreNulls: _ignore_nulls_rule,
+    },
+    aggregates={exp.ArrayAgg: AggregateRule(core=_array_agg_core)},
+    ground=_ground,
+)

--- a/src/dblect/lineage/properties/array_nonemptiness.py
+++ b/src/dblect/lineage/properties/array_nonemptiness.py
@@ -86,16 +86,27 @@ def _is_grouped(agg: exp.AggFunc) -> bool:
     """Whether the aggregate folds per group rather than over the whole relation.
 
     Read off the :class:`AggregationSite` the builder stamps on every non-windowed
-    aggregate: an empty ``group_refs`` is the whole-relation fold (no GROUP BY),
-    a non-empty set is a resolved GROUP BY, and ``None`` is a GROUP BY whose keys
-    the builder could not resolve to plain columns (positional or computed). Any
-    GROUP BY at all guarantees at least one row per group, so the last two both
+    aggregate: an empty ``group_refs`` is the whole-relation fold (no GROUP BY, or
+    the ``GROUP BY ()`` grand-total grouping set), a non-empty set is a resolved
+    GROUP BY, and ``None`` is a GROUP BY whose keys the builder could not resolve to
+    plain columns (positional or computed). A non-empty set and the ``None`` case
+    both name a real GROUP BY that guarantees at least one row per group, so both
     count as grouped; only the empty set, or an absent site (a windowed aggregate,
     an unmodelled scope), is treated as whole-relation."""
     site = aggregation_site_meta(agg)
     if site is None:
         return False
     return site.group_refs != frozenset()
+
+
+def _aggregated_expr(agg: exp.AggFunc) -> Expr:
+    """The expression an aggregate folds, looking through an ``ORDER BY``.
+
+    ``ARRAY_AGG(STRUCT(...) ORDER BY ts)`` parses with ``agg.this`` an ``exp.Order``
+    wrapping the real argument, so reading ``agg.this`` directly would miss the
+    ``STRUCT`` underneath. The order clause changes element order, never element
+    presence, so it is transparent to non-emptiness."""
+    return agg.this.this if isinstance(agg.this, exp.Order) else agg.this
 
 
 def _array_agg_value(agg: exp.AggFunc, *, ignore_nulls: bool) -> Annotation[ArrayNonEmpty]:
@@ -105,13 +116,14 @@ def _array_agg_value(agg: exp.AggFunc, *, ignore_nulls: bool) -> Annotation[Arra
     contributes at least one element (a NULL element still counts), so the array is
     ``NON_EMPTY``. With ``IGNORE NULLS`` an all-NULL group collapses to ``[]``, so
     it is ``NON_EMPTY`` only when the aggregated expression is provably non-null;
-    a ``STRUCT(...)`` constructor is the one such form we recognise. A
-    whole-relation fold returns NULL over zero rows, so it stays ``UNKNOWN``."""
+    a ``STRUCT(...)`` constructor is the one such form we recognise (an ``ORDER BY``
+    on the argument is transparent). A whole-relation fold returns NULL over zero
+    rows, so it stays ``UNKNOWN``."""
     if not _is_grouped(agg):
         return _UNKNOWN
     if not ignore_nulls:
         return _NON_EMPTY
-    return _NON_EMPTY if isinstance(agg.this, exp.Struct) else _UNKNOWN
+    return _NON_EMPTY if isinstance(_aggregated_expr(agg), exp.Struct) else _UNKNOWN
 
 
 def _array_literal_rule(
@@ -145,6 +157,22 @@ def _array_agg_core(
     return _array_agg_value(expr, ignore_nulls=bool(expr.args.get("nulls_excluded")))
 
 
+def _filter_rule(
+    expr: Expr, kids: tuple[Annotation[ArrayNonEmpty], ...], _ctx: DepContext
+) -> Annotation[ArrayNonEmpty]:
+    """``ARRAY_AGG(expr) FILTER (WHERE cond)`` parses as a ``Filter`` wrapping the aggregate.
+    The filter keeps only the rows that match ``cond``, so a group whose rows all fail it
+    collapses to an empty array. The filtered aggregate therefore carries no non-emptiness
+    guarantee, whatever the inner (unfiltered) reduction proved. A ``Filter`` over anything
+    else passes its child through unchanged."""
+    inner = expr.this
+    if isinstance(inner, exp.ArrayAgg) or (
+        isinstance(inner, exp.IgnoreNulls) and isinstance(inner.this, exp.ArrayAgg)
+    ):
+        return _UNKNOWN
+    return kids[0] if kids else _UNKNOWN
+
+
 def _ground(_col: ColumnRef) -> Annotation[ArrayNonEmpty]:
     """Nothing is declared non-empty: every column grounds to the implicit top, and
     the transfers supply the only positive facts. A base-relation array column lands
@@ -158,6 +186,7 @@ array_nonemptiness: Property[ArrayNonEmpty, ColumnRef] = column_property(
     operators={
         exp.Array: _array_literal_rule,
         exp.IgnoreNulls: _ignore_nulls_rule,
+        exp.Filter: _filter_rule,
     },
     aggregates={exp.ArrayAgg: AggregateRule(core=_array_agg_core)},
     ground=_ground,

--- a/src/dblect/sql/__init__.py
+++ b/src/dblect/sql/__init__.py
@@ -46,6 +46,7 @@ from dblect.sql.vocab import (
     SURROGATE_HASH_FUNCTIONS,
     SURROGATE_HASH_PASSTHROUGH,
     SURROGATE_HASH_STRUCTURAL,
+    array_literal_nonempty,
 )
 
 __all__ = [
@@ -69,6 +70,7 @@ __all__ = [
     "WindowSummary",
     "aggregate_behavior",
     "all_findings",
+    "array_literal_nonempty",
     "detect_coalesce_on_join_key",
     "detect_inner_flatten_row_drop",
     "detect_null_group_after_outer_join",

--- a/src/dblect/sql/patterns.py
+++ b/src/dblect/sql/patterns.py
@@ -20,7 +20,7 @@ with the per-finding ignore syntax).
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import TYPE_CHECKING
@@ -31,6 +31,7 @@ from sqlglot import Expr
 from dblect.sql import _sqlglot as sg
 from dblect.sql import guards
 from dblect.sql._sqlglot import JoinSide
+from dblect.sql.vocab import array_literal_nonempty
 
 if TYPE_CHECKING:
     # Referenced only in ``suppression_hint``'s signature; imported under
@@ -484,7 +485,9 @@ def detect_where_on_outer_joined_nullable(tree: Expr) -> tuple[Finding, ...]:
     return tuple(out)
 
 
-def detect_inner_flatten_row_drop(tree: Expr) -> tuple[Finding, ...]:
+def detect_inner_flatten_row_drop(
+    tree: Expr, *, model_nonempty: Mapping[str, frozenset[str]] | None = None
+) -> tuple[Finding, ...]:
     """Flag an inner array-flatten arm (``UNNEST``/``explode``/``flatten``) that drops the
     parent row when the array is empty or NULL.
 
@@ -497,7 +500,15 @@ def detect_inner_flatten_row_drop(tree: Expr) -> tuple[Finding, ...]:
     FLATTEN(... OUTER => TRUE)``, spark ``LATERAL VIEW OUTER explode(...)``), which is
     silent. The construct parses dialect-specifically, so the detector reads the structural
     shape sqlglot produces rather than the surface syntax.
+
+    An ``UNNEST`` whose argument is provably non-empty drops no row, so it is silent too.
+    A literal ``ARRAY[...]`` constructor with one or more elements is the local, always-on
+    case (the wide-to-long pivot idiom). When ``model_nonempty`` is supplied (per relation
+    name, the output columns the ``array_nonemptiness`` property proved non-empty), an
+    ``UNNEST`` of a column that resolves to one of those columns is cleared as well, so a
+    rebuilt-then-unnested array carried across a model boundary stays quiet.
     """
+    cte_names = {sg.name_of(cte).lower() for cte in tree.find_all(exp.CTE)}
     out: list[Finding] = []
     for sel in sg.find_all_selects(tree):
         for j in sg.joins_of(sel):
@@ -505,6 +516,8 @@ def detect_inner_flatten_row_drop(tree: Expr) -> tuple[Finding, ...]:
             if kernel is None:
                 continue
             if sg.join_side_of(j) in _OUTER_JOIN_SIDES or _flatten_preserves_rows(kernel):
+                continue
+            if _unnest_arg_provably_nonempty(kernel, sel, model_nonempty, cte_names):
                 continue
             out.append(_inner_flatten_finding(j))
         for lat in sg.laterals_of(sel):
@@ -691,6 +704,73 @@ def _has_outer_kwarg(fn: Expr) -> bool:
             value = kw.expression
             return value.this if isinstance(value, exp.Boolean) else value is not None
     return False
+
+
+def _unnest_arg_provably_nonempty(
+    kernel: Expr,
+    sel: exp.Select,
+    model_nonempty: Mapping[str, frozenset[str]] | None,
+    cte_names: set[str],
+) -> bool:
+    """True when every array ``kernel`` unnests is provably non-empty, so no parent row drops.
+
+    Only the ``UNNEST`` spelling carries its array arguments where we can read them; the
+    ``explode``/``flatten`` function forms wrap the array in dialect-specific ways and are
+    left to the outer-form check. ``UNNEST(a, b)`` zips several arrays, every one of which
+    must be non-empty for the row to survive."""
+    if not isinstance(kernel, exp.Unnest):
+        return False
+    args = [a for a in kernel.expressions if isinstance(a, Expr)]
+    if not args:
+        return False
+    return all(_array_expr_nonempty(a, sel, model_nonempty, cte_names) for a in args)
+
+
+def _array_expr_nonempty(
+    arg: Expr,
+    sel: exp.Select,
+    model_nonempty: Mapping[str, frozenset[str]] | None,
+    cte_names: set[str],
+) -> bool:
+    """Whether one unnested expression is provably non-empty.
+
+    A literal ``ARRAY[...]`` with one or more constructed elements is non-empty by
+    construction (the always-on local case). A column is non-empty when it resolves to a
+    relation read in ``sel`` whose ``model_nonempty`` set lists it; a column qualified by a
+    CTE in scope is local scaffolding the propagated map does not address, so it is not
+    cleared here."""
+    if array_literal_nonempty(arg):
+        return True
+    if model_nonempty is None or not isinstance(arg, exp.Column):
+        return False
+    relation = _column_relation_name(arg, sel)
+    if relation is None or relation.lower() in cte_names:
+        return False
+    return sg.column_name(arg) in model_nonempty.get(relation, frozenset())
+
+
+def _column_relation_name(col: exp.Column, sel: exp.Select) -> str | None:
+    """The relation name a column reads from in ``sel``: its qualifier resolved through the
+    scope's FROM/JOIN tables, or the sole table when the column is unqualified. ``None`` when
+    the qualifier names no table arm or the unqualified scope reads more than one relation."""
+    relations = _relation_names(sel)
+    qualifier = sg.column_table(col)
+    if qualifier is not None:
+        return relations.get(qualifier.lower())
+    return next(iter(relations.values())) if len(relations) == 1 else None
+
+
+def _relation_names(sel: exp.Select) -> dict[str, str]:
+    """Map each table arm's alias-or-name (case-folded) to its relation name, skipping the
+    flatten arms themselves so an ``UNNEST`` does not shadow the relation it draws from."""
+    out: dict[str, str] = {}
+    from_ = sg.from_of(sel)
+    if from_ is not None and isinstance(from_.this, exp.Table):
+        out[from_.this.alias_or_name.lower()] = from_.this.name
+    for j in sg.joins_of(sel):
+        if isinstance(j.this, exp.Table):
+            out[j.this.alias_or_name.lower()] = j.this.name
+    return out
 
 
 def _inner_flatten_finding(node: Expr) -> Finding:

--- a/src/dblect/sql/vocab.py
+++ b/src/dblect/sql/vocab.py
@@ -12,6 +12,22 @@ from __future__ import annotations
 import sqlglot.expressions as exp
 from sqlglot import Expr
 
+
+def array_literal_nonempty(expr: Expr) -> bool:
+    """True when ``expr`` is an array constructor with one or more constructed elements,
+    which cannot be empty.
+
+    ``ARRAY[e1, ..., en]`` and ``ARRAY(e1, ..., en)`` both parse to ``exp.Array`` with the
+    elements as ``expressions``, so a non-empty element list is a provably non-empty array.
+    The ``ARRAY(SELECT ...)`` array-subquery form parses to ``exp.Array`` too, but its single
+    element is a query that may return zero rows, so it carries no guarantee and disqualifies
+    the array. Used by both the ``array_nonemptiness`` property and the inner-flatten detector
+    so the two read the literal-array idiom the same way."""
+    if not isinstance(expr, exp.Array) or not expr.expressions:
+        return False
+    return not any(isinstance(e, exp.Query) for e in expr.expressions)
+
+
 # --- surrogate-hash grammar --------------------------------------------------
 #
 # The typed-node vocabulary for recognizing a surrogate-hash key: a hash of a

--- a/src/dblect/sql/vocab.py
+++ b/src/dblect/sql/vocab.py
@@ -17,15 +17,20 @@ def array_literal_nonempty(expr: Expr) -> bool:
     """True when ``expr`` is an array constructor with one or more constructed elements,
     which cannot be empty.
 
-    ``ARRAY[e1, ..., en]`` and ``ARRAY(e1, ..., en)`` both parse to ``exp.Array`` with the
-    elements as ``expressions``, so a non-empty element list is a provably non-empty array.
-    The ``ARRAY(SELECT ...)`` array-subquery form parses to ``exp.Array`` too, but its single
-    element is a query that may return zero rows, so it carries no guarantee and disqualifies
-    the array. Used by both the ``array_nonemptiness`` property and the inner-flatten detector
-    so the two read the literal-array idiom the same way."""
+    A bracket array literal (``[e1, ..., en]`` / ``ARRAY[e1, ..., en]``) parses to ``exp.Array``
+    with each element as one ``expressions`` entry, so a non-empty list is a provably non-empty
+    array. The elements may be literals, structs, or even parenthesised scalar subqueries
+    (``[(SELECT AS STRUCT ...), ...]``, the wide-to-long pivot idiom), each of which contributes
+    exactly one element and parses as ``exp.Subquery``.
+
+    The one form that can still be empty is the ``ARRAY(<query>)`` array-subquery function: its
+    single element is a *bare* ``exp.Select`` / ``exp.Union`` (not wrapped in ``exp.Subquery``)
+    that may return zero rows. That bare-query element disqualifies the array. Used by both the
+    ``array_nonemptiness`` property and the inner-flatten detector so the two read the
+    literal-array idiom the same way."""
     if not isinstance(expr, exp.Array) or not expr.expressions:
         return False
-    return not any(isinstance(e, exp.Query) for e in expr.expressions)
+    return not any(isinstance(e, (exp.Select, exp.Union)) for e in expr.expressions)
 
 
 # --- surrogate-hash grammar --------------------------------------------------

--- a/src/dblect/sql/vocab.py
+++ b/src/dblect/sql/vocab.py
@@ -12,25 +12,42 @@ from __future__ import annotations
 import sqlglot.expressions as exp
 from sqlglot import Expr
 
+from dblect.sql import _sqlglot as sg
+
 
 def array_literal_nonempty(expr: Expr) -> bool:
-    """True when ``expr`` is an array constructor with one or more constructed elements,
-    which cannot be empty.
+    """True when ``expr`` is an array constructor with one or more elements that are each
+    guaranteed present, so the array cannot be empty.
 
-    A bracket array literal (``[e1, ..., en]`` / ``ARRAY[e1, ..., en]``) parses to ``exp.Array``
-    with each element as one ``expressions`` entry, so a non-empty list is a provably non-empty
-    array. The elements may be literals, structs, or even parenthesised scalar subqueries
-    (``[(SELECT AS STRUCT ...), ...]``, the wide-to-long pivot idiom), each of which contributes
-    exactly one element and parses as ``exp.Subquery``.
+    A bracket array literal (``[e1, ..., en]`` / ``ARRAY[e1, ..., en]``) lists each element
+    explicitly, so a literal, struct, or other scalar element always contributes one item. A
+    parenthesised scalar subquery (``[(SELECT AS STRUCT ...), ...]``, the wide-to-long pivot
+    idiom) also contributes exactly one item, because a ``SELECT`` with no ``FROM`` returns
+    exactly one row.
 
-    The one form that can still be empty is the ``ARRAY(<query>)`` array-subquery function: its
-    single element is a *bare* ``exp.Select`` / ``exp.Union`` (not wrapped in ``exp.Subquery``)
-    that may return zero rows. That bare-query element disqualifies the array. Used by both the
+    The form that can still be empty is a *set-returning* subquery element: the
+    ``ARRAY(<query>)`` array-subquery function, or a parenthesised subquery that reads a
+    ``FROM`` (``ARRAY((SELECT AS STRUCT ... FROM unnest(...) WHERE ...))``), each of which may
+    return zero rows. A query element is therefore treated as guaranteed only when it has no
+    ``FROM``; any element that can be absent disqualifies the array. Used by both the
     ``array_nonemptiness`` property and the inner-flatten detector so the two read the
     literal-array idiom the same way."""
     if not isinstance(expr, exp.Array) or not expr.expressions:
         return False
-    return not any(isinstance(e, (exp.Select, exp.Union)) for e in expr.expressions)
+    return all(_array_element_present(e) for e in expr.expressions)
+
+
+def _array_element_present(element: Expr) -> bool:
+    """Whether one array-constructor element is guaranteed to contribute an item.
+
+    A non-query scalar (literal, struct, column, expression) always does. A query element
+    (a bare ``SELECT``/``UNION`` or one wrapped in ``exp.Subquery``) does only when it has no
+    ``FROM``: a ``FROM``-bearing subquery is set-returning and may yield zero rows, so the
+    array carries no non-emptiness guarantee."""
+    inner = element.this if isinstance(element, exp.Subquery) else element
+    if isinstance(inner, exp.Query):
+        return isinstance(inner, exp.Select) and sg.from_of(inner) is None
+    return True
 
 
 # --- surrogate-hash grammar --------------------------------------------------

--- a/src/dblect/uniqueness/detector.py
+++ b/src/dblect/uniqueness/detector.py
@@ -23,15 +23,14 @@ inline-subquery scopes, which are not relations the propagator annotates.
 from __future__ import annotations
 
 from collections.abc import Callable, Iterator, Mapping
-from typing import TypeVar
 
 import sqlglot.expressions as exp
 from sqlglot import Expr
 
 from dblect.adapters import AdapterProfile
-from dblect.lineage.builder import build_manifest_graph, build_relation_graph
+from dblect.lineage.builder import build_manifest_graph, build_relation_graph, index_by_name
 from dblect.lineage.facts.model import Annotation
-from dblect.lineage.graph import ColumnRef, RelationLineageGraph, SourceKind, SourceRef
+from dblect.lineage.graph import ColumnRef, RelationLineageGraph, SourceRef
 from dblect.lineage.properties import where_provenance
 from dblect.lineage.properties.predicate_flow import (
     predicate_flow_property,
@@ -244,9 +243,11 @@ def make_fact_grounded_detectors(
     conditional_scopes = [ref for ref, ann in keys.items() if ann.value.conditional]
     flow = propagate(graph, predicate_flow_property(), subjects=conditional_scopes)
     activated = activate_conditional(keys, flow)
-    model_keys = _by_name(manifest, activated, lambda _ref, cks: cks.keys)
-    conditional_by_name = _by_name(manifest, keys, lambda _ref, ann: ann.value.conditional)
-    flow_by_name = _by_name(manifest, flow, lambda _ref, ann: ann.value)
+    model_keys = index_by_name(manifest, {ref: cks.keys for ref, cks in activated.items()})
+    conditional_by_name = index_by_name(
+        manifest, {ref: ann.value.conditional for ref, ann in keys.items()}
+    )
+    flow_by_name = index_by_name(manifest, {ref: ann.value for ref, ann in flow.items()})
     cache: dict[int, ScopeIndex] = {}
 
     def scope_index(tree: Expr) -> ScopeIndex:
@@ -364,7 +365,7 @@ def make_cross_model_fanout_detectors(
     col_graph = build_manifest_graph(manifest, dialect=profile.sqlglot_dialect, parsed=parsed).graph
     provenance = propagate(col_graph, where_provenance)
     provenance_by_source = _provenance_by_source(provenance)
-    name_to_ref = _by_name(manifest, keys_by_source, lambda ref, _v: ref)
+    name_to_ref = index_by_name(manifest, {ref: ref for ref in keys_by_source})
 
     def fanout(tree: Expr) -> tuple[Finding, ...]:
         return detect_cross_model_fanout(
@@ -473,36 +474,6 @@ def _provenance_by_source(
     for col_ref, ann in provenance.items():
         by_source.setdefault(col_ref.source, {})[col_ref.column] = ann.value
     return by_source
-
-
-_V = TypeVar("_V")
-_R = TypeVar("_R")
-
-
-def _by_name(
-    manifest: Manifest, anns: Mapping[SourceRef, _V], extract: Callable[[SourceRef, _V], _R]
-) -> dict[str, _R]:
-    """Index a per-relation value by the relation name as it appears in compiled SQL.
-
-    A source resolves under ``identifier or name`` (dbt compiles
-    ``{{ source(...) }}`` to its ``identifier``, which can diverge from ``name``);
-    a model resolves under ``name``. This must match the relation-graph builder's
-    ``_build_name_to_source`` so a name the detectors look up by lands on the same
-    relation the propagation annotated. Models win over sources on a name collision
-    (applied last), matching how a ``ref`` resolves. ``extract`` pulls the value the
-    caller wants (keys, conditional keys, flow, or the ``SourceRef`` itself) from each
-    relation's ``(ref, annotation)`` pair.
-    """
-    by_name: dict[str, _R] = {}
-    models: dict[str, _R] = {}
-    for ref, value in anns.items():
-        node = manifest.nodes.get(ref.unique_id)
-        if node is None:
-            continue
-        target = models if ref.kind is SourceKind.MODEL else by_name
-        target[node.identifier or node.name] = extract(ref, value)
-    by_name.update(models)
-    return by_name
 
 
 def _scope_index_for(

--- a/tests/audit/test_walker.py
+++ b/tests/audit/test_walker.py
@@ -139,7 +139,9 @@ def test_default_detectors_includes_every_sql_detector_exactly_once() -> None:
     }
     default_set = set(DEFAULT_DETECTORS)
     assert sql_detectors - context_bound == default_set
-    assert not (context_bound & default_set), "a context-bound detector is also in DEFAULT_DETECTORS"
+    assert not (context_bound & default_set), (
+        "a context-bound detector is also in DEFAULT_DETECTORS"
+    )
     assert len(DEFAULT_DETECTORS) == len(default_set), "DEFAULT_DETECTORS contains duplicates"
 
 

--- a/tests/audit/test_walker.py
+++ b/tests/audit/test_walker.py
@@ -127,13 +127,19 @@ def test_default_detectors_includes_every_sql_detector_exactly_once() -> None:
     # outside this guard by design.
     import dblect.sql as sql_module
 
+    # `detect_inner_flatten_row_drop` is exported structurally (for standalone scans) but
+    # run in run_audit only through its fact-grounded factory, which threads the
+    # cross-model array-non-emptiness map in; wiring it into DEFAULT_DETECTORS too would
+    # double-report it. So it is deliberately context-bound, like the `make_*` factories.
+    context_bound = {sql_module.detect_inner_flatten_row_drop}
     sql_detectors = {
         getattr(sql_module, name)
         for name in dir(sql_module)
         if name.startswith("detect_") and callable(getattr(sql_module, name))
     }
     default_set = set(DEFAULT_DETECTORS)
-    assert sql_detectors == default_set
+    assert sql_detectors - context_bound == default_set
+    assert not (context_bound & default_set), "a context-bound detector is also in DEFAULT_DETECTORS"
     assert len(DEFAULT_DETECTORS) == len(default_set), "DEFAULT_DETECTORS contains duplicates"
 
 

--- a/tests/flatten/test_detector.py
+++ b/tests/flatten/test_detector.py
@@ -1,0 +1,103 @@
+"""Cross-model inner-flatten: an UNNEST of an array a model rebuilt non-empty upstream.
+
+The structural detector cannot tell a raw source array (whose emptiness is an ingestion
+fact) from one a staging model rebuilt with ARRAY_AGG under a GROUP BY. The fact-grounded
+factory propagates ``array_nonemptiness`` across the manifest and clears the rebuilt case.
+
+These pin the worked example from the broadening of the issue: the unnest of a *raw source*
+array fires, the unnest of the *rebuilt* array one model downstream stays silent.
+"""
+
+from __future__ import annotations
+
+from dblect.adapters import profile_for_adapter
+from dblect.audit.walker import run_audit
+from dblect.flatten.detector import make_array_nonemptiness_detectors
+from dblect.manifest import Manifest, Node, ResourceType
+from dblect.sql import Finding, FindingKind, parse_sql
+
+_BQ = profile_for_adapter("bigquery")
+
+_RAW = "source.app.raw.raw_events"
+_STG = "model.app.stg_event_tags"
+_MART = "model.app.mart_event_tags"
+
+# Staging unnests a raw source array (A), regroups, and rebuilds the array with ARRAY_AGG.
+_STG_SQL = (
+    "WITH exploded AS ("
+    "  SELECT e.event_id, e.region, t.tag, t.weight"
+    "  FROM raw_events e CROSS JOIN UNNEST(e.tags) AS t"
+    "  GROUP BY 1, 2, 3, 4"
+    "), regrouped AS ("
+    "  SELECT event_id, region,"
+    "    ARRAY_AGG(STRUCT(tag, SUM(weight) AS weight)) AS tags"
+    "  FROM exploded GROUP BY event_id, region"
+    ") SELECT * FROM regrouped"
+)
+# The mart unnests the rebuilt array (B).
+_MART_SQL = (
+    "SELECT s.event_id, x.tag, x.weight FROM stg_event_tags s CROSS JOIN UNNEST(s.tags) AS x"
+)
+
+
+def _model(uid: str, sql: str) -> Node:
+    return Node(
+        unique_id=uid,
+        name=uid.split(".")[-1],
+        resource_type=ResourceType.MODEL,
+        fqn=(uid,),
+        package_name="app",
+        schema="analytics",
+        raw_code=None,
+        compiled_code=sql,
+        original_file_path=None,
+        columns={},
+    )
+
+
+def _source(uid: str) -> Node:
+    return Node(
+        unique_id=uid,
+        name=uid.split(".")[-1],
+        resource_type=ResourceType.SOURCE,
+        fqn=(uid,),
+        package_name="app",
+        schema="raw",
+        raw_code=None,
+        compiled_code=None,
+        original_file_path=None,
+        columns={},
+    )
+
+
+def _manifest() -> Manifest:
+    nodes = [_source(_RAW), _model(_STG, _STG_SQL), _model(_MART, _MART_SQL)]
+    return Manifest(
+        schema_version="v12", adapter_type="bigquery", nodes={n.unique_id: n for n in nodes}
+    )
+
+
+def _findings(manifest: Manifest, consumer_uid: str) -> tuple[Finding, ...]:
+    detectors = make_array_nonemptiness_detectors(manifest, _BQ)
+    node = manifest.nodes[consumer_uid]
+    assert node.compiled_code is not None
+    tree = parse_sql(node.compiled_code, dialect="bigquery")
+    return tuple(f for detect in detectors for f in detect(tree))
+
+
+def test_unnest_of_raw_source_array_fires() -> None:
+    findings = _findings(_manifest(), _STG)
+    assert [f.kind for f in findings] == [FindingKind.INNER_FLATTEN_ROW_DROP]
+
+
+def test_unnest_of_rebuilt_array_is_silent_across_the_model_boundary() -> None:
+    assert _findings(_manifest(), _MART) == ()
+
+
+def test_run_audit_reports_the_flatten_finding_exactly_once() -> None:
+    # End to end: the structural form is no longer in DEFAULT_DETECTORS, so the finding
+    # comes solely through the fact-grounded factory. The raw-source unnest in staging
+    # fires once; the mart's rebuilt-array unnest stays silent.
+    report = run_audit(_manifest(), _BQ)
+    flatten = [lf for lf in report.findings if lf.kind is FindingKind.INNER_FLATTEN_ROW_DROP]
+    assert [lf.model_unique_id for lf in flatten] == [_STG]

--- a/tests/lineage/test_array_nonemptiness_propagation.py
+++ b/tests/lineage/test_array_nonemptiness_propagation.py
@@ -159,6 +159,50 @@ def test_array_agg_ignore_nulls_of_scalar_is_unknown() -> None:
     assert values[_col("model.app.stg", "tags")] is ArrayNonEmpty.UNKNOWN
 
 
+def test_array_agg_under_empty_grouping_set_is_unknown() -> None:
+    # GROUP BY () is the grand-total grouping set: it folds the whole relation into one
+    # group, so over zero input rows the single output row's ARRAY_AGG is NULL/empty,
+    # exactly like a whole-relation ARRAY_AGG. It must not be read as a per-group fold.
+    src = _source("source.app.raw.events")
+    values = _values(
+        src,
+        _model("model.app.grand", "SELECT ARRAY_AGG(tag) AS tags FROM events GROUP BY ()"),
+    )
+    assert values[_col("model.app.grand", "tags")] is ArrayNonEmpty.UNKNOWN
+
+
+def test_array_agg_with_filter_is_unknown() -> None:
+    # ARRAY_AGG(x) FILTER (WHERE cond) keeps only matching rows, so a group whose rows
+    # all fail the filter collapses to an empty array, even under a real GROUP BY.
+    src = _source("source.app.raw.events")
+    values = _values(
+        src,
+        _model(
+            "model.app.stg",
+            "SELECT event_id, ARRAY_AGG(tag) FILTER (WHERE weight > 0) AS tags "
+            "FROM events GROUP BY event_id",
+        ),
+    )
+    assert values[_col("model.app.stg", "tags")] is ArrayNonEmpty.UNKNOWN
+
+
+def test_array_agg_ignore_nulls_of_ordered_struct_is_non_empty() -> None:
+    # ARRAY_AGG(STRUCT(...) ORDER BY ...) parses with an exp.Order wrapping the argument.
+    # The order clause changes element order, never presence, so a STRUCT under it is still
+    # provably non-null and the IGNORE NULLS group cannot empty out. This is the canonical
+    # rebuilt-array idiom, so it must clear.
+    src = _source("source.app.raw.events")
+    values = _values(
+        src,
+        _model(
+            "model.app.stg",
+            "SELECT event_id, ARRAY_AGG(STRUCT(tag, weight) ORDER BY weight IGNORE NULLS) AS tags "
+            "FROM events GROUP BY event_id",
+        ),
+    )
+    assert values[_col("model.app.stg", "tags")] is ArrayNonEmpty.NON_EMPTY
+
+
 def test_non_emptiness_carries_across_a_model_boundary() -> None:
     # The rebuilt array stays NON_EMPTY one model downstream (the (B) side).
     src = _source("source.app.raw.events")

--- a/tests/lineage/test_array_nonemptiness_propagation.py
+++ b/tests/lineage/test_array_nonemptiness_propagation.py
@@ -102,6 +102,25 @@ def test_array_literal_is_non_empty() -> None:
     assert values[_col("model.app.pivot", "metrics")] is ArrayNonEmpty.NON_EMPTY
 
 
+def test_array_of_filtered_set_subqueries_is_unknown() -> None:
+    # ARRAY((SELECT AS STRUCT ... FROM unnest(...) WHERE ...)) is set-returning: the filter can
+    # match nothing, so the array can be empty even though it is built inline. Concatenating two
+    # such arrays does not change that. (The real-world shape that exposed the bug: a column an
+    # UNNEST later reads, which must stay flagged.)
+    src = _source("source.app.raw.events")
+    values = _values(
+        src,
+        _model(
+            "model.app.filtered",
+            "SELECT event_id, ARRAY_CONCAT("
+            "  ARRAY((SELECT AS STRUCT name, value FROM UNNEST(raw_metrics) WHERE name IN ('a'))),"
+            "  ARRAY((SELECT AS STRUCT name, value FROM UNNEST(raw_metrics) WHERE name IN ('b')))"
+            ") AS metrics FROM events",
+        ),
+    )
+    assert values[_col("model.app.filtered", "metrics")] is ArrayNonEmpty.UNKNOWN
+
+
 def test_raw_source_array_stays_unknown() -> None:
     # The raw array column's emptiness is an ingestion fact we cannot see; a pure
     # passthrough must not claim non-emptiness (the (A) side of the worked example).

--- a/tests/lineage/test_array_nonemptiness_propagation.py
+++ b/tests/lineage/test_array_nonemptiness_propagation.py
@@ -1,0 +1,175 @@
+"""Cross-model array-non-emptiness propagation, end to end through the substrate.
+
+These pin the property at its contract boundary: build a manifest of sources and
+models, propagate over the column graph, and read each model output column's
+value. The rules under test are the sound ones the walk can justify, including the
+worked example from the broadening of the inner-flatten issue: a raw source array
+stays UNKNOWN, an array rebuilt by ARRAY_AGG under a GROUP BY is NON_EMPTY, and that
+guarantee carries across a model boundary.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from dblect.adapters import profile_for_adapter
+from dblect.lineage.builder import build_manifest_graph
+from dblect.lineage.graph import ColumnRef, SourceKind, SourceRef
+from dblect.lineage.properties.array_nonemptiness import ArrayNonEmpty, array_nonemptiness
+from dblect.lineage.property import propagate
+from dblect.manifest import Manifest, Node, ResourceType
+
+_BQ = profile_for_adapter("bigquery")
+
+
+def _model(uid: str, sql: str) -> Node:
+    return Node(
+        unique_id=uid,
+        name=uid.split(".")[-1],
+        resource_type=ResourceType.MODEL,
+        fqn=(uid,),
+        package_name="app",
+        schema="analytics",
+        raw_code=None,
+        compiled_code=sql,
+        original_file_path=None,
+        columns={},
+    )
+
+
+def _source(uid: str) -> Node:
+    return Node(
+        unique_id=uid,
+        name=uid.split(".")[-1],
+        resource_type=ResourceType.SOURCE,
+        fqn=(uid,),
+        package_name="app",
+        schema="raw",
+        raw_code=None,
+        compiled_code=None,
+        original_file_path=None,
+        columns={},
+    )
+
+
+def _values(*nodes: Node) -> Mapping[ColumnRef, ArrayNonEmpty]:
+    manifest = Manifest(
+        schema_version="v12",
+        adapter_type="bigquery",
+        nodes={n.unique_id: n for n in nodes},
+    )
+    graph = build_manifest_graph(manifest, dialect=_BQ.sqlglot_dialect).graph
+    anns = propagate(graph, array_nonemptiness)
+    return {ref: ann.value for ref, ann in anns.items()}
+
+
+def _col(uid: str, column: str) -> ColumnRef:
+    return ColumnRef(SourceRef(SourceKind.MODEL, uid), column)
+
+
+def test_array_agg_under_group_by_is_non_empty() -> None:
+    src = _source("source.app.raw.events")
+    values = _values(
+        src,
+        _model(
+            "model.app.stg",
+            "SELECT event_id, ARRAY_AGG(STRUCT(tag, weight)) AS tags FROM events GROUP BY event_id",
+        ),
+    )
+    assert values[_col("model.app.stg", "tags")] is ArrayNonEmpty.NON_EMPTY
+
+
+def test_array_agg_without_group_by_is_unknown() -> None:
+    # A whole-relation ARRAY_AGG returns NULL over zero rows, so it cannot be claimed
+    # non-empty.
+    src = _source("source.app.raw.events")
+    values = _values(
+        src,
+        _model("model.app.allrows", "SELECT ARRAY_AGG(tag) AS tags FROM events"),
+    )
+    assert values[_col("model.app.allrows", "tags")] is ArrayNonEmpty.UNKNOWN
+
+
+def test_array_literal_is_non_empty() -> None:
+    src = _source("source.app.raw.events")
+    values = _values(
+        src,
+        _model(
+            "model.app.pivot",
+            "SELECT event_id, ARRAY[STRUCT('clicks' AS k, clicks AS v)] AS metrics FROM events",
+        ),
+    )
+    assert values[_col("model.app.pivot", "metrics")] is ArrayNonEmpty.NON_EMPTY
+
+
+def test_raw_source_array_stays_unknown() -> None:
+    # The raw array column's emptiness is an ingestion fact we cannot see; a pure
+    # passthrough must not claim non-emptiness (the (A) side of the worked example).
+    src = _source("source.app.raw.events")
+    values = _values(
+        src,
+        _model("model.app.passthrough", "SELECT event_id, tags FROM events"),
+    )
+    assert values[_col("model.app.passthrough", "tags")] is ArrayNonEmpty.UNKNOWN
+
+
+def test_array_agg_ignore_nulls_of_struct_is_non_empty() -> None:
+    # A STRUCT(...) is never null, so IGNORE NULLS cannot empty the group.
+    src = _source("source.app.raw.events")
+    values = _values(
+        src,
+        _model(
+            "model.app.stg",
+            "SELECT event_id, ARRAY_AGG(STRUCT(tag, weight) IGNORE NULLS) AS tags "
+            "FROM events GROUP BY event_id",
+        ),
+    )
+    assert values[_col("model.app.stg", "tags")] is ArrayNonEmpty.NON_EMPTY
+
+
+def test_array_agg_ignore_nulls_of_scalar_is_unknown() -> None:
+    # An all-NULL group collapses to [] under IGNORE NULLS when the value can be null.
+    src = _source("source.app.raw.events")
+    values = _values(
+        src,
+        _model(
+            "model.app.stg",
+            "SELECT event_id, ARRAY_AGG(tag IGNORE NULLS) AS tags FROM events GROUP BY event_id",
+        ),
+    )
+    assert values[_col("model.app.stg", "tags")] is ArrayNonEmpty.UNKNOWN
+
+
+def test_non_emptiness_carries_across_a_model_boundary() -> None:
+    # The rebuilt array stays NON_EMPTY one model downstream (the (B) side).
+    src = _source("source.app.raw.events")
+    values = _values(
+        src,
+        _model(
+            "model.app.stg",
+            "SELECT event_id, ARRAY_AGG(STRUCT(tag, weight)) AS tags FROM events GROUP BY event_id",
+        ),
+        _model("model.app.mart", "SELECT event_id, tags FROM stg"),
+    )
+    assert values[_col("model.app.mart", "tags")] is ArrayNonEmpty.NON_EMPTY
+
+
+def test_union_all_is_non_empty_only_when_every_arm_is() -> None:
+    src = _source("source.app.raw.events")
+    mixed = _values(
+        src,
+        _model(
+            "model.app.u",
+            "SELECT ARRAY[1] AS xs FROM events UNION ALL SELECT xs FROM events",
+        ),
+    )
+    assert mixed[_col("model.app.u", "xs")] is ArrayNonEmpty.UNKNOWN
+
+    both = _values(
+        src,
+        _model(
+            "model.app.u2",
+            "SELECT ARRAY[1] AS xs FROM events UNION ALL SELECT ARRAY[2, 3] AS xs FROM events",
+        ),
+    )
+    assert both[_col("model.app.u2", "xs")] is ArrayNonEmpty.NON_EMPTY

--- a/tests/sql/test_patterns.py
+++ b/tests/sql/test_patterns.py
@@ -490,6 +490,54 @@ def test_spark_explode_outer_variants(sql: str, expected: int) -> None:
     assert len(detect_inner_flatten_row_drop(_parse_d(sql, "spark"))) == expected
 
 
+@pytest.mark.parametrize(
+    "sql",
+    [
+        # The wide-to-long pivot idiom: a constructed array of N literal structs is never
+        # empty, so the cross join drops no parent row.
+        "select t.id, m.metric_name, m.metric_value from t, "
+        "unnest(array[struct('clicks' as metric_name, t.clicks as metric_value), "
+        "struct('impressions' as metric_name, t.impressions as metric_value)]) as m",
+        "select t.id, x from t cross join unnest(array[1, 2, 3]) as x",
+    ],
+)
+def test_inner_unnest_of_nonempty_literal_array_not_flagged(sql: str) -> None:
+    assert detect_inner_flatten_row_drop(_parse_d(sql, "bigquery")) == ()
+
+
+def test_inner_unnest_of_empty_literal_array_still_flagged() -> None:
+    # An empty constructor carries no non-emptiness guarantee (degenerate, but pinned).
+    sql = "select t.id, x from t cross join unnest(array[]) as x"
+    assert len(detect_inner_flatten_row_drop(_parse_d(sql, "bigquery"))) == 1
+
+
+def test_inner_unnest_of_array_subquery_still_flagged() -> None:
+    # ARRAY(SELECT ...) also parses to exp.Array, but the subquery may return zero rows, so
+    # the array can be empty and the parent row can still drop.
+    sql = "select t.id, x from t cross join unnest(array(select v from u where u.id = t.id)) as x"
+    assert len(detect_inner_flatten_row_drop(_parse_d(sql, "bigquery"))) == 1
+
+
+def test_inner_unnest_of_column_still_flagged_without_a_map() -> None:
+    # A column array's non-emptiness needs the propagated property; the bare structural
+    # detector cannot prove it and keeps firing.
+    sql = "select t.id, x from t cross join unnest(t.arr) as x"
+    assert len(detect_inner_flatten_row_drop(_parse_d(sql, "bigquery"))) == 1
+
+
+def test_inner_unnest_of_column_cleared_by_model_nonempty_map() -> None:
+    sql = "select s.id, x from stg s cross join unnest(s.tags) as x"
+    tree = _parse_d(sql, "bigquery")
+    assert len(detect_inner_flatten_row_drop(tree)) == 1
+    assert detect_inner_flatten_row_drop(tree, model_nonempty={"stg": frozenset({"tags"})}) == ()
+
+
+def test_model_nonempty_map_only_clears_the_named_column() -> None:
+    sql = "select s.id, x from stg s cross join unnest(s.other) as x"
+    tree = _parse_d(sql, "bigquery")
+    assert len(detect_inner_flatten_row_drop(tree, model_nonempty={"stg": frozenset({"tags"})})) == 1
+
+
 def test_plain_cross_join_of_tables_not_flagged() -> None:
     # A cartesian product of two relations is not an array flatten; not our hazard.
     sql = "select * from a cross join b"

--- a/tests/sql/test_patterns.py
+++ b/tests/sql/test_patterns.py
@@ -546,7 +546,9 @@ def test_inner_unnest_of_column_cleared_by_model_nonempty_map() -> None:
 def test_model_nonempty_map_only_clears_the_named_column() -> None:
     sql = "select s.id, x from stg s cross join unnest(s.other) as x"
     tree = _parse_d(sql, "bigquery")
-    assert len(detect_inner_flatten_row_drop(tree, model_nonempty={"stg": frozenset({"tags"})})) == 1
+    assert (
+        len(detect_inner_flatten_row_drop(tree, model_nonempty={"stg": frozenset({"tags"})})) == 1
+    )
 
 
 def test_plain_cross_join_of_tables_not_flagged() -> None:

--- a/tests/sql/test_patterns.py
+++ b/tests/sql/test_patterns.py
@@ -518,6 +518,17 @@ def test_inner_unnest_of_array_subquery_still_flagged() -> None:
     assert len(detect_inner_flatten_row_drop(_parse_d(sql, "bigquery"))) == 1
 
 
+def test_inner_unnest_of_scalar_subquery_array_literal_not_flagged() -> None:
+    # The real-world pivot idiom: a bracket array of N parenthesised `(SELECT AS STRUCT ...)`
+    # scalar subqueries. Each contributes exactly one element, so the array is non-empty.
+    sql = (
+        "select t.id, m.metric_name, m.metric_value from t cross join unnest([ "
+        "(select as struct 'clicks' as metric_name, t.clicks as metric_value), "
+        "(select as struct 'impressions' as metric_name, t.impressions as metric_value)]) as m"
+    )
+    assert detect_inner_flatten_row_drop(_parse_d(sql, "bigquery")) == ()
+
+
 def test_inner_unnest_of_column_still_flagged_without_a_map() -> None:
     # A column array's non-emptiness needs the propagated property; the bare structural
     # detector cannot prove it and keeps firing.

--- a/tests/sql/test_vocab.py
+++ b/tests/sql/test_vocab.py
@@ -11,13 +11,19 @@ whether the element subquery reads a ``FROM``.
 from __future__ import annotations
 
 import pytest
-import sqlglot
+import sqlglot.expressions as exp
+from sqlglot import Expr
 
+from dblect.sql import parse_sql
 from dblect.sql.vocab import array_literal_nonempty
 
 
-def _array(frag: str) -> object:
-    return sqlglot.parse_one(f"SELECT {frag} AS a", read="bigquery").selects[0].this
+def _array(frag: str) -> Expr:
+    """The expression a single projection parses to, unwrapping its alias."""
+    select = parse_sql(f"SELECT {frag} AS a", dialect="bigquery")
+    assert isinstance(select, exp.Select)
+    projected = select.expressions[0]
+    return projected.this if isinstance(projected, exp.Alias) else projected
 
 
 @pytest.mark.parametrize(

--- a/tests/sql/test_vocab.py
+++ b/tests/sql/test_vocab.py
@@ -1,0 +1,46 @@
+"""Array-literal non-emptiness recognition.
+
+The detector and the ``array_nonemptiness`` property both read ``array_literal_nonempty`` to
+decide whether an array constructor is provably non-empty. The soundness line is between a
+bracket list (every element guaranteed present) and a set-returning subquery element (which
+can be empty), and it is subtle because BigQuery's array-subquery form and a bracket of
+parenthesised scalar subqueries parse to the same ``exp.Array`` shape, separated only by
+whether the element subquery reads a ``FROM``.
+"""
+
+from __future__ import annotations
+
+import pytest
+import sqlglot
+
+from dblect.sql.vocab import array_literal_nonempty
+
+
+def _array(frag: str) -> object:
+    return sqlglot.parse_one(f"SELECT {frag} AS a", read="bigquery").selects[0].this
+
+
+@pytest.mark.parametrize(
+    ("frag", "nonempty"),
+    [
+        ("[1, 2, 3]", True),
+        ("ARRAY[1, 2]", True),
+        ("ARRAY[STRUCT('clicks' AS k, x AS v)]", True),
+        # The wide-to-long pivot idiom: parenthesised scalar subqueries with no FROM, each
+        # exactly one row.
+        ("[(SELECT AS STRUCT 1 AS a), (SELECT AS STRUCT 2 AS a)]", True),
+        ("ARRAY((SELECT AS STRUCT 1 AS a))", True),
+        # Empty constructor: no guarantee.
+        ("ARRAY[]", False),
+        # Array-subquery forms are set-returning and can be empty, whether bare or
+        # parenthesised, and a filter can empty them out.
+        ("ARRAY(SELECT v FROM u)", False),
+        ("ARRAY((SELECT AS STRUCT name FROM UNNEST(m) WHERE name IN ('x')))", False),
+    ],
+)
+def test_array_literal_nonempty(frag: str, nonempty: bool) -> None:
+    assert array_literal_nonempty(_array(frag)) is nonempty
+
+
+def test_non_array_expression_is_not_a_literal_array() -> None:
+    assert array_literal_nonempty(_array("x + 1")) is False


### PR DESCRIPTION
Closes #181.

## What

`detect_inner_flatten_row_drop` flagged every inner `UNNEST` arm, including arrays that are provably non-empty and therefore drop no parent row. The issue's measurement found two dominant false-positive shapes:

- **local**: the wide-to-long pivot idiom `UNNEST(ARRAY[STRUCT(...), STRUCT(...)])`, an array of N literal structs;
- **cross-model** (the higher-value case from the broadening comment): an array rebuilt non-empty in one model (`ARRAY_AGG(...)` under `GROUP BY`) and unnested in another. A within-query check cannot see this, so it wants a propagated property in the same family as `uniqueness` / `nullability`.

## How

**New property `array_nonemptiness`** (`src/dblect/lineage/properties/array_nonemptiness.py`): a per-column lattice `{NON_EMPTY, UNKNOWN}` (with the usual unreachable bottom). Grounding comes from intrinsic SQL facts read by the transfers, so it needs no manifest discoverer:

- a literal `ARRAY[...]` / `ARRAY(...)` with one or more constructed elements is `NON_EMPTY`;
- `ARRAY_AGG(expr)` under a `GROUP BY` is `NON_EMPTY` per group; whole-relation `ARRAY_AGG` returns NULL over zero rows, so it stays `UNKNOWN`;
- `ARRAY_AGG(expr IGNORE NULLS)` is `NON_EMPTY` only when `expr` is provably non-null (a `STRUCT(...)` constructor);
- a base-relation array column stays `UNKNOWN` (ingestion fact).

Transfer is the ordinary column walk: passthrough/rename carry the value, `UNION ALL` is `NON_EMPTY` only when every arm is (the lattice join gives exactly that, so no semiring is needed).

**Detector** now treats an `UNNEST` of a provably non-empty argument as row-preserving:

- the literal-array case locally, always on, in `detect_inner_flatten_row_drop`;
- the cross-model case through a new fact-grounded factory `make_array_nonemptiness_detectors` (`src/dblect/flatten/`), wired into `run_audit` alongside the other context-bound detectors.

The structural form moves out of `DEFAULT_DETECTORS` and runs only through the factory, so the finding is reported once (mirrors how the uniqueness detectors are wired). The literal-array predicate is shared via `sql.vocab.array_literal_nonempty`, which also excludes the `ARRAY(SELECT ...)` array-subquery form (it can return zero rows).

### Worked example outcome
- the unnest of the **raw source** array still fires (a contract a human should confirm);
- the unnest of the **rebuilt** array one model downstream goes quiet.

## Tests
- `tests/lineage/test_array_nonemptiness_propagation.py` — property contract: ARRAY_AGG ±GROUP BY, IGNORE NULLS of struct vs scalar, literal array, raw passthrough, cross-model carry, UNION ALL.
- `tests/flatten/test_detector.py` — the worked example end to end (A fires, B silent) plus `run_audit` exactly-once.
- `tests/sql/test_patterns.py` — literal-array clears, empty/array-subquery still fire, column needs the map.

Full suite green (1068), ruff + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)