### PR TITLE
fix(uniqueness): a COUNT fold never double-counts a cross-model fan-out (#179)

### DIFF
--- a/src/dblect/uniqueness/detector.py
+++ b/src/dblect/uniqueness/detector.py
@@ -18,7 +18,10 @@ to make a claim, and stay silent otherwise):
 * ``detect_cross_model_fanout``: a duplicate-sensitive aggregate that folds a
   magnitude an upstream fan-out replicated, over a relation no longer keyed at the
   magnitude's grain. This one also reads ``where_provenance`` to find the origin a
-  magnitude traces to, the grain ``grain_preserved`` is asked about.
+  magnitude traces to, the grain ``grain_preserved`` is asked about. A COUNT fold
+  (``COUNT(*)``, ``COUNT(col)``) yields a cardinality, not a magnitude: it counts the
+  relation's rows, whose grain the relation preserves, so it stays silent (the ``SUM(qty)``
+  analog), unlike ``SUM(amount)``.
 
 The first two read keys from the lineage.facts uniqueness substrate: per-model keys
 come from cross-model propagation (``uniqueness_property`` over the relation graph),
@@ -55,7 +58,14 @@ from dblect.lineage.properties.uniqueness import (
 )
 from dblect.lineage.property import propagate
 from dblect.manifest import Manifest, Materialization
-from dblect.sql import Finding, FindingKind, duplicate_sensitive, suppression_hint
+from dblect.sql import (
+    AggregateBehavior,
+    Finding,
+    FindingKind,
+    aggregate_behavior,
+    duplicate_sensitive,
+    suppression_hint,
+)
 from dblect.sql import _sqlglot as sg
 from dblect.sql._sqlglot import JoinSide
 
@@ -567,13 +577,24 @@ def detect_cross_model_fanout(
     translated into ``R``'s column names through provenance. When no origin candidate key
     survives in ``R``, the fold can double count and we flag.
 
+    A grain-collapse guard precedes the per-aggregate check: when the relation is provably
+    unique at the GROUP BY grain (a candidate key fits within the grouping columns), every
+    bucket is a single row and no fold over it can over-count, so the whole select is silent.
+    This is the cross-model analog of the local ``_collapsed_before_sensitive_consumer`` guard,
+    and it clears the magnitude path's grouped-to-a-finer-grain case (``SUM(amount) GROUP BY
+    order_id, item_id`` over line-grain staging) as well.
+
     Silent when the FROM is not a single ref'd relation (a join or a CTE/subquery needs
     column-level reasoning kept for later), when the aggregate is duplicate-safe, and when the
     origin relation has no known key, the firewall posture: with no grain to name there is no
-    positive fact to fire on. Also silent on a star-argument fold (``COUNT(*)``): it names no
-    column, so there is no magnitude to trace to an origin grain. A star count over a
-    fanned-out relation does double count, so closing that gap (it needs the relation's own
-    row grain rather than a traced origin) is tracked as future work, not handled here.
+    positive fact to fire on. Also silent on a COUNT-behavior fold (``COUNT(*)``, ``COUNT(1)``,
+    ``COUNT(col)``, ``COUNT_IF``): it yields a cardinality, not a magnitude, so it counts the
+    relation's rows (whose grain the relation preserves) rather than summing a replicated value.
+    That makes every COUNT the ``SUM(qty)`` analog (a fold at the genuine, un-replicated grain),
+    not the ``SUM(amount)`` analog: a count per group reads distinct rows, so a single-level
+    fan-out does not make it double count. The fan-trap case where it would (independent
+    fan-outs leaving the relation with no key) is indistinguishable from an undeclared grain, so
+    the firewall keeps it silent there too (issue #179).
     """
     out: list[Finding] = []
     for sel in sg.find_all_selects(tree):
@@ -582,6 +603,13 @@ def detect_cross_model_fanout(
             continue
         rel_prov = provenance_by_source.get(ref, {})
         rel_keys = keys_by_source.get(ref, NO_KEYS)
+        group_cols = _group_by_columns(sel)
+        # Grain-collapse guard: when the relation is provably unique at the GROUP BY grain
+        # (a candidate key fits within the grouping columns), every bucket is a single row, so
+        # no fold over it can over-count, whatever magnitude it reads. This is the cross-model
+        # analog of the local ``_collapsed_before_sensitive_consumer`` guard.
+        if group_cols is not None and grain_preserved(rel_keys, group_cols):
+            continue
         for agg in _sensitive_aggregate_consumers(sel, safe_builtins=duplicate_safe_builtins):
             origin = _replicated_origin(
                 agg, rel_keys=rel_keys, rel_prov=rel_prov, keys_by_source=keys_by_source
@@ -672,6 +700,21 @@ def _single_from_ref(sel: exp.Select, name_to_ref: NameToRef) -> SourceRef | Non
     return name_to_ref.get(name)
 
 
+def _group_by_columns(sel: exp.Select) -> frozenset[str] | None:
+    """The GROUP BY key column names of ``sel`` when every grouping term is a bare column,
+    else ``None`` (no GROUP BY, or a positional/expression key whose grain we cannot size).
+
+    ``None`` carries the same "cannot judge" meaning as elsewhere: it disables the
+    grain-collapse guard, so an un-sizable grouping keeps the detector conservative rather than
+    proving a collapse it cannot.
+    """
+    group = sg.group_of(sel)
+    if group is None or not group.expressions:
+        return None
+    names = _bare_column_names(group.expressions)
+    return frozenset(names) if names is not None else None
+
+
 def _replicated_origin(
     agg: Expr,
     *,
@@ -686,7 +729,17 @@ def _replicated_origin(
     that origin's grain (translated into the relation's columns). The first origin that fails
     is the replicated side the fold double counts; an origin with no known key is skipped
     (nothing to claim).
+
+    A COUNT-behavior fold (``COUNT(*)``, ``COUNT(col)``, ``COUNT_IF``) yields a cardinality,
+    not a magnitude: it counts rows (modulo nulls), and the row grain is what the relation
+    preserves, so the replicated value a counted column carries is never summed and cannot
+    double count. ``COUNT(amount)`` over a fan-out reads distinct rows, not a replicated
+    magnitude, exactly like ``COUNT(*)`` and unlike ``SUM(amount)``. It returns ``None`` here.
+    The fan-trap where a COUNT would over-count leaves the relation with no key at all,
+    indistinguishable from an undeclared grain, so the firewall keeps it silent there too.
     """
+    if isinstance(agg, exp.AggFunc) and aggregate_behavior(agg) is AggregateBehavior.COUNT:
+        return None
     origin_refs: set[ColumnRef] = set()
     for c in {sg.column_name(c) for c in sg.find_columns(agg)}:
         origin_refs |= set(rel_prov.get(c, frozenset()))

--- a/tests/uniqueness/test_cross_model_fanout.py
+++ b/tests/uniqueness/test_cross_model_fanout.py
@@ -213,3 +213,72 @@ def test_unrelated_nested_cte_does_not_shadow_a_real_read() -> None:
     )
     manifest = _shop(items_unique_on=None, mart_sql=mart_sql)
     assert [f.kind for f in _findings(manifest, _MART)] == [FindingKind.CROSS_MODEL_FANOUT]
+
+
+# --- the COUNT fold: COUNT(*), COUNT(1), COUNT(col), COUNT_IF stay silent (#179) ----------
+#
+# A COUNT-behavior fold yields a cardinality, not a magnitude: it counts rows (modulo nulls),
+# and the row grain is what the relation preserves. ``COUNT(*) GROUP BY g`` reads distinct
+# rows, not a replicated magnitude, so a single-level fan-out does not make it double count.
+# Every COUNT is the ``SUM(qty)`` analog (a fold at the genuine line grain), not the
+# ``SUM(amount)`` analog: counting a column reads how many rows have it, never sums its
+# (replicated) value, so even ``COUNT(amount)`` over the broken order grain stays silent.
+
+_COUNT_STAR = "SELECT order_id, COUNT(*) AS num_items FROM stg_order_items GROUP BY order_id"
+_COUNT_ONE = "SELECT order_id, COUNT(1) AS num_items FROM stg_order_items GROUP BY order_id"
+_COUNT_AMOUNT = "SELECT order_id, COUNT(amount) AS n FROM stg_order_items GROUP BY order_id"
+_COUNT_ORDER_ID = "SELECT order_id, COUNT(order_id) AS n FROM stg_order_items GROUP BY order_id"
+
+
+def test_count_folds_over_fanned_staging_are_silent() -> None:
+    """Over the fanned-out staging, every COUNT shape counts distinct rows (line items), so the
+    count is exact and none fire: the star/literal folds, and a count of the replicated
+    order-grain column ``amount`` or the group key ``order_id`` alike, whether the staging is
+    keyless or keyed at the line grain."""
+    for items_key in (None, "item_id"):
+        for sql in (_COUNT_STAR, _COUNT_ONE, _COUNT_AMOUNT, _COUNT_ORDER_ID):
+            assert _findings(_shop(items_unique_on=items_key, mart_sql=sql), _MART) == (), (
+                items_key,
+                sql,
+            )
+
+
+def test_count_amount_is_silent_where_sum_amount_fires() -> None:
+    """The contrast that pins the discriminator over identical data and the same column:
+    ``SUM(amount)`` folds the replicated order-grain magnitude and fires, while ``COUNT(amount)``
+    counts the rows carrying a non-null amount and stays silent. The two folds are not
+    interchangeable, even though both read ``amount``."""
+    fired = _findings(_shop(items_unique_on="item_id", mart_sql=_SUM_AMOUNT), _MART)
+    silent = _findings(_shop(items_unique_on="item_id", mart_sql=_COUNT_AMOUNT), _MART)
+    assert [f.kind for f in fired] == [FindingKind.CROSS_MODEL_FANOUT]
+    assert silent == ()
+
+
+def test_count_if_over_fanned_staging_is_silent() -> None:
+    """``COUNT_IF`` is a COUNT-behavior fold too (it counts rows matching a predicate), so it is
+    a cardinality, not a magnitude, and stays silent over the fan-out like the others."""
+    mart_sql = "SELECT order_id, COUNT_IF(amount > 0) AS n FROM stg_order_items GROUP BY order_id"
+    assert _findings(_shop(items_unique_on=None, mart_sql=mart_sql), _MART) == ()
+
+
+def test_ungrouped_count_star_is_silent() -> None:
+    """An ungrouped ``COUNT(*)`` folds the whole relation's row grain, with no magnitude column
+    to trace, so there is no replicated origin to fire on."""
+    manifest = _shop(items_unique_on=None, mart_sql="SELECT COUNT(*) AS n FROM stg_order_items")
+    assert _findings(manifest, _MART) == ()
+
+
+# --- the grain-collapse guard (fixes a magnitude-path false positive) ---------------------
+
+
+def test_sum_grouped_to_unique_bucket_is_silent() -> None:
+    """The grain-collapse guard: grouping by ``(order_id, item_id)`` makes each bucket the line
+    grain staging is keyed on, so every bucket is a provable singleton. ``SUM(amount)`` folds one
+    row and returns that row's amount once, so it cannot double count even though the order
+    amount is replicated across the staging's lines."""
+    mart_sql = (
+        "SELECT order_id, item_id, SUM(amount) AS total FROM stg_order_items "
+        "GROUP BY order_id, item_id"
+    )
+    manifest = _shop(items_unique_on="item_id", mart_sql=mart_sql)
+    assert _findings(manifest, _MART) == ()


### PR DESCRIPTION
Closes #179.

## Summary

#179 proposed firing `detect_cross_model_fanout` on `COUNT(*)` over a non-collapsed relation. On review the premise inverts, and working it through also surfaced a pre-existing over-fire and a magnitude-path false positive. The net change makes every COUNT silent in this detector and adds a grain-collapse guard.

## Why COUNT does not double-count a fan-out

A COUNT yields a **cardinality, not a magnitude**. It counts rows (modulo nulls), and the row grain is exactly what the relation preserves, so `COUNT(*) GROUP BY g` reads distinct rows, not a replicated value. A star count per order over `orders ⋈ order_items` is the *correct* count of line items per order, so firing would be a false positive.

This holds for `COUNT(col)` too, which the detector fired on today: `COUNT(amount)` counts the rows carrying a non-null `amount`, it never sums `amount`'s replicated value. The sharp contrast, pinned by a test, is the same column over the same fanned relation:

- `SUM(amount)` → **fires** (sums the replicated order-grain magnitude)
- `COUNT(amount)` → **silent** (counts distinct rows; the `SUM(qty)` analog, not the `SUM(amount)` analog)

The only case a COUNT would over-count is a fan-trap that leaves the relation with no key at all, which is indistinguishable from an undeclared grain, so the firewall keeps it silent there too.

## What changed

- `_replicated_origin` returns `None` for any COUNT-behavior fold, grounded on the existing aggregates registry (`AggregateBehavior.COUNT`: `Count`, `CountIf`), not a spelling check. This keeps `COUNT(*)`/`COUNT(1)` silent and corrects the pre-existing over-fire on `COUNT(col)`.
- A **grain-collapse guard**: when the relation is provably unique at the GROUP BY grain (a key fits within the grouping columns), every bucket is one row and no fold over it can over-count, so the select is silent. This is the cross-model analog of the local `_collapsed_before_sensitive_consumer` guard, and it clears a pre-existing magnitude-path false positive (`SUM(amount) GROUP BY order_id, item_id` over line-grain staging).

## Scope

Deliberately limited to `detect_cross_model_fanout`, not the shared `duplicate_sensitive` predicate: COUNT *is* genuinely duplicate-sensitive in the multiset sense (the local `join_fanout` collapse guard relies on that). The right home for "COUNT folds a cardinality, not a magnitude" is the magnitude-trace, which is where it now lives.

## Tests

New tests pin: all four COUNT shapes silent over the fan-out, the `SUM(amount)`-fires/`COUNT(amount)`-silent contrast, `COUNT_IF`, ungrouped `COUNT(*)`, and the grain-collapse guard on both paths. Mutation-checked to bite (removing either guard re-fails the relevant tests).

## Gate

`ruff check`, `ruff format --check`, `pyright` (strict), `pytest` (1201 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)