### PR TITLE
fix(patterns): silence row_number() dedups whose PARTITION BY covers the projection (#171)

### DIFF
--- a/src/dblect/sql/_sqlglot.py
+++ b/src/dblect/sql/_sqlglot.py
@@ -99,6 +99,18 @@ def fn_of(w: exp.Window) -> Expr | None:
     return cast("Expr | None", w.this)
 
 
+def window_output_alias(w: exp.Window) -> str | None:
+    """The SELECT-list alias a window is projected under (``rn`` in ``row_number() ... as rn``).
+
+    ``None`` when the window is not directly aliased (an unaliased projection, or one where the
+    window is nested inside a larger expression that carries the alias). Callers use this to
+    recognise a later reference to the window by name, e.g. a ``qualify rn = 1`` that names the
+    rank rather than inlining the window.
+    """
+    parent = w.parent
+    return parent.alias if isinstance(parent, exp.Alias) else None
+
+
 def join_side_of(j: exp.Join) -> JoinSide:
     """The side of `j` as a `JoinSide`.
 

--- a/src/dblect/sql/_sqlglot.py
+++ b/src/dblect/sql/_sqlglot.py
@@ -43,6 +43,10 @@ def where_of(sel: exp.Select) -> exp.Where | None:
     return cast("exp.Where | None", sel.args.get("where"))
 
 
+def qualify_of(sel: exp.Select) -> exp.Qualify | None:
+    return cast("exp.Qualify | None", sel.args.get("qualify"))
+
+
 def joins_of(sel: exp.Select) -> list[exp.Join]:
     return cast("list[exp.Join]", sel.args.get("joins") or [])
 

--- a/src/dblect/sql/_sqlglot.py
+++ b/src/dblect/sql/_sqlglot.py
@@ -218,6 +218,15 @@ def column_name(c: exp.Column) -> str:
     return c.name
 
 
+def column_key(c: exp.Column) -> tuple[str | None, str]:
+    """The ``(qualifier, name)`` identity of a column reference, for matching columns by name.
+
+    Two references share a key when they name the same column, ``a.id`` distinct from a bare
+    ``id`` (an under-qualified reference matches conservatively, never spuriously).
+    """
+    return (column_table(c), column_name(c))
+
+
 def find_columns(e: Expr) -> list[exp.Column]:
     return list(e.find_all(exp.Column))
 
@@ -308,9 +317,7 @@ def equality_cols_by_alias(predicate: Expr) -> dict[str, frozenset[str]] | None:
         left, right = leaf.this, leaf.expression
         if not isinstance(left, exp.Column) or not isinstance(right, exp.Column):
             return None
-        sides.append(
-            ((column_table(left), column_name(left)), (column_table(right), column_name(right)))
-        )
+        sides.append((column_key(left), column_key(right)))
     out: dict[str, frozenset[str]] = {}
     for alias in {a for pair in sides for a, _ in pair if a is not None}:
         cols: set[str] = set()

--- a/src/dblect/sql/patterns.py
+++ b/src/dblect/sql/patterns.py
@@ -309,12 +309,85 @@ def detect_coalesce_on_join_key(tree: Expr) -> tuple[Finding, ...]:
     return tuple(out)
 
 
+def _partition_column_keys(w: exp.Window) -> frozenset[tuple[str | None, str]] | None:
+    """The PARTITION BY columns of ``w`` as ``(table, name)`` keys.
+
+    ``None`` when the partition is empty or any term is not a bare column: an expression like
+    ``partition by lower(id)`` is one we cannot match against a projected column, so the
+    caller stays conservative.
+    """
+    keys: set[tuple[str | None, str]] = set()
+    for term in sg.partition_of(w):
+        if not isinstance(term, exp.Column):
+            return None
+        keys.add((sg.column_table(term), sg.column_name(term)))
+    return frozenset(keys) if keys else None
+
+
+def _columns_outside_windows_covered(node: Expr, keys: frozenset[tuple[str | None, str]]) -> bool:
+    """True when every column ``node`` carries forward is one of ``keys``.
+
+    Columns inside a window spec are excluded: those are the dedup's own PARTITION BY terms,
+    which are the keys by construction. A star or subquery makes coverage unprovable (its
+    columns are not enumerable here), so either one is reported as not covered.
+    """
+    if node.find(exp.Star) is not None:
+        return False
+    if node.find(exp.Subquery) is not None or node.find(exp.Select) is not None:
+        return False
+    for col in sg.find_columns(node):
+        if col.find_ancestor(exp.Window) is not None:
+            continue
+        if (sg.column_table(col), sg.column_name(col)) not in keys:
+            return False
+    return True
+
+
+def _row_number_dedup_is_order_insensitive(w: exp.Window) -> bool:
+    """True when an ORDER-BY-less ``row_number()`` cannot affect its query's result bag.
+
+    A ``row_number()`` with no ORDER BY labels rows in an arbitrary within-partition order.
+    That label is observable only through the columns the ranked scope carries forward. When
+    every carried column is a partition key, all rows in a partition are identical on the
+    surfaced columns, so the scope's output bag is the same whichever physical row each rank
+    lands on: the labels ``1..n`` attach to indistinguishable rows. A consumer of a
+    deterministic bag is itself deterministic, so the decision rests on the ranked scope
+    alone, whether the dedup filter sits in a QUALIFY here or a ``where rn = 1`` one level out.
+
+    Scoped to ``row_number()`` as the sole window of a non-aggregating scope, the dedup idiom
+    the refinement targets. ``rank()``/``dense_rank()``/value windows, and multi-window or
+    grouped scopes, stay flagged: the output-bag argument does not carry to them unchanged.
+    """
+    if not isinstance(sg.fn_of(w), exp.RowNumber):
+        return False
+    keys = _partition_column_keys(w)
+    if keys is None:
+        return False
+    scope = w.find_ancestor(exp.Select)
+    if scope is None or sg.group_of(scope) is not None:
+        return False
+    scope_windows = [
+        win for win in sg.find_all_windows(scope) if win.find_ancestor(exp.Select) is scope
+    ]
+    if scope_windows != [w]:
+        return False
+    if not all(_columns_outside_windows_covered(proj, keys) for proj in scope.expressions):
+        return False
+    qualify = sg.qualify_of(scope)
+    return qualify is None or _columns_outside_windows_covered(qualify.this, keys)
+
+
 def detect_unordered_window(tree: Expr) -> tuple[Finding, ...]:
     """Flag ranking window functions with no deterministic ORDER BY.
 
     ``ROW_NUMBER()``, ``RANK()``, and friends produce different results across
     runs unless an ORDER BY pins the order. ``LAG``/``LEAD``/``FIRST_VALUE``/
     ``LAST_VALUE`` are similarly meaningless without an ordering.
+
+    The exception is the dedup where a ``row_number() = 1`` keeps one row per partition and
+    the partition key covers every column the ranked scope carries forward: the surviving
+    rows are then identical on all surfaced columns, so the missing ORDER BY does not change
+    the output (see :func:`_row_number_dedup_is_order_insensitive`).
     """
     out: list[Finding] = []
     for w in sg.find_all_windows(tree):
@@ -322,17 +395,20 @@ def detect_unordered_window(tree: Expr) -> tuple[Finding, ...]:
         if fn is None or type(fn) not in _RANKING_FUNCTIONS:
             continue
         order = sg.order_of(w)
-        if order is None or not order.expressions:
-            out.append(
-                finding_at(
-                    FindingKind.UNORDERED_RANKING_WINDOW,
-                    message=(
-                        f"{type(fn).__name__.upper()} window function has no ORDER BY; "
-                        "result is non-deterministic"
-                    ),
-                    node=w,
-                )
+        if order is not None and order.expressions:
+            continue
+        if _row_number_dedup_is_order_insensitive(w):
+            continue
+        out.append(
+            finding_at(
+                FindingKind.UNORDERED_RANKING_WINDOW,
+                message=(
+                    f"{type(fn).__name__.upper()} window function has no ORDER BY; "
+                    "result is non-deterministic"
+                ),
+                node=w,
             )
+        )
     return tuple(out)
 
 

--- a/src/dblect/sql/patterns.py
+++ b/src/dblect/sql/patterns.py
@@ -190,7 +190,7 @@ def list_group_bys(tree: Expr) -> tuple[GroupBySummary, ...]:
         targets = tuple(sg.render_sql(e) for e in g.expressions)
         cols: list[tuple[str | None, str]] = []
         for e in g.expressions:
-            cols.extend((sg.column_table(c), sg.column_name(c)) for c in sg.find_columns(e))
+            cols.extend(sg.column_key(c) for c in sg.find_columns(e))
         out.append(GroupBySummary(targets=targets, target_columns=tuple(cols)))
     return tuple(out)
 
@@ -283,7 +283,7 @@ def detect_coalesce_on_join_key(tree: Expr) -> tuple[Finding, ...]:
     for sel in sg.find_all_selects(tree):
         ons = [on for j in sg.joins_of(sel) if (on := sg.on_of(j)) is not None]
         keys: set[tuple[str | None, str]] = {
-            (sg.column_table(c), sg.column_name(c))
+            sg.column_key(c)
             for on in ons
             for eq in on.find_all(exp.EQ)
             for c in sg.find_columns(eq)
@@ -295,7 +295,7 @@ def detect_coalesce_on_join_key(tree: Expr) -> tuple[Finding, ...]:
                 first = coalesce.this
                 if not isinstance(first, exp.Column):
                     continue
-                if (sg.column_table(first), sg.column_name(first)) in keys:
+                if sg.column_key(first) in keys:
                     out.append(
                         finding_at(
                             FindingKind.COALESCE_ON_JOIN_KEY,
@@ -320,7 +320,7 @@ def _partition_column_keys(w: exp.Window) -> frozenset[tuple[str | None, str]] |
     for term in sg.partition_of(w):
         if not isinstance(term, exp.Column):
             return None
-        keys.add((sg.column_table(term), sg.column_name(term)))
+        keys.add(sg.column_key(term))
     return frozenset(keys) if keys else None
 
 
@@ -331,16 +331,30 @@ def _columns_outside_windows_covered(node: Expr, keys: frozenset[tuple[str | Non
     which are the keys by construction. A star or subquery makes coverage unprovable (its
     columns are not enumerable here), so either one is reported as not covered.
     """
-    if node.find(exp.Star) is not None:
-        return False
-    if node.find(exp.Subquery) is not None or node.find(exp.Select) is not None:
+    if node.find(exp.Star, exp.Subquery, exp.Select) is not None:
         return False
     for col in sg.find_columns(node):
         if col.find_ancestor(exp.Window) is not None:
             continue
-        if (sg.column_table(col), sg.column_name(col)) not in keys:
+        if sg.column_key(col) not in keys:
             return False
     return True
+
+
+def _scope_is_aggregating(scope: exp.Select) -> bool:
+    """True when ``scope`` collapses its rows: an explicit GROUP BY, or a bare aggregate that
+    triggers implicit grouping (``select count(1) from src`` is one group with no GROUP BY).
+
+    An aggregate inside the window spec or a nested subquery belongs elsewhere and does not
+    count. A collapsing scope carries different rows than the per-row dedup argument assumes,
+    so the caller stays conservative when this holds.
+    """
+    if sg.group_of(scope) is not None:
+        return True
+    return any(
+        agg.find_ancestor(exp.Select) is scope and agg.find_ancestor(exp.Window) is None
+        for agg in sg.find_all_aggfunc(scope)
+    )
 
 
 def _row_number_dedup_is_order_insensitive(w: exp.Window) -> bool:
@@ -356,7 +370,8 @@ def _row_number_dedup_is_order_insensitive(w: exp.Window) -> bool:
 
     Scoped to ``row_number()`` as the sole window of a non-aggregating scope, the dedup idiom
     the refinement targets. ``rank()``/``dense_rank()``/value windows, and multi-window or
-    grouped scopes, stay flagged: the output-bag argument does not carry to them unchanged.
+    aggregating scopes (see :func:`_scope_is_aggregating`), stay flagged: the output-bag
+    argument does not carry to them unchanged.
     """
     if not isinstance(sg.fn_of(w), exp.RowNumber):
         return False
@@ -364,7 +379,7 @@ def _row_number_dedup_is_order_insensitive(w: exp.Window) -> bool:
     if keys is None:
         return False
     scope = w.find_ancestor(exp.Select)
-    if scope is None or sg.group_of(scope) is not None:
+    if scope is None or _scope_is_aggregating(scope):
         return False
     scope_windows = [
         win for win in sg.find_all_windows(scope) if win.find_ancestor(exp.Select) is scope

--- a/src/dblect/sql/patterns.py
+++ b/src/dblect/sql/patterns.py
@@ -374,7 +374,14 @@ def _row_number_dedup_is_order_insensitive(w: exp.Window) -> bool:
     if not all(_columns_outside_windows_covered(proj, keys) for proj in scope.expressions):
         return False
     qualify = sg.qualify_of(scope)
-    return qualify is None or _columns_outside_windows_covered(qualify.this, keys)
+    if qualify is None:
+        return True
+    # A QUALIFY commonly names the window by its SELECT alias (``qualify rn = 1``) instead of
+    # inlining it. That reference is this window's rank label, covered by the same output-bag
+    # argument as the inline form, so admit it alongside the partition keys.
+    alias = sg.window_output_alias(w)
+    qualify_keys = keys | {(None, alias)} if alias is not None else keys
+    return _columns_outside_windows_covered(qualify.this, qualify_keys)
 
 
 def detect_unordered_window(tree: Expr) -> tuple[Finding, ...]:

--- a/tests/sql/test_patterns.py
+++ b/tests/sql/test_patterns.py
@@ -349,6 +349,24 @@ def test_row_number_qualify_mixing_non_covered_predicate_fires() -> None:
     assert len(findings) == 1
 
 
+def test_row_number_qualify_referencing_window_alias_silent() -> None:
+    # QUALIFY names the window by its SELECT alias rather than inlining it. That reference is
+    # the rank label, not a carried data column, so the dedup is as silent as the inline form.
+    sql = "select id, a, b, row_number() over (partition by id, a, b) as rn from src qualify rn = 1"
+    assert detect_unordered_window(_parse(sql)) == ()
+
+
+def test_row_number_qualify_alias_with_non_covered_predicate_fires() -> None:
+    # The alias reference is allowed, but the QUALIFY also pins a non-partition column, so
+    # which row survives is observable: the finding stays live.
+    sql = (
+        "select id, row_number() over (partition by id) as rn from src "
+        "qualify rn = 1 and payload > 5"
+    )
+    findings = detect_unordered_window(_parse(sql))
+    assert len(findings) == 1
+
+
 def test_row_number_dedup_star_projection_fires() -> None:
     # A star can carry any column out of the partition key, so coverage is unprovable.
     sql = "select * from src qualify row_number() over (partition by id) = 1"

--- a/tests/sql/test_patterns.py
+++ b/tests/sql/test_patterns.py
@@ -264,7 +264,9 @@ def test_coalesce_on_filter_pushed_into_on_clause_not_detected() -> None:
 
 
 def test_unordered_row_number_detected() -> None:
-    p = _parse("select row_number() over (partition by x) as rn from t")
+    # The label lands on an arbitrary row, and that row's `payload` is surfaced, so which
+    # value pairs with rank 1 is observable: a genuine non-determinism.
+    p = _parse("select payload, row_number() over (partition by x) as rn from t")
     findings = detect_unordered_window(p)
     assert len(findings) == 1
     assert findings[0].kind is FindingKind.UNORDERED_RANKING_WINDOW
@@ -273,6 +275,128 @@ def test_unordered_row_number_detected() -> None:
 def test_ordered_row_number_not_flagged() -> None:
     p = _parse("select row_number() over (order by ts) as rn from t")
     assert detect_unordered_window(p) == ()
+
+
+# --- row_number() dedup whose PARTITION BY covers the carried columns (#171) ---
+# An ORDER-BY-less row_number() is non-deterministic only when the row each rank lands on
+# is observable. When every column the ranked scope carries forward is a partition key,
+# all rows in a partition are identical on the surfaced columns, so the result bag is the
+# same whichever physical row each rank picks. These dedups are silent. The moment a
+# non-partition column is surfaced, which row wins is observable again and the finding
+# returns.
+
+
+def test_row_number_qualify_dedup_partition_covers_projection_silent() -> None:
+    sql = "select id, a, b from src qualify row_number() over (partition by id, a, b) = 1"
+    assert detect_unordered_window(_parse(sql)) == ()
+
+
+def test_row_number_subquery_dedup_partition_covers_projection_silent() -> None:
+    sql = """
+    select id, a, b
+    from (
+      select id, a, b, row_number() over (partition by id, a, b) as rn from src
+    ) where rn = 1
+    """
+    assert detect_unordered_window(_parse(sql)) == ()
+
+
+def test_row_number_cte_dedup_partition_covers_projection_silent() -> None:
+    sql = """
+    with d as (
+      select id, a, b, row_number() over (partition by id, a, b) as rn from src
+    )
+    select id, a, b from d where rn = 1
+    """
+    assert detect_unordered_window(_parse(sql)) == ()
+
+
+def test_row_number_dedup_surfacing_only_covered_columns_silent() -> None:
+    # rn itself is carried forward, but the ranked scope's own output bag is already
+    # deterministic (identical rows get the rank labels 1..n as a fixed bag), so a
+    # consumer that surfaces rn stays deterministic.
+    sql = """
+    select id, a, b, rn
+    from (
+      select id, a, b, row_number() over (partition by id, a, b) as rn from src
+    ) where rn = 1
+    """
+    assert detect_unordered_window(_parse(sql)) == ()
+
+
+def test_row_number_dedup_projection_expression_over_covered_columns_silent() -> None:
+    sql = "select id, lower(b) as lb from src qualify row_number() over (partition by id, b) = 1"
+    assert detect_unordered_window(_parse(sql)) == ()
+
+
+def test_row_number_dedup_carrying_non_partition_column_fires() -> None:
+    sql = """
+    select id, payload
+    from (
+      select id, payload, row_number() over (partition by id) as rn from src
+    ) where rn = 1
+    """
+    findings = detect_unordered_window(_parse(sql))
+    assert len(findings) == 1
+    assert findings[0].kind is FindingKind.UNORDERED_RANKING_WINDOW
+
+
+def test_row_number_qualify_mixing_non_covered_predicate_fires() -> None:
+    # The QUALIFY combines the rank with a predicate on a non-partition column, so whether
+    # the surviving row also satisfies `payload > 5` depends on which row got rank 1.
+    sql = "select id from src qualify row_number() over (partition by id) = 1 and payload > 5"
+    findings = detect_unordered_window(_parse(sql))
+    assert len(findings) == 1
+
+
+def test_row_number_dedup_star_projection_fires() -> None:
+    # A star can carry any column out of the partition key, so coverage is unprovable.
+    sql = "select * from src qualify row_number() over (partition by id) = 1"
+    findings = detect_unordered_window(_parse(sql))
+    assert len(findings) == 1
+
+
+def test_unordered_rank_dedup_not_suppressed() -> None:
+    # The coverage argument is sound for other ranking functions too, but the dedup idiom
+    # this refinement targets is row_number(); rank()/dense_rank() stay flagged.
+    sql = "select id, a, b from src qualify rank() over (partition by id, a, b) = 1"
+    findings = detect_unordered_window(_parse(sql))
+    assert len(findings) == 1
+
+
+def test_value_window_over_covered_partition_not_suppressed() -> None:
+    # first_value reads a value rather than a rank label; the refinement is scoped to
+    # row_number(), so a value window stays flagged even when its inputs are covered.
+    sql = "select id, a, first_value(a) over (partition by id, a) as fa from src"
+    findings = detect_unordered_window(_parse(sql))
+    assert len(findings) == 1
+
+
+def test_row_number_no_partition_stays_flagged() -> None:
+    sql = "select id, row_number() over () as rn from t"
+    findings = detect_unordered_window(_parse(sql))
+    assert len(findings) == 1
+
+
+def test_row_number_dedup_with_group_by_stays_flagged() -> None:
+    # A GROUP BY changes what the ranked scope carries; the dedup coverage argument does
+    # not apply, so stay conservative.
+    sql = "select id from src group by id qualify row_number() over (partition by id) = 1"
+    findings = detect_unordered_window(_parse(sql))
+    assert len(findings) == 1
+
+
+def test_two_unordered_row_numbers_in_one_scope_stay_flagged() -> None:
+    # The output-bag argument needs the row_number() to be the only window shaping the
+    # scope's output; a second unordered window keeps both findings live.
+    sql = """
+    select id,
+           row_number() over (partition by id) as rn,
+           row_number() over (partition by id) as rn2
+    from src
+    """
+    findings = detect_unordered_window(_parse(sql))
+    assert len(findings) == 2
 
 
 @pytest.mark.parametrize(
@@ -755,6 +879,23 @@ def test_no_windows_implies_no_window_findings(table: str, col: str) -> None:
     """A query with no window expression cannot produce window-ordering findings."""
     p = _parse(f"select sum({col}) as s from {table}")
     assert detect_unordered_window(p) == ()
+
+
+@given(cols=st.lists(_IDENT, min_size=1, max_size=4, unique=True), extra=_IDENT)
+@settings(max_examples=50, deadline=None)
+def test_qualify_dedup_silent_iff_projection_covered(cols: list[str], extra: str) -> None:
+    """A row_number()=1 dedup is silent exactly when the projection stays within the
+    partition key; surfacing any column outside it brings the finding back."""
+    pcsv = ", ".join(cols)
+    covered = f"select {pcsv} from src qualify row_number() over (partition by {pcsv}) = 1"
+    assert detect_unordered_window(_parse(covered)) == ()
+    if extra in cols:
+        return
+    uncovered = (
+        f"select {pcsv}, {extra} from src qualify row_number() over (partition by {pcsv}) = 1"
+    )
+    findings = detect_unordered_window(_parse(uncovered))
+    assert len(findings) == 1
 
 
 @given(

--- a/tests/sql/test_patterns.py
+++ b/tests/sql/test_patterns.py
@@ -404,6 +404,15 @@ def test_row_number_dedup_with_group_by_stays_flagged() -> None:
     assert len(findings) == 1
 
 
+def test_row_number_dedup_with_implicit_aggregate_stays_flagged() -> None:
+    # A bare aggregate with no GROUP BY collapses the scope to one row per group; the
+    # per-row dedup coverage argument does not apply, so stay conservative. count(1) carries
+    # no column, so the coverage check alone would wave it through.
+    sql = "select count(1) from src qualify row_number() over (partition by id) = 1"
+    findings = detect_unordered_window(_parse(sql))
+    assert len(findings) == 1
+
+
 def test_two_unordered_row_numbers_in_one_scope_stay_flagged() -> None:
     # The output-bag argument needs the row_number() to be the only window shaping the
     # scope's output; a second unordered window keeps both findings live.


### PR DESCRIPTION
Closes #171.

## What

`detect_unordered_window` flagged every ORDER-BY-less ranking window. That is a false positive for the wide-partition dedup idiom, where `qualify row_number() over (partition by id, a, b) = 1` keeps one row per partition and the partition key covers every projected column. This refinement makes those silent while keeping the warning everywhere the surviving row is actually observable.

## Why it is sound

An ORDER-BY-less `row_number()` labels rows in an arbitrary within-partition order. That label is observable only through the columns the ranked scope carries forward. When every carried column is a partition key, all rows in a partition are identical on the surfaced columns, so the scope's **output bag** is the same whichever physical row each rank lands on (the labels `1..n` attach to indistinguishable rows). A consumer of a deterministic bag is itself deterministic, so the decision rests on the ranked scope alone, which is why the QUALIFY, inline-subquery, and CTE forms all fall out of one check without consumer analysis.

## Scope and boundaries (each pinned by a counterexample test)

Suppressed only when **all** hold:
- the window is `row_number()` (the dedup workhorse; `rank()`/`dense_rank()`/value windows stay flagged, the bag argument does not carry to them unchanged),
- it is the sole window of a non-aggregating scope,
- the `PARTITION BY` terms are bare columns,
- every column the projection (and any QUALIFY predicate) carries forward, outside the window spec, is a partition key.

A star projection, a non-bare partition term, a non-partition column in the projection, a QUALIFY mixing the rank with a non-covered predicate, an empty partition, a GROUP BY, or a second window all keep the finding live.

Dialect-agnostic: the detector reads AST shape, verified identical on duckdb / bigquery / snowflake / redshift.

## Tests

Written test-first (the silent cases failed before the change). Covers the three dedup forms, an expression-over-covered-columns case, the counterexamples above, and a PBT pinning "silent iff projection within the partition key." The pre-existing `test_unordered_row_number_detected` was re-pointed at a genuinely non-deterministic shape, since a bare `row_number()` with no carried payload is a deterministic bag `{1..n}`. Both coverage guards were mutation-checked. Full gate green: ruff check + format, pyright clean, 1130 passed.

Surfaced by a false-positive calibration run against a large external BigQuery dbt project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)