### PR TITLE
refactor(sql): extract the finding type system into sql/findings.py (#176)

### DIFF
--- a/src/dblect/sql/__init__.py
+++ b/src/dblect/sql/__init__.py
@@ -7,6 +7,13 @@ from dblect.sql.aggregates import (
     duplicate_sensitive,
     strips_duplicates,
 )
+from dblect.sql.findings import (
+    Finding,
+    FindingKind,
+    finding_at,
+    suppression_code,
+    suppression_hint,
+)
 from dblect.sql.parse import (
     MultiResultScript,
     NoResultScript,
@@ -19,8 +26,6 @@ from dblect.sql.parse import (
 from dblect.sql.patterns import (
     PORTABLE_NON_DETERMINISTIC_BUILTINS,
     AggregateSummary,
-    Finding,
-    FindingKind,
     GroupBySummary,
     JoinSide,
     JoinSummary,
@@ -32,15 +37,12 @@ from dblect.sql.patterns import (
     detect_unordered_aggregate,
     detect_unordered_window,
     detect_where_on_outer_joined_nullable,
-    finding_at,
     list_aggregations,
     list_group_bys,
     list_joins,
     list_windows,
     make_non_determinism_detector,
     scan_all,
-    suppression_code,
-    suppression_hint,
 )
 from dblect.sql.vocab import (
     SURROGATE_HASH_FUNCTIONS,

--- a/src/dblect/sql/findings.py
+++ b/src/dblect/sql/findings.py
@@ -1,0 +1,98 @@
+"""The project-wide finding type system for SQL static analysis.
+
+A ``Finding`` is a single structural observation about one SQL statement, located
+by a line span. Every detector layer emits these: the structural pattern detectors
+in :mod:`dblect.sql.patterns`, the lineage-grounded detectors under
+:mod:`dblect.nullability`, :mod:`dblect.uniqueness`, :mod:`dblect.snapshot`, and
+:mod:`dblect.flatten`. ``FindingKind`` is their shared vocabulary, so it lives here
+rather than in any one detector module.
+
+These are span-in-one-statement findings, distinct from the declaration-level
+findings :mod:`dblect.check.findings` carries (``CheckFindingKind`` /
+``CheckFinding``). The two families share the ``-- noqa`` suppression syntax, which
+is why ``suppression_code`` / ``suppression_hint`` accept either kind.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+from sqlglot import Expr
+
+from dblect.sql import _sqlglot as sg
+
+if TYPE_CHECKING:
+    # Referenced only in the suppression helpers' signatures; imported under
+    # ``TYPE_CHECKING`` so this SQL-layer module stays free of a declaration-check
+    # import at load time.
+    from dblect.check.findings import CheckFindingKind
+
+
+class FindingKind(StrEnum):
+    NULL_GROUP_AFTER_OUTER_JOIN = "null_group_after_outer_join"
+    COALESCE_ON_JOIN_KEY = "coalesce_on_join_key"
+    UNORDERED_RANKING_WINDOW = "unordered_ranking_window"
+    UNORDERED_AGGREGATE = "unordered_aggregate"
+    WHERE_ON_OUTER_JOINED_NULLABLE = "where_on_outer_joined_nullable"
+    NON_DETERMINISTIC_FUNCTION = "non_deterministic_function"
+    NON_UNIQUE_WINDOW_ORDER_KEYS = "non_unique_window_order_keys"
+    JOIN_FANOUT = "join_fanout"
+    CROSS_MODEL_FANOUT = "cross_model_fanout"
+    NULL_GROUP_ON_NULLABLE_KEY = "null_group_on_nullable_key"
+    JOIN_ON_NULLABLE_KEY = "join_on_nullable_key"
+    NOT_IN_NULLABLE_SUBQUERY = "not_in_nullable_subquery"
+    INNER_FLATTEN_ROW_DROP = "inner_flatten_row_drop"
+    SNAPSHOT_TEMPORAL_FILTER_MISSING = "snapshot_temporal_filter_missing"
+
+
+def suppression_code(kind: FindingKind | CheckFindingKind) -> str:
+    """The SQLFluff-style noqa code for a finding kind: ``DBLECT_`` plus the kind's
+    value uppercased (e.g. ``DBLECT_JOIN_FANOUT``). The ``DBLECT_`` prefix is what
+    distinguishes our codes from real lint rule codes (``RF01`` and friends), so dbt
+    lint's noqa directives and ours coexist in one comment without colliding."""
+    return f"DBLECT_{kind.value.upper()}"
+
+
+def suppression_hint(kind: FindingKind | CheckFindingKind) -> str:
+    # The suggested directive must stay valid suppression syntax (round-trip tested).
+    # Both finding families share the directive, so the hint takes either kind and
+    # renders the noqa code the scanner reads back.
+    return f"If this is intentional, suppress it with `-- noqa: {suppression_code(kind)}`."
+
+
+@dataclass(frozen=True, slots=True)
+class Finding:
+    """A single static-analysis observation about a SQL statement.
+
+    ``line_start`` and ``line_end`` are 1-indexed line numbers in the SQL
+    the detector was given — the model's ``compiled_code``, which dbt
+    renders with refs and macro calls expanded inline. Line numbers
+    correspond to the compiled output; the reporter still surfaces the
+    model's source file path so navigation works as expected.
+
+    A value of ``0`` means we couldn't pin the finding to a line, which
+    happens when the offending AST node has no ``Identifier`` descendants
+    sqlglot stamped with position info. Callers can treat ``0`` as "model
+    scope, line unknown" and report it without a line number.
+    """
+
+    kind: FindingKind
+    message: str
+    sql_snippet: str
+    line_start: int
+    line_end: int
+
+
+def finding_at(kind: FindingKind, *, message: str, node: Expr) -> Finding:
+    """Build a Finding whose snippet and source span both come from `node`."""
+    span = sg.line_range(node)
+    line_start, line_end = span if span is not None else (0, 0)
+    return Finding(
+        kind=kind,
+        message=message,
+        sql_snippet=sg.render_sql(node),
+        line_start=line_start,
+        line_end=line_end,
+    )

--- a/src/dblect/sql/patterns.py
+++ b/src/dblect/sql/patterns.py
@@ -22,8 +22,6 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
-from enum import StrEnum
-from typing import TYPE_CHECKING
 
 import sqlglot.expressions as exp
 from sqlglot import Expr
@@ -31,68 +29,8 @@ from sqlglot import Expr
 from dblect.sql import _sqlglot as sg
 from dblect.sql import guards
 from dblect.sql._sqlglot import JoinSide
+from dblect.sql.findings import Finding, FindingKind, finding_at, suppression_code
 from dblect.sql.vocab import array_literal_nonempty
-
-if TYPE_CHECKING:
-    # Referenced only in ``suppression_hint``'s signature; imported under
-    # ``TYPE_CHECKING`` so this SQL-layer module stays free of a declaration-check
-    # import at load time.
-    from dblect.check.findings import CheckFindingKind
-
-
-class FindingKind(StrEnum):
-    NULL_GROUP_AFTER_OUTER_JOIN = "null_group_after_outer_join"
-    COALESCE_ON_JOIN_KEY = "coalesce_on_join_key"
-    UNORDERED_RANKING_WINDOW = "unordered_ranking_window"
-    UNORDERED_AGGREGATE = "unordered_aggregate"
-    WHERE_ON_OUTER_JOINED_NULLABLE = "where_on_outer_joined_nullable"
-    NON_DETERMINISTIC_FUNCTION = "non_deterministic_function"
-    NON_UNIQUE_WINDOW_ORDER_KEYS = "non_unique_window_order_keys"
-    JOIN_FANOUT = "join_fanout"
-    CROSS_MODEL_FANOUT = "cross_model_fanout"
-    NULL_GROUP_ON_NULLABLE_KEY = "null_group_on_nullable_key"
-    JOIN_ON_NULLABLE_KEY = "join_on_nullable_key"
-    NOT_IN_NULLABLE_SUBQUERY = "not_in_nullable_subquery"
-    INNER_FLATTEN_ROW_DROP = "inner_flatten_row_drop"
-    SNAPSHOT_TEMPORAL_FILTER_MISSING = "snapshot_temporal_filter_missing"
-
-
-def suppression_code(kind: FindingKind | CheckFindingKind) -> str:
-    """The SQLFluff-style noqa code for a finding kind: ``DBLECT_`` plus the kind's
-    value uppercased (e.g. ``DBLECT_JOIN_FANOUT``). The ``DBLECT_`` prefix is what
-    distinguishes our codes from real lint rule codes (``RF01`` and friends), so dbt
-    lint's noqa directives and ours coexist in one comment without colliding."""
-    return f"DBLECT_{kind.value.upper()}"
-
-
-def suppression_hint(kind: FindingKind | CheckFindingKind) -> str:
-    # The suggested directive must stay valid suppression syntax (round-trip tested).
-    # Both finding families share the directive, so the hint takes either kind and
-    # renders the noqa code the scanner reads back.
-    return f"If this is intentional, suppress it with `-- noqa: {suppression_code(kind)}`."
-
-
-@dataclass(frozen=True, slots=True)
-class Finding:
-    """A single static-analysis observation about a SQL statement.
-
-    ``line_start`` and ``line_end`` are 1-indexed line numbers in the SQL
-    the detector was given — the model's ``compiled_code``, which dbt
-    renders with refs and macro calls expanded inline. Line numbers
-    correspond to the compiled output; the reporter still surfaces the
-    model's source file path so navigation works as expected.
-
-    A value of ``0`` means we couldn't pin the finding to a line, which
-    happens when the offending AST node has no ``Identifier`` descendants
-    sqlglot stamped with position info. Callers can treat ``0`` as "model
-    scope, line unknown" and report it without a line number.
-    """
-
-    kind: FindingKind
-    message: str
-    sql_snippet: str
-    line_start: int
-    line_end: int
 
 
 @dataclass(frozen=True, slots=True)
@@ -200,19 +138,6 @@ _NON_DETERMINISTIC_TYPED: frozenset[type[Expr]] = frozenset(
 PORTABLE_NON_DETERMINISTIC_BUILTINS: frozenset[str] = frozenset(
     {"now", "current_database", "current_schema", "gen_random_uuid", "sysdate"}
 )
-
-
-def finding_at(kind: FindingKind, *, message: str, node: Expr) -> Finding:
-    """Build a Finding whose snippet and source span both come from `node`."""
-    span = sg.line_range(node)
-    line_start, line_end = span if span is not None else (0, 0)
-    return Finding(
-        kind=kind,
-        message=message,
-        sql_snippet=sg.render_sql(node),
-        line_start=line_start,
-        line_end=line_end,
-    )
 
 
 def list_joins(tree: Expr) -> tuple[JoinSummary, ...]:

--- a/tests/snapshot/test_snapshot_temporal_filter.py
+++ b/tests/snapshot/test_snapshot_temporal_filter.py
@@ -26,8 +26,7 @@ from dblect.adapters import profile_for_adapter
 from dblect.audit import run_audit
 from dblect.manifest import Manifest
 from dblect.snapshot import detect_snapshot_temporal_filter
-from dblect.sql import parse_sql
-from dblect.sql.patterns import FindingKind
+from dblect.sql import FindingKind, parse_sql
 
 # A default-named snapshot and a snapshot that renamed its validity columns.
 _DEFAULT = {"orders_snapshot": ("dbt_valid_from", "dbt_valid_to")}

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from dblect.audit.walker import LocatedFinding
 from dblect.baseline import introduced_findings
 from dblect.check.findings import CheckFinding, CheckFindingKind
-from dblect.sql.patterns import Finding, FindingKind
+from dblect.sql import Finding, FindingKind
 
 
 def _structural(


### PR DESCRIPTION
Closes #176.

`sql/patterns.py` was the home of the **project-wide finding type system** even though it is named for one specific detector layer. Detectors across `nullability`, `uniqueness`, `snapshot`, and `flatten` emit `FindingKind`s that `patterns.py` never detects, so the type system reads as shared infrastructure rather than a pattern.

## What changed

- New `sql/findings.py` holds `FindingKind`, `Finding`, `finding_at`, `suppression_code`, `suppression_hint` (plus the `TYPE_CHECKING` `CheckFindingKind` import they reference).
- `patterns.py` now imports the finding types like every other detector module; it dropped the now-unused `StrEnum` / `TYPE_CHECKING` imports.
- `sql/__init__.py` sources the five symbols from `findings` but re-exports the **exact same public surface**, so no consumer churns.
- The two tests that reached into the private `dblect.sql.patterns` now import from the public `dblect.sql`.

## Naming/home decision

The issue flagged that a parallel `check/findings.py` already exists, so the naming was worth settling deliberately. I kept the two as distinct parallels rather than unifying them: `sql/findings.py` is span-in-one-statement structural findings, `check/findings.py` is declaration-level findings. They are genuinely different shapes that only share the `-- noqa` suppression syntax. The new module's docstring spells out the distinction.

## Verification

No behavior change — a mechanical move plus import updates. Full gate green: `ruff check`, `ruff format --check`, `pyright` (0 errors), `pytest` (1091 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)