### PR TITLE
feat(uniqueness): flag non-unique ORDER BY on a top-n aggregate (#159); tier the LIMIT smells as warn

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,27 @@ This writes a harness-specific skill (`.claude/skills/`, `.cursor/rules/`, or an
 
 See the [demo walkthrough](docs/design/demo_walkthrough.md) for an end-to-end tour against `jaffle_shop_duckdb`, and [docs/current_state/architecture.md](docs/current_state/architecture.md) for what is built today.
 
+## Severity and CI
+
+Every finding carries a severity, and that severity is what turns `dblect check` into a CI gate:
+
+- **error** is a correctness hazard: the query can return wrong rows by silently dropping, duplicating, or mis-grouping them. A fan-out that double counts, a `WHERE` that inverts an outer join into an inner one, a nullable join key that drops unmatched rows. The output is wrong and no test fails.
+- **warn** is a determinism smell: each run is correct on its own, but the result is not pinned and can drift between runs. An `array_agg` or window with no `ORDER BY`, a top-level `LIMIT` with no total order, a top-n `LIMIT` inside an aggregate whose order key has ties, a nondeterministic builtin like `current_timestamp()` in a key.
+- **info** is an observation worth surfacing but not worth acting on by default.
+
+The report always prints every finding. `--fail-on` sets only the exit code: the run exits non-zero when an unsuppressed finding sits at or above the threshold, and `0` below it. The default threshold is `warn`.
+
+```bash
+dblect check .                  # default: fail on warn and above
+dblect check . --fail-on error  # gate only on correctness hazards; smells still print
+dblect check . --fail-on info   # strictest: any finding fails the run
+dblect check . --no-fail        # always exit 0, report only
+```
+
+The error/warn line is wrong-rows versus drift. An `error` means the data is incorrect today, so fix it. A `warn` means the data is correct today but not reproducible, so a rerun, a backfill, or a late-arriving row can change it. A determinism smell is real even when it is not urgent: `array_agg(order_id order by amount desc limit 10)` returns a genuine top ten by amount every run, yet a metric over those ten orders (their average basket size, say) can shift between runs when amounts tie at the cutoff, so add a stable tiebreaker where reproducibility matters.
+
+Two levers cover the smells you have already weighed. When one is intentional, record it with `-- noqa: DBLECT_<KIND>` so it moves to the `suppressed:` section instead of failing the build. When you want CI to block only on correctness and treat reproducibility as advisory, run `--fail-on error`. Start at the default so the smells stay visible, and tighten or loosen from there.
+
 ## Status
 
 Pre-alpha, and useful now. The structural audit and the typed-declaration check both run end-to-end against real dbt projects. The runtime layer (property-based testing of models against generated adversarial data, replay-determinism via differential execution) is designed and on the way; see [docs/](docs/) for the design notes and [questions_and_decisions.md](questions_and_decisions.md) for the decisions log.

--- a/src/dblect/severity.py
+++ b/src/dblect/severity.py
@@ -75,8 +75,9 @@ _RANK: dict[Severity, int] = {Severity.INFO: 0, Severity.WARN: 1, Severity.ERROR
 
 
 def _structural_severity(kind: FindingKind) -> Severity:
-    """A structural finding's default severity. error: the query can return wrong rows.
-    warn: the rows are right but their order or value is not pinned, so they can drift."""
+    """A structural finding's default severity. error: the query can return wrong rows, by
+    silently dropping or duplicating or mis-grouping them. warn: each run is right on its own, but
+    the rows' order, selection, or value is not pinned, so the result drifts between runs."""
     match kind:
         case (
             FindingKind.NULL_GROUP_AFTER_OUTER_JOIN
@@ -90,13 +91,13 @@ def _structural_severity(kind: FindingKind) -> Severity:
             | FindingKind.NOT_IN_NULLABLE_SUBQUERY
             | FindingKind.INNER_FLATTEN_ROW_DROP
             | FindingKind.SNAPSHOT_TEMPORAL_FILTER_MISSING
-            | FindingKind.LIMIT_WITHOUT_DETERMINISTIC_ORDER
         ):
             return Severity.ERROR
         case (
             FindingKind.UNORDERED_RANKING_WINDOW
             | FindingKind.UNORDERED_AGGREGATE
             | FindingKind.NON_UNIQUE_AGGREGATE_ORDER_KEYS
+            | FindingKind.LIMIT_WITHOUT_DETERMINISTIC_ORDER
             | FindingKind.NON_DETERMINISTIC_FUNCTION
         ):
             return Severity.WARN

--- a/src/dblect/severity.py
+++ b/src/dblect/severity.py
@@ -83,7 +83,6 @@ def _structural_severity(kind: FindingKind) -> Severity:
             | FindingKind.COALESCE_ON_JOIN_KEY
             | FindingKind.WHERE_ON_OUTER_JOINED_NULLABLE
             | FindingKind.NON_UNIQUE_WINDOW_ORDER_KEYS
-            | FindingKind.NON_UNIQUE_AGGREGATE_ORDER_KEYS
             | FindingKind.JOIN_FANOUT
             | FindingKind.CROSS_MODEL_FANOUT
             | FindingKind.NULL_GROUP_ON_NULLABLE_KEY
@@ -97,6 +96,7 @@ def _structural_severity(kind: FindingKind) -> Severity:
         case (
             FindingKind.UNORDERED_RANKING_WINDOW
             | FindingKind.UNORDERED_AGGREGATE
+            | FindingKind.NON_UNIQUE_AGGREGATE_ORDER_KEYS
             | FindingKind.NON_DETERMINISTIC_FUNCTION
         ):
             return Severity.WARN

--- a/src/dblect/severity.py
+++ b/src/dblect/severity.py
@@ -83,6 +83,7 @@ def _structural_severity(kind: FindingKind) -> Severity:
             | FindingKind.COALESCE_ON_JOIN_KEY
             | FindingKind.WHERE_ON_OUTER_JOINED_NULLABLE
             | FindingKind.NON_UNIQUE_WINDOW_ORDER_KEYS
+            | FindingKind.NON_UNIQUE_AGGREGATE_ORDER_KEYS
             | FindingKind.JOIN_FANOUT
             | FindingKind.CROSS_MODEL_FANOUT
             | FindingKind.NULL_GROUP_ON_NULLABLE_KEY

--- a/src/dblect/sql/_sqlglot.py
+++ b/src/dblect/sql/_sqlglot.py
@@ -91,6 +91,22 @@ def aggregate_order_of(agg: Expr) -> exp.Order | None:
     return inner if isinstance(inner, exp.Order) else None
 
 
+def aggregate_limit_of(agg: Expr) -> exp.Limit | None:
+    """The top-n ``LIMIT`` modifier on an aggregate, if present.
+
+    ``ARRAY_AGG(x ORDER BY y LIMIT n)`` (the top-n idiom) keeps only the first ``n``
+    elements; the ``Limit`` sits among the modifiers stacked above the ORDER BY, so
+    walk through them the same way :func:`aggregate_order_of` does. Returns ``None``
+    when the aggregate folds every element (no inner ``LIMIT``).
+    """
+    inner = agg.this
+    while isinstance(inner, _AGGREGATE_CLAUSE_MODIFIERS):
+        if isinstance(inner, exp.Limit):
+            return inner
+        inner = inner.this
+    return None
+
+
 def partition_of(w: exp.Window) -> list[Expr]:
     return cast("list[Expr]", w.args.get("partition_by") or [])
 
@@ -245,6 +261,16 @@ def find_all_windows(e: Expr) -> list[exp.Window]:
 
 def find_all_aggfunc(e: Expr) -> list[Expr]:
     return cast("list[Expr]", list(e.find_all(exp.AggFunc)))
+
+
+# The order-sensitive aggregates: their element order is part of the result, so an absent or
+# non-total ORDER BY makes the output non-deterministic. ``GroupConcat`` is sqlglot's node for
+# both ``GROUP_CONCAT`` and ``STRING_AGG``.
+ORDERED_AGGREGATE_FUNCTIONS: tuple[type[Expr], ...] = (exp.ArrayAgg, exp.GroupConcat)
+
+
+def find_all_ordered_aggregates(e: Expr) -> list[Expr]:
+    return list(e.find_all(*ORDERED_AGGREGATE_FUNCTIONS))
 
 
 def render_sql(e: Expr) -> str:

--- a/src/dblect/sql/findings.py
+++ b/src/dblect/sql/findings.py
@@ -38,6 +38,7 @@ class FindingKind(StrEnum):
     WHERE_ON_OUTER_JOINED_NULLABLE = "where_on_outer_joined_nullable"
     NON_DETERMINISTIC_FUNCTION = "non_deterministic_function"
     NON_UNIQUE_WINDOW_ORDER_KEYS = "non_unique_window_order_keys"
+    NON_UNIQUE_AGGREGATE_ORDER_KEYS = "non_unique_aggregate_order_keys"
     JOIN_FANOUT = "join_fanout"
     CROSS_MODEL_FANOUT = "cross_model_fanout"
     NULL_GROUP_ON_NULLABLE_KEY = "null_group_on_nullable_key"

--- a/src/dblect/sql/patterns.py
+++ b/src/dblect/sql/patterns.py
@@ -87,8 +87,6 @@ _RANKING_FUNCTIONS: frozenset[type[Expr]] = frozenset(
     }
 )
 
-_ORDERED_AGGREGATE_FUNCTIONS: frozenset[type[Expr]] = frozenset({exp.ArrayAgg, exp.GroupConcat})
-
 _NULL_INTOLERANT_COMPARISONS: frozenset[type[Expr]] = frozenset(
     {
         exp.EQ,
@@ -437,7 +435,7 @@ def detect_unordered_window(tree: Expr) -> tuple[Finding, ...]:
 def detect_unordered_aggregate(tree: Expr) -> tuple[Finding, ...]:
     """Flag order-sensitive aggregates (ARRAY_AGG, STRING_AGG) with no ORDER BY."""
     out: list[Finding] = []
-    for node in tree.find_all(*_ORDERED_AGGREGATE_FUNCTIONS):
+    for node in sg.find_all_ordered_aggregates(tree):
         if isinstance(node.parent, exp.WithinGroup):
             continue
         if sg.aggregate_order_of(node) is not None:

--- a/src/dblect/uniqueness/__init__.py
+++ b/src/dblect/uniqueness/__init__.py
@@ -10,6 +10,7 @@ project's SQL.
 from dblect.uniqueness.detector import (
     detect_join_fanout,
     detect_limit_without_deterministic_order,
+    detect_non_unique_aggregate_order_keys,
     detect_non_unique_window_order_keys,
     make_fact_grounded_detectors,
 )
@@ -17,6 +18,7 @@ from dblect.uniqueness.detector import (
 __all__ = [
     "detect_join_fanout",
     "detect_limit_without_deterministic_order",
+    "detect_non_unique_aggregate_order_keys",
     "detect_non_unique_window_order_keys",
     "make_fact_grounded_detectors",
 ]

--- a/src/dblect/uniqueness/detector.py
+++ b/src/dblect/uniqueness/detector.py
@@ -132,6 +132,14 @@ def detect_non_unique_aggregate_order_keys(
     known uniqueness key of the single source. An aggregate with no ``GROUP BY`` folds the whole
     relation, so the order key alone must be unique.
 
+    The hazard is reproducibility, not correctness, which is why this is a ``warn`` (see
+    :func:`dblect.severity._structural_severity`): a top-n by ``k`` is a genuine top-n by ``k``,
+    every surviving element legitimately among the highest-ranked, so no row is *wrong*. What is
+    not pinned is which tied element the cutoff keeps. That still bites downstream: a metric
+    folded over the selected set (the average basket size of the ten most expensive orders, say)
+    is correct under whichever tie-break happened, yet drifts across runs. A stable tiebreaker
+    removes the drift.
+
     Only the top-n shape fires: an ordered aggregate with no inner ``LIMIT`` keeps every element,
     so its membership is deterministic regardless of ties (only the internal tie order is
     unstable, which the unordered-aggregate detector's territory). An aggregate with no

--- a/src/dblect/uniqueness/detector.py
+++ b/src/dblect/uniqueness/detector.py
@@ -6,6 +6,9 @@ to make a claim, and stay silent otherwise):
 * ``detect_non_unique_window_order_keys``: window functions whose combined
   (partition, order) columns are not covered by any candidate key of the scope's
   single source. Ties in the ordering produce non-deterministic rankings.
+* ``detect_non_unique_aggregate_order_keys``: the aggregate twin of the window check.
+  A top-n ordered aggregate (``ARRAY_AGG(x ORDER BY k LIMIT n)``) whose (group, order)
+  columns are not covered by a source key keeps an arbitrary winner among ties.
 * ``detect_join_fanout``: JOINs whose joined-in side has known keys, none of
   which is covered by the join's equality predicate columns, so the join can
   multiply rows.
@@ -84,21 +87,15 @@ def detect_non_unique_window_order_keys(
         if source_keys is None:
             continue
         for w in sg.find_all_windows(sel):
-            if not _window_is_in_scope(w, sel):
+            if not _node_in_scope(w, sel):
                 continue
             order = sg.order_of(w)
-            if order is None or not order.expressions:
+            if order is None:
                 continue
-            order_cols = _bare_column_names(order.expressions)
-            partition_cols = _bare_column_names(sg.partition_of(w))
-            if order_cols is None or partition_cols is None:
-                # We only reason about windows whose keys are bare columns.
-                # Expressions (`order by date_trunc(...)`) need an equivalence
-                # check we don't model yet; skip.
+            uncovered = _uncovered_order_keys(order.expressions, sg.partition_of(w), source_keys)
+            if uncovered is None:
                 continue
-            key_set = frozenset(order_cols) | frozenset(partition_cols)
-            if any(k <= key_set for k in source_keys):
-                continue
+            order_cols, partition_cols = uncovered
             rendered = sg.render_sql(w)
             out.append(
                 Finding(
@@ -113,6 +110,70 @@ def detect_non_unique_window_order_keys(
                     sql_snippet=rendered,
                     line_start=_line_start(w),
                     line_end=_line_end(w),
+                )
+            )
+    return tuple(out)
+
+
+def detect_non_unique_aggregate_order_keys(
+    tree: Expr,
+    *,
+    model_keys: ModelKeys,
+    scope_index: ScopeIndex | None = None,
+) -> tuple[Finding, ...]:
+    """Flag a top-n ordered aggregate whose order key is not unique within its group.
+
+    ``ARRAY_AGG(x ORDER BY k LIMIT n)`` (and ``STRING_AGG``/``GROUP_CONCAT`` likewise) keeps
+    only the first ``n`` elements, so *which* elements survive is deterministic only when the
+    order key totally orders the rows of each group. With ties at the cutoff the ``LIMIT`` keeps
+    an arbitrary winner, so the result drifts run to run even though an ``ORDER BY`` is present.
+    This is the aggregate analog of :func:`detect_non_unique_window_order_keys`: a ``GROUP BY``
+    plays the partition's role, and the combined (group, order) key set must be covered by a
+    known uniqueness key of the single source. An aggregate with no ``GROUP BY`` folds the whole
+    relation, so the order key alone must be unique.
+
+    Only the top-n shape fires: an ordered aggregate with no inner ``LIMIT`` keeps every element,
+    so its membership is deterministic regardless of ties (only the internal tie order is
+    unstable, which the unordered-aggregate detector's territory). An aggregate with no
+    ``ORDER BY`` at all is that detector's job too, and stays silent here.
+
+    Conservative toward silence, like the window check: single-source scopes only (a join or
+    ``UNION`` needs column-level lineage), bare-column order and group keys only (an expression
+    needs an equivalence we do not model), and silent when no source key is known (the firewall
+    posture, with no grain to name there is no positive fact to fire on).
+    """
+    scopes = _scope_index_for(tree, model_keys, scope_index)
+    out: list[Finding] = []
+    for sel in sg.find_all_selects(tree):
+        source_keys = _single_source_keys(sel, model_keys=model_keys, scope_index=scopes)
+        if source_keys is None:
+            continue
+        group = sg.group_of(sel)
+        grouping = group.expressions if group is not None else []
+        for agg in sg.find_all_ordered_aggregates(sel):
+            if not _node_in_scope(agg, sel):
+                continue
+            order = sg.aggregate_order_of(agg)
+            if order is None or sg.aggregate_limit_of(agg) is None:
+                continue
+            uncovered = _uncovered_order_keys(order.expressions, grouping, source_keys)
+            if uncovered is None:
+                continue
+            order_cols, group_cols = uncovered
+            rendered = sg.render_sql(agg)
+            out.append(
+                Finding(
+                    kind=FindingKind.NON_UNIQUE_AGGREGATE_ORDER_KEYS,
+                    message=(
+                        f"top-n aggregate {rendered} orders by {sorted(order_cols)} "
+                        f"grouped by {sorted(group_cols) or '()'}, and no known uniqueness key "
+                        f"on the source covers the combined key set. The LIMIT keeps an arbitrary "
+                        f"winner among rows that tie on the order keys, so which elements survive "
+                        f"can drift across runs; add a stable tiebreaker."
+                    ),
+                    sql_snippet=rendered,
+                    line_start=_line_start(agg),
+                    line_end=_line_end(agg),
                 )
             )
     return tuple(out)
@@ -444,6 +505,11 @@ def make_fact_grounded_detectors(
             tree, model_keys=model_keys, scope_index=scope_index(tree)
         )
 
+    def aggregate_order_keys(tree: Expr) -> tuple[Finding, ...]:
+        return detect_non_unique_aggregate_order_keys(
+            tree, model_keys=model_keys, scope_index=scope_index(tree)
+        )
+
     def fanout(tree: Expr) -> tuple[Finding, ...]:
         return detect_join_fanout(
             tree,
@@ -460,7 +526,7 @@ def make_fact_grounded_detectors(
             is_materialized=materialized_by_tree.get(id(tree), False),
         )
 
-    return (window_keys, fanout, limit_order)
+    return (window_keys, fanout, limit_order, aggregate_order_keys)
 
 
 # Per-relation views the cross-model fan-out detector reads, all keyed by the relation's
@@ -822,14 +888,42 @@ def _reads_outside_grouping(node: Expr, group_keys: frozenset[tuple[str | None, 
     )
 
 
-def _window_is_in_scope(w: exp.Window, sel: exp.Select) -> bool:
-    """True when window ``w`` belongs to ``sel`` (not a nested sub-SELECT)."""
-    node: Expr | None = w.parent
-    while node is not None:
-        if isinstance(node, exp.Select):
-            return node is sel
-        node = node.parent
+def _node_in_scope(node: Expr, sel: exp.Select) -> bool:
+    """True when ``node``'s nearest enclosing SELECT is ``sel`` (not a nested sub-SELECT).
+
+    Both the window and top-n-aggregate order-key checks read a node against ``sel``'s source
+    keys and grouping, so a window or aggregate that actually belongs to a nested SELECT must be
+    excluded: its keys and grouping are a different scope's."""
+    cur: Expr | None = node.parent
+    while cur is not None:
+        if isinstance(cur, exp.Select):
+            return cur is sel
+        cur = cur.parent
     return False
+
+
+def _uncovered_order_keys(
+    order: list[Expr], grouping: list[Expr], source_keys: frozenset[Key]
+) -> tuple[list[str], list[str]] | None:
+    """The bare order and grouping column names when their combined key set is not covered by a
+    known source key, signalling a non-total order; ``None`` when the order is provably total or
+    we cannot judge it.
+
+    The window and top-n-aggregate checks share this decision: the order is total iff some
+    candidate key fits within the (grouping + order) column set. ``None`` folds the three silent
+    cases both share: an empty order, an order or grouping key that is not a bare column (an
+    expression we do not model an equivalence for), or a combined set a known key already covers.
+    """
+    if not order:
+        return None
+    order_cols = _bare_column_names(order)
+    grouping_cols = _bare_column_names(grouping)
+    if order_cols is None or grouping_cols is None:
+        return None
+    key_set = frozenset(order_cols) | frozenset(grouping_cols)
+    if any(k <= key_set for k in source_keys):
+        return None
+    return order_cols, grouping_cols
 
 
 def _bare_column_names(expressions: list[Expr]) -> list[str] | None:

--- a/tests/lineage/test_conditional_activation.py
+++ b/tests/lineage/test_conditional_activation.py
@@ -319,7 +319,7 @@ def _fanout_kinds(*nodes: Node) -> list[FindingKind]:
         adapter_type="duckdb",
         nodes={n.unique_id: n for n in nodes},
     )
-    _window, fanout, _limit = make_fact_grounded_detectors(manifest, _DUCKDB)
+    _window, fanout, _limit, _agg = make_fact_grounded_detectors(manifest, _DUCKDB)
     return [f.kind for f in fanout(parse_sql(_CONSUMER, dialect="duckdb"))]
 
 
@@ -385,7 +385,7 @@ def _window_kinds(model_sql: str, *nodes: Node) -> list[FindingKind]:
         adapter_type="duckdb",
         nodes={n.unique_id: n for n in nodes},
     )
-    window_keys, _fanout, _limit = make_fact_grounded_detectors(manifest, _DUCKDB)
+    window_keys, _fanout, _limit, _agg = make_fact_grounded_detectors(manifest, _DUCKDB)
     return [f.kind for f in window_keys(parse_sql(model_sql, dialect="duckdb"))]
 
 

--- a/tests/uniqueness/test_detector.py
+++ b/tests/uniqueness/test_detector.py
@@ -16,6 +16,7 @@ from dblect.sql import Finding, FindingKind, parse_sql
 from dblect.uniqueness.detector import (
     detect_join_fanout,
     detect_limit_without_deterministic_order,
+    detect_non_unique_aggregate_order_keys,
     detect_non_unique_window_order_keys,
     make_fact_grounded_detectors,
 )
@@ -230,6 +231,125 @@ def test_limit_verdict(sql: str, keys: _Keys, materialized: bool, fires: bool) -
         assert findings[0].kind is FindingKind.LIMIT_WITHOUT_DETERMINISTIC_ORDER
     else:
         assert findings == ()
+
+
+# --- top-n aggregate (ARRAY_AGG/STRING_AGG ... ORDER BY k LIMIT n) -----------
+#
+# An ordered aggregate that keeps only some elements (`ARRAY_AGG(x ORDER BY k LIMIT n)`, the
+# top-n idiom) is deterministic in *which* elements survive only when the order key is unique
+# within the group. With ties at the cutoff the LIMIT keeps an arbitrary winner, so the result
+# drifts run to run. This is the aggregate analog of the window order-key check: the GROUP BY
+# columns play the partition's role. Each case is the minimal repro of one branch of the verdict.
+
+
+def _agg_order(sql: str, keys: _Keys) -> tuple[Finding, ...]:
+    return detect_non_unique_aggregate_order_keys(_parse(sql), model_keys=keys)
+
+
+_SRC_ON_ID = _model_keys(src=(("id",),))
+
+# (branch id, sql, model keys, expected-to-fire).
+_AGG_ORDER_CASES = [
+    # Whole-relation top-1 by a non-unique key: which row survives is arbitrary.
+    (
+        "whole_relation_non_unique",
+        "select array_agg(x order by ts limit 1) from src",
+        _SRC_ON_ID,
+        True,
+    ),
+    # Grouped top-1: within each group `ts` is not unique, so the combined (g, ts) key isn't
+    # covered by (id).
+    (
+        "grouped_non_unique",
+        "select g, array_agg(x order by ts limit 1) from src group by g",
+        _SRC_ON_ID,
+        True,
+    ),
+    # Order key is the source key: the top-n cut is total, silent.
+    ("order_covers_key", "select array_agg(x order by id limit 1) from src", _SRC_ON_ID, False),
+    # Group + order together cover a composite key, silent.
+    (
+        "group_plus_order_covers_key",
+        "select g, array_agg(x order by seq limit 1) from src group by g",
+        _model_keys(src=(("g", "seq"),)),
+        False,
+    ),
+    # Superkey of the unique key still totally orders, silent.
+    ("order_superkey", "select array_agg(x order by id, ts limit 1) from src", _SRC_ON_ID, False),
+    # No inner LIMIT: every element survives, so membership is deterministic (only the internal
+    # tie order is unstable, which this check leaves to the unordered-aggregate detector). Silent.
+    ("no_limit", "select array_agg(x order by ts) from src", _SRC_ON_ID, False),
+    # No ORDER BY at all is the unordered-aggregate detector's job, not this one. Silent here.
+    ("no_order", "select array_agg(x limit 1) from src", _SRC_ON_ID, False),
+    # No known key on the source: firewall posture, no positive fact to fire on.
+    ("no_keys", "select array_agg(x order by ts limit 1) from src", _model_keys(), False),
+    # Non-bare order key needs an equivalence we don't model, silent.
+    (
+        "order_expression",
+        "select array_agg(x order by date_trunc('day', ts) limit 1) from src",
+        _SRC_ON_ID,
+        False,
+    ),
+    # Non-bare grouping key, likewise silent.
+    (
+        "group_expression",
+        "select date_trunc('day', ts) d, array_agg(x order by k limit 1) from src "
+        "group by date_trunc('day', ts)",
+        _SRC_ON_ID,
+        False,
+    ),
+    # Multi-source scope needs column-level lineage, silent.
+    (
+        "join_out_of_scope",
+        "select array_agg(a.x order by a.ts limit 1) from src a join other b on a.k = b.k",
+        _model_keys(src=(("id",),), other=(("id",),)),
+        False,
+    ),
+    # Unresolved source name, silent.
+    ("unknown_source", "select array_agg(x order by ts limit 1) from unknown", _SRC_ON_ID, False),
+    # STRING_AGG (sqlglot's GroupConcat) is order-sensitive too, fires.
+    ("string_agg", "select string_agg(x, ',' order by ts limit 1) from src", _SRC_ON_ID, True),
+    # The DISTINCT modifier sqlglot wraps around the ORDER BY is seen through, fires.
+    (
+        "distinct_modifier",
+        "select array_agg(distinct x order by ts limit 1) from src",
+        _SRC_ON_ID,
+        True,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("sql", "keys", "fires"),
+    [case[1:] for case in _AGG_ORDER_CASES],
+    ids=[case[0] for case in _AGG_ORDER_CASES],
+)
+def test_aggregate_order_verdict(sql: str, keys: _Keys, fires: bool) -> None:
+    findings = _agg_order(sql, keys)
+    if fires:
+        assert len(findings) == 1
+        assert findings[0].kind is FindingKind.NON_UNIQUE_AGGREGATE_ORDER_KEYS
+    else:
+        assert findings == ()
+
+
+def test_aggregate_order_against_cte_inherits_keys_via_propagation() -> None:
+    # The CTE `src` pass-throughs `raw`; its key (id) propagates. The top-1 by `ts` isn't
+    # covered, so flag — a CTE source is checkable like a ref'd model.
+    parsed = _parse(
+        "with src as (select * from raw) select array_agg(x order by ts limit 1) from src"
+    )
+    findings = detect_non_unique_aggregate_order_keys(
+        parsed, model_keys=_model_keys(raw=(("id",),))
+    )
+    assert len(findings) == 1
+
+
+def test_aggregate_order_finding_carries_line_number() -> None:
+    sql = "select\n  array_agg(x order by ts limit 1) as latest\nfrom src\n"
+    findings = detect_non_unique_aggregate_order_keys(_parse(sql), model_keys=_SRC_ON_ID)
+    assert len(findings) == 1
+    assert findings[0].line_start == 2
 
 
 def test_window_against_inline_subquery_inherits_keys() -> None:
@@ -558,7 +678,7 @@ def test_source_keys_resolve_by_compiled_identifier_not_name() -> None:
         nodes={n.unique_id: n for n in (src, test, model)},
     )
     tree = _parse(sql)
-    window_keys, _fanout, _limit = make_fact_grounded_detectors(
+    window_keys, _fanout, _limit, _agg = make_fact_grounded_detectors(
         manifest, _DUCKDB, parsed={model.unique_id: tree}
     )
     findings = window_keys(tree)
@@ -566,6 +686,29 @@ def test_source_keys_resolve_by_compiled_identifier_not_name() -> None:
     # covered, so the non-deterministic ranking is flagged.
     assert len(findings) == 1
     assert findings[0].kind is FindingKind.NON_UNIQUE_WINDOW_ORDER_KEYS
+
+
+def test_aggregate_order_resolves_keys_through_factory_boundary() -> None:
+    """The top-n aggregate detector reaches production through ``make_fact_grounded_detectors``
+    and grounds on keys the indexer produces, the same boundary the window check uses."""
+    src = _source_with_identifier("source.shop.raw.orders", name="orders", identifier="orders_v2")
+    test = _unique_test("test.shop.u", column="id", target=src.unique_id)
+    sql = "select array_agg(line order by created_at limit 1) as latest from orders_v2"
+    model = _model("model.shop.latest_line", sql)
+    manifest = Manifest(
+        schema_version="v12",
+        adapter_type="duckdb",
+        nodes={n.unique_id: n for n in (src, test, model)},
+    )
+    tree = _parse(sql)
+    _window, _fanout, _limit, agg_order = make_fact_grounded_detectors(
+        manifest, _DUCKDB, parsed={model.unique_id: tree}
+    )
+    findings = agg_order(tree)
+    # `orders_v2` is unique on (id); the top-1 by `created_at` is not covered, so the
+    # non-deterministic winner is flagged.
+    assert len(findings) == 1
+    assert findings[0].kind is FindingKind.NON_UNIQUE_AGGREGATE_ORDER_KEYS
 
 
 def _materialized_model(uid: str, sql: str, *, materialized: str | None) -> Node:
@@ -618,7 +761,7 @@ def test_limit_detector_fires_only_for_persisted_materialization(
         nodes={model.unique_id: model},
     )
     tree = _parse(sql)
-    _window, _fanout, limit_order = make_fact_grounded_detectors(
+    _window, _fanout, limit_order, _agg = make_fact_grounded_detectors(
         manifest, _DUCKDB, parsed={model.unique_id: tree}
     )
     findings = limit_order(tree)

--- a/tests/uniqueness/test_detector.py
+++ b/tests/uniqueness/test_detector.py
@@ -316,6 +316,14 @@ _AGG_ORDER_CASES = [
         _SRC_ON_ID,
         True,
     ),
+    # ANY_VALUE is the deliberately-arbitrary pick: the author opted into "whichever", so even
+    # in a top-n-looking shape it must stay silent (it is not an order-sensitive aggregate).
+    (
+        "any_value_not_order_sensitive",
+        "select g, any_value(x order by ts limit 1) from src group by g",
+        _SRC_ON_ID,
+        False,
+    ),
 ]
 
 


### PR DESCRIPTION
Closes #159.

## What

`ARRAY_AGG(x ORDER BY k LIMIT n)` (the top-n idiom; `STRING_AGG`/`GROUP_CONCAT` likewise) is deterministic in *which* elements survive only when the order key totally orders each group. With ties at the `LIMIT` cutoff an arbitrary winner survives, so a "latest row per group" pick drifts run to run even though an `ORDER BY` is present. `detect_unordered_aggregate` only checks ORDER BY *presence*, so this passed silently.

This adds `detect_non_unique_aggregate_order_keys`, the aggregate twin of `detect_non_unique_window_order_keys`:

- `GROUP BY` columns play the partition's role; the combined `(group, order)` key set must be covered by a known uniqueness key of the single source. No `GROUP BY` folds the whole relation, so the order key alone must be unique.
- Only the top-n shape fires. An ordered aggregate with no inner `LIMIT` keeps every element, so its membership is deterministic (only the internal tie order is unstable, which stays with the unordered-aggregate detector). No `ORDER BY` at all is that detector's job too.

## Severity: the LIMIT-family checks are determinism smells (warn)

A top-n by `k` is a genuine top-n by `k` — every surviving element is legitimately among the highest-ranked, so no returned row is *wrong*. What is not pinned is which tied element the cutoff keeps. By this codebase's taxonomy that is `warn` ("a determinism smell"), not `error` ("a correctness hazard"). The smell still bites downstream: a metric folded over the selected set (the average basket size of the ten most expensive orders) is correct under whichever tie-break happened, yet drifts across runs.

This corrects the new check (it briefly landed as error) and **also aligns the existing top-level `LIMIT` check (`limit_without_deterministic_order`, #5) from error to warn**, so the whole LIMIT family is tiered consistently. The principle separating these from the error-tier row-drop findings: a `WHERE` that inverts an outer join, or a flatten that annihilates a parent row, drops rows *silently and unintentionally* (error); a `LIMIT` is an *explicit, visible cap* the author wrote on purpose, whose only defect is that which rows survive is not reproducible (warn).

Gating is unchanged in spirit: warn fails CI under the default `--fail-on warn`; a correctness-only run opts out with `--fail-on error`.

## Docs

Adds a **Severity and CI** section to the README explaining the three tiers, the `--fail-on` exit-code gate (default warn), and how to think about wrong-rows versus drift. Sharpens the `_structural_severity` docstring to match.

## Scope / firewall posture

Conservative toward silence, like the window check: single-source scopes only (a join or `UNION` needs column-level lineage), bare-column order and group keys only (an expression needs an equivalence we do not model), and silent when no source key is known. `ANY_VALUE` / `ARBITRARY` are the deliberately-arbitrary picks and are never considered (a regression test pins that exemption).

## Reuse

The covering decision and bare-column extraction the window check already ran are lifted into `_uncovered_order_keys`, and `_window_is_in_scope` is generalized to `_node_in_scope`, so both order-key detectors share one scope-membership rule. The ordered-aggregate function set and a new `aggregate_limit_of` helper move alongside `aggregate_order_of` in the sqlglot layer.

## Tests

Test-first: a table-driven `test_aggregate_order_verdict` (whole-relation / grouped / covered / superkey / no-limit / no-order / no-keys / order-expression / group-expression / join / unknown-source / STRING_AGG / DISTINCT / ANY_VALUE), plus CTE-propagation, line-number, and end-to-end factory-boundary cases. The tests were proven to bite by injecting contract violations. Full gate green (`ruff check`, `ruff format --check`, `pyright`, `pytest` 1193 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)