### PR TITLE
ci: collect coverage only on main pushes, not on the PR path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,13 +43,21 @@ jobs:
       - name: Type-check (pyright strict)
         run: uv run pyright
 
+      # -n auto parallelises across the runner's cores; loadscope keeps each module on
+      # one worker so the module-scoped dbt-compile fixtures still run once apiece.
+      # Coverage instrumentation adds ~45% to the test step (measured) and nothing gates
+      # on it, so it runs only on the main push that publishes the artifact, keeping the
+      # PR feedback path on the uninstrumented run of the same tests.
+      - name: Tests (pytest)
+        if: github.event_name != 'push'
+        run: uv run pytest -n auto --dist loadscope
+
       - name: Tests (pytest with coverage)
-        # -n auto parallelises across the runner's cores; loadscope keeps each module on
-        # one worker so the module-scoped dbt-compile fixtures still run once apiece.
+        if: github.event_name == 'push'
         run: uv run pytest -n auto --dist loadscope --cov --cov-report=term-missing --cov-report=xml
 
       - name: Upload coverage artifact
-        if: matrix.python-version == '3.13'
+        if: github.event_name == 'push' && matrix.python-version == '3.13'
         uses: actions/upload-artifact@v4
         with:
           name: coverage-xml


### PR DESCRIPTION
## What

Coverage instrumentation is the dominant, removable cost in CI. Measured under `-n auto --dist loadscope` locally (8 cores):

| Config | Wall time |
|---|---|
| tests, no coverage | **56s** |
| tests, with coverage (CI today) | **82s** |

That's **~26s (+45%)** from `--cov`, and nothing gates on it: the workflow uploads `coverage.xml` as an artifact with no Codecov step and no threshold.

## Change

The PR feedback path now runs the same tests uninstrumented; coverage and the artifact upload run only on the push to main. No change to which tests run or to their assertions.

## Why not consolidate tests

The other time is in the dbt integration tests (live `dbt compile`/`build`, ~5–8.5s each). They are already well-factored: module-scoped compile fixtures run once, and each `run_model` test pins a distinct contract (real seeds, empty seeds, custom rows, build error, persisted warehouse). Merging them would trade real-scenario coverage for a few seconds, so they are left as is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)