### PR TITLE
fix(uniqueness): LIMIT 0 is deterministic, not an arbitrary slice

### DIFF
--- a/src/dblect/sql/_sqlglot.py
+++ b/src/dblect/sql/_sqlglot.py
@@ -107,6 +107,21 @@ def aggregate_limit_of(agg: Expr) -> exp.Limit | None:
     return None
 
 
+def limit_keeps_no_rows(limit: exp.Limit) -> bool:
+    """True when ``limit`` provably keeps zero rows (its count is the literal ``0``).
+
+    ``LIMIT 0`` yields the empty set whatever the row order, so it is deterministic by
+    construction: there is no slice to pick and no tie to break. This is the schema-only
+    stub idiom (``select cast(null as ...) ... limit 0``, an empty table with a fixed
+    shape) and the empty-array aggregate (``array_agg(x ... limit 0)``). The check is
+    deliberately narrow: only a literal ``0`` count is provably empty, so a parameter or
+    an expression that might evaluate to ``0`` is not exempted and the caller keeps its
+    conservative posture.
+    """
+    count = limit.expression
+    return isinstance(count, exp.Literal) and not count.args.get("is_string") and count.this == "0"
+
+
 def partition_of(w: exp.Window) -> list[Expr]:
     return cast("list[Expr]", w.args.get("partition_by") or [])
 

--- a/src/dblect/uniqueness/detector.py
+++ b/src/dblect/uniqueness/detector.py
@@ -162,7 +162,8 @@ def detect_non_unique_aggregate_order_keys(
             if not _node_in_scope(agg, sel):
                 continue
             order = sg.aggregate_order_of(agg)
-            if order is None or sg.aggregate_limit_of(agg) is None:
+            agg_limit = sg.aggregate_limit_of(agg)
+            if order is None or agg_limit is None or sg.limit_keeps_no_rows(agg_limit):
                 continue
             uncovered = _uncovered_order_keys(order.expressions, grouping, source_keys)
             if uncovered is None:
@@ -298,6 +299,8 @@ def detect_limit_without_deterministic_order(
         return ()
     limit = tree.args.get("limit")
     if not isinstance(limit, exp.Limit):
+        return ()
+    if sg.limit_keeps_no_rows(limit):
         return ()
     if _is_single_row_scope(tree):
         return ()

--- a/tests/uniqueness/test_detector.py
+++ b/tests/uniqueness/test_detector.py
@@ -159,6 +159,16 @@ _LIMIT_CASES = [
     ),
     ("no_limit", "select id from orders order by id", _ORDERS_ON_ID, True, False),
     ("not_persisted", "select id from orders limit 10", _ORDERS_ON_ID, False, False),
+    # `LIMIT 0` keeps no rows (see `limit_keeps_no_rows`): silent with no ORDER BY and silent
+    # even with one a known key cannot cover.
+    ("limit_zero_no_order", "select id from orders limit 0", _model_keys(), True, False),
+    (
+        "limit_zero_ordered",
+        "select id from orders order by total limit 0",
+        _ORDERS_ON_ID,
+        True,
+        False,
+    ),
     (
         "order_unknown_keys",
         "select id from orders order by total limit 10",
@@ -281,6 +291,8 @@ _AGG_ORDER_CASES = [
     ("no_limit", "select array_agg(x order by ts) from src", _SRC_ON_ID, False),
     # No ORDER BY at all is the unordered-aggregate detector's job, not this one. Silent here.
     ("no_order", "select array_agg(x limit 1) from src", _SRC_ON_ID, False),
+    # `LIMIT 0` keeps no elements, so the top-n drift cannot arise (see `limit_keeps_no_rows`).
+    ("limit_zero", "select array_agg(x order by ts limit 0) from src", _SRC_ON_ID, False),
     # No known key on the source: firewall posture, no positive fact to fire on.
     ("no_keys", "select array_agg(x order by ts limit 1) from src", _model_keys(), False),
     # Non-bare order key needs an equivalence we don't model, silent.


### PR DESCRIPTION
## What

`detect_limit_without_deterministic_order` fired on any top-level `LIMIT` with no total ordering, including `LIMIT 0`. But `LIMIT 0` returns the empty set regardless of row order, so it is deterministic by construction: there is no slice to pick and no tie to break.

This adds `sg.limit_keeps_no_rows` (literal-`0` count) and exempts it in both the top-level LIMIT detector and the top-n aggregate detector (`array_agg(x ... limit 0)` is the empty array by the same argument). Deliberately narrow: only a literal `0` is provably empty, so a parameter or an expression that might evaluate to `0` keeps the conservative firing posture.

## Why

Shaken out by the #125 calibration pass against two real BigQuery dbt projects. The firing hit the schema-only stub idiom (`select cast(null as ...) ... limit 0`, an empty table with a fixed shape) and accounted for **40 of 41** `limit_without_deterministic_order` findings across both projects. The lone survivor was a genuine `LIMIT 1` with no `ORDER BY` (a true positive). This removes the need to `-- noqa` every schema stub.

## Tests

Test-first: added `limit_zero_no_order`, `limit_zero_ordered`, and an aggregate `limit_zero` case to the parametrized verdict tables; confirmed all three failed before the fix. Full gate green (`ruff check`, `ruff format --check`, `pyright` 0 errors, `pytest` 1196 passed).

Part of #125.