### PR TITLE
feat(flatten): treat provably non-empty generated arrays as row-preserving (#191)

### DIFF
--- a/src/dblect/lineage/properties/array_nonemptiness.py
+++ b/src/dblect/lineage/properties/array_nonemptiness.py
@@ -11,8 +11,10 @@ The value is driven entirely by intrinsic facts the transfers read off the SQL,
 not by anything a manifest declares, so the property needs no discoverer and
 every column grounds to the implicit top:
 
-* an ``ARRAY[...]`` / ``ARRAY(...)`` constructor with one or more elements is
-  ``NON_EMPTY`` (a literal array cannot be empty);
+* an intrinsic constructor whose non-emptiness the SQL vocabulary reads off the node
+  alone is ``NON_EMPTY``: an ``ARRAY[...]`` / ``ARRAY(...)`` with one or more elements, or
+  a ``GENERATE_ARRAY`` / ``GENERATE_SERIES`` / ``GENERATE_DATE_ARRAY`` whose literal bounds
+  make the range non-empty;
 * an ``ARRAY_AGG(expr)`` under a ``GROUP BY`` is ``NON_EMPTY`` per group, since a
   group has at least one row and so at least one element (even a NULL element
   counts toward non-emptiness). Without a ``GROUP BY`` the fold is over the whole
@@ -32,6 +34,7 @@ the inner-flatten row-drop detector, which treats an ``UNNEST`` of a provably
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from enum import StrEnum
 
 import sqlglot.expressions as exp
@@ -46,7 +49,7 @@ from dblect.lineage.facts.property import (
     column_property,
 )
 from dblect.lineage.graph import ColumnRef, aggregation_site_meta
-from dblect.sql.vocab import array_literal_nonempty
+from dblect.sql.vocab import array_literal_nonempty, generator_provably_nonempty
 
 
 class ArrayNonEmpty(StrEnum):
@@ -126,13 +129,21 @@ def _array_agg_value(agg: exp.AggFunc, *, ignore_nulls: bool) -> Annotation[Arra
     return _NON_EMPTY if isinstance(_aggregated_expr(agg), exp.Struct) else _UNKNOWN
 
 
-def _array_literal_rule(
-    expr: Expr, _kids: tuple[Annotation[ArrayNonEmpty], ...], _ctx: DepContext
-) -> Annotation[ArrayNonEmpty]:
-    """An ``ARRAY[...]`` / ``ARRAY(...)`` constructor with one or more constructed
-    elements is non-empty by construction; an empty constructor or an array-subquery
-    (which can return zero rows) carries no guarantee."""
-    return _NON_EMPTY if array_literal_nonempty(expr) else _UNKNOWN
+def _intrinsic_constructor_rule(
+    predicate: Callable[[Expr], bool],
+) -> Callable[[Expr, tuple[Annotation[ArrayNonEmpty], ...], DepContext], Annotation[ArrayNonEmpty]]:
+    """A rule for a constructor whose non-emptiness the SQL vocabulary decides from the node
+    alone, with no lineage: a literal ``ARRAY[...]``, a bounded ``GENERATE_ARRAY``. ``predicate``
+    is the vocab check; a positive proof grounds ``NON_EMPTY``, anything else the ``UNKNOWN``
+    top. The inner-flatten detector consults the same vocab predicates on inline arguments, so
+    the local and cross-model paths recognise each constructor the same way."""
+
+    def rule(
+        expr: Expr, _kids: tuple[Annotation[ArrayNonEmpty], ...], _ctx: DepContext
+    ) -> Annotation[ArrayNonEmpty]:
+        return _NON_EMPTY if predicate(expr) else _UNKNOWN
+
+    return rule
 
 
 def _ignore_nulls_rule(
@@ -184,7 +195,9 @@ array_nonemptiness: Property[ArrayNonEmpty, ColumnRef] = column_property(
     name="array_nonemptiness",
     lattice=ARRAY_NONEMPTY_LATTICE,
     operators={
-        exp.Array: _array_literal_rule,
+        exp.Array: _intrinsic_constructor_rule(array_literal_nonempty),
+        exp.GenerateSeries: _intrinsic_constructor_rule(generator_provably_nonempty),
+        exp.GenerateDateArray: _intrinsic_constructor_rule(generator_provably_nonempty),
         exp.IgnoreNulls: _ignore_nulls_rule,
         exp.Filter: _filter_rule,
     },

--- a/src/dblect/lineage/properties/array_nonemptiness.py
+++ b/src/dblect/lineage/properties/array_nonemptiness.py
@@ -13,8 +13,8 @@ every column grounds to the implicit top:
 
 * an intrinsic constructor whose non-emptiness the SQL vocabulary reads off the node
   alone is ``NON_EMPTY``: an ``ARRAY[...]`` / ``ARRAY(...)`` with one or more elements, or
-  a ``GENERATE_ARRAY`` / ``GENERATE_SERIES`` / ``GENERATE_DATE_ARRAY`` whose literal bounds
-  make the range non-empty;
+  a ``GENERATE_ARRAY`` / ``GENERATE_SERIES`` / ``GENERATE_DATE_ARRAY`` /
+  ``GENERATE_TIMESTAMP_ARRAY`` whose literal bounds make the range non-empty;
 * an ``ARRAY_AGG(expr)`` under a ``GROUP BY`` is ``NON_EMPTY`` per group, since a
   group has at least one row and so at least one element (even a NULL element
   counts toward non-emptiness). Without a ``GROUP BY`` the fold is over the whole
@@ -198,6 +198,7 @@ array_nonemptiness: Property[ArrayNonEmpty, ColumnRef] = column_property(
         exp.Array: _intrinsic_constructor_rule(array_literal_nonempty),
         exp.GenerateSeries: _intrinsic_constructor_rule(generator_provably_nonempty),
         exp.GenerateDateArray: _intrinsic_constructor_rule(generator_provably_nonempty),
+        exp.GenerateTimestampArray: _intrinsic_constructor_rule(generator_provably_nonempty),
         exp.IgnoreNulls: _ignore_nulls_rule,
         exp.Filter: _filter_rule,
     },

--- a/src/dblect/sql/patterns.py
+++ b/src/dblect/sql/patterns.py
@@ -30,7 +30,7 @@ from dblect.sql import _sqlglot as sg
 from dblect.sql import guards
 from dblect.sql._sqlglot import JoinSide
 from dblect.sql.findings import Finding, FindingKind, finding_at, suppression_code
-from dblect.sql.vocab import array_literal_nonempty
+from dblect.sql.vocab import array_literal_nonempty, generator_provably_nonempty
 
 
 @dataclass(frozen=True, slots=True)
@@ -754,16 +754,17 @@ def _array_expr_nonempty(
 ) -> bool:
     """Whether one unnested expression is provably non-empty.
 
-    A literal ``ARRAY[...]`` with one or more constructed elements is non-empty by
-    construction (the always-on local case). For a column, the answer comes from
-    ``column_is_nonempty``, the lineage-grounded predicate the audit supplies; without it,
-    a column is treated as opaque, so the detector module stays free of lineage types.
+    The intrinsic constructors the SQL vocabulary proves from the node alone are the always-on
+    local cases: a literal ``ARRAY[...]``, a ``GENERATE_ARRAY`` over literal bounds. For a
+    column, the answer comes from ``column_is_nonempty``, the lineage-grounded predicate the
+    audit supplies; without it, a column is treated as opaque, so the detector module stays
+    free of lineage types.
 
     Non-emptiness is proved where the array is *produced*. A column that arrives through the
     nullable side of an outer join can still be NULL at the unnest, and ``UNNEST(NULL)`` drops
     the row, so a column read from an outer-join-optional relation is never cleared here even
     when its value is non-empty wherever it exists."""
-    if array_literal_nonempty(arg):
+    if array_literal_nonempty(arg) or generator_provably_nonempty(arg):
         return True
     if column_is_nonempty is None or not isinstance(arg, exp.Column):
         return False

--- a/src/dblect/sql/vocab.py
+++ b/src/dblect/sql/vocab.py
@@ -9,12 +9,22 @@ structural column combination as a key.
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime
 
 import sqlglot.expressions as exp
 from sqlglot import Expr
 
 from dblect.sql import _sqlglot as sg
+
+# The clock-point cast targets a timestamp bound wears: the ``TIMESTAMP '...'`` literal and the
+# ``'...'::timestamp`` cast both parse to a string literal under one of these.
+_TIMESTAMP_TYPES = (
+    exp.DataType.Type.TIMESTAMP,
+    exp.DataType.Type.TIMESTAMPTZ,
+    exp.DataType.Type.TIMESTAMPLTZ,
+    exp.DataType.Type.TIMESTAMPNTZ,
+    exp.DataType.Type.DATETIME,
+)
 
 
 def array_literal_nonempty(expr: Expr) -> bool:
@@ -43,15 +53,15 @@ def generator_provably_nonempty(expr: Expr) -> bool:
     """True when ``expr`` is a series or date-spine generator whose literal bounds make the
     produced range non-empty, so an ``UNNEST`` of it drops no parent row.
 
-    Covers ``GENERATE_SERIES``/``GENERATE_ARRAY`` over numeric literals and the calendar spine
-    over literal dates in either spelling: ``GENERATE_DATE_ARRAY`` and the Postgres/Redshift
-    ``generate_series`` over date-cast bounds with an interval step. All map into one comparable
-    domain (dates via their calendar ordinal), so a single test serves them. Decidable only from
-    the call, so a non-literal bound (a ``CAST(n AS INT64)`` count that can be ``0``, a column
-    start/end that can invert) leaves the range possibly empty and keeps the caller firing.
-    Timestamp
-    generators are deferred: a raw literal compare is unsound across timezone offsets, so they
-    are excluded by type and stay firing. The generator analog of
+    Covers ``GENERATE_SERIES``/``GENERATE_ARRAY`` over numeric literals and the calendar and clock
+    spines over literal dates and timestamps in either spelling: ``GENERATE_DATE_ARRAY`` /
+    ``GENERATE_TIMESTAMP_ARRAY`` and the Postgres/Redshift ``generate_series`` over temporal-cast
+    bounds with an interval step. All map into one comparable domain (dates via their calendar
+    ordinal, timestamps parsed to real instants), so a single test serves them. Decidable only
+    from the call, so a non-literal bound (a ``CAST(n AS INT64)`` count that can be ``0``, a column
+    start/end that can invert) leaves the range possibly empty and keeps the caller firing. A
+    timestamp spine is proved when its bounds order soundly; only a naive/aware literal mix, whose
+    two zones cannot be compared, is deferred. The generator analog of
     :func:`array_literal_nonempty`: silence only on a positive proof."""
     bounds = _generator_bounds(expr)
     if bounds is None:
@@ -68,14 +78,16 @@ def generator_provably_nonempty(expr: Expr) -> bool:
 
 def _generator_bounds(expr: Expr) -> tuple[float, float, float, bool] | None:
     """The ``(start, end, step, exclusive-end)`` of a generator whose bounds and step are all
-    literals, or ``None`` when any is not one we can read. Numeric series and date spines reduce
-    to the same ordered scalar domain, chosen from the bounds rather than the function name: a
-    ``generate_series`` carries either numeric bounds (``generate_series(0, 23)``) or date-cast
-    bounds (the Postgres/Redshift calendar spine ``generate_series(d1, d2, interval '1 day')``),
-    and the date form is the same idiom as ``GENERATE_DATE_ARRAY``. The step value carries only a
-    sign, never a magnitude that affects non-emptiness (an inclusive range always holds its
-    start)."""
-    if not isinstance(expr, (exp.GenerateSeries, exp.GenerateDateArray)):
+    literals, or ``None`` when any is not one we can read. Numeric series, date spines, and
+    timestamp spines reduce to the same ordered scalar domain, chosen from the bounds rather than
+    the function name: a ``generate_series`` carries either numeric bounds
+    (``generate_series(0, 23)``) or temporal-cast bounds (the Postgres/Redshift calendar spine
+    ``generate_series(d1, d2, interval '1 day')``), the same idiom as ``GENERATE_DATE_ARRAY`` and
+    ``GENERATE_TIMESTAMP_ARRAY``. The step value carries only a sign, never a magnitude that
+    affects non-emptiness (an inclusive range always holds its start)."""
+    if not isinstance(
+        expr, (exp.GenerateSeries, exp.GenerateDateArray, exp.GenerateTimestampArray)
+    ):
         return None
     start_arg, end_arg, step_arg = (expr.args.get(k) for k in ("start", "end", "step"))
     exclusive = bool(expr.args.get("is_end_exclusive"))
@@ -84,10 +96,15 @@ def _generator_bounds(expr: Expr) -> tuple[float, float, float, bool] | None:
     if start is not None and end is not None:
         step = 1.0 if step_arg is None else _numeric_literal(step_arg)
     else:
-        start = _date_ordinal(start_arg)
-        end = _date_ordinal(end_arg)
+        start_t = _temporal_scalar(start_arg)
+        end_t = _temporal_scalar(end_arg)
+        # Comparable only when both bounds are the same temporal kind (a naive/aware timestamp
+        # mix, most sharply, has no sound order); the step is an interval whose sign we read.
+        if start_t is None or end_t is None or start_t[0] != end_t[0]:
+            return None
+        start, end = start_t[1], end_t[1]
         step = 1.0 if step_arg is None else _interval_sign(step_arg)
-    if start is None or end is None or step is None:
+    if step is None:  # an unreadable step magnitude leaves the sign, and the range, unproven
         return None
     return start, end, step, exclusive
 
@@ -112,6 +129,41 @@ def _date_ordinal(expr: Expr | None) -> float | None:
         return None
     try:
         return float(date.fromisoformat(expr.this).toordinal())
+    except ValueError:
+        return None
+
+
+def _temporal_scalar(expr: Expr | None) -> tuple[str, float] | None:
+    """A literal date or timestamp bound as a ``(kind, comparable-scalar)`` pair, or ``None`` when
+    it is not a literal calendar or clock point. The kind partitions bounds that can be soundly
+    ordered against one another: a date, a naive timestamp (ordered by civil value under the
+    session zone), and an offset-aware timestamp (ordered by absolute instant). Two bounds of the
+    same kind compare correctly through their scalar (aware instants across differing offsets
+    included, since each reduces to its epoch), so only a cross-kind pair, most sharply a
+    naive/aware timestamp mix, is left unproven."""
+    date_ord = _date_ordinal(expr)
+    if date_ord is not None:
+        return "date", date_ord
+    moment = _timestamp_literal(expr)
+    if moment is None:
+        return None
+    if moment.tzinfo is None:
+        # A civil-value scalar, monotonic in the naive datetime and free of the DST folds that
+        # ``datetime.timestamp()`` would introduce for a naive value.
+        return "naive", (moment - datetime.min).total_seconds()
+    return "aware", moment.timestamp()
+
+
+def _timestamp_literal(expr: Expr | None) -> datetime | None:
+    # A timestamp bound is a string literal under a TIMESTAMP/DATETIME cast (the ``TIMESTAMP '...'``
+    # literal and the ``'...'::timestamp`` cast both parse this way). Parsing to a real datetime
+    # orders the bounds chronologically and rejects any spelling that is not a clock point.
+    if isinstance(expr, (exp.Cast, exp.TryCast)) and expr.to.is_type(*_TIMESTAMP_TYPES):
+        expr = expr.this
+    if not (isinstance(expr, exp.Literal) and expr.args.get("is_string")):
+        return None
+    try:
+        return datetime.fromisoformat(expr.this)
     except ValueError:
         return None
 

--- a/src/dblect/sql/vocab.py
+++ b/src/dblect/sql/vocab.py
@@ -9,6 +9,8 @@ structural column combination as a key.
 
 from __future__ import annotations
 
+from datetime import date
+
 import sqlglot.expressions as exp
 from sqlglot import Expr
 
@@ -35,6 +37,91 @@ def array_literal_nonempty(expr: Expr) -> bool:
     if not isinstance(expr, exp.Array) or not expr.expressions:
         return False
     return all(_array_element_present(e) for e in expr.expressions)
+
+
+def generator_provably_nonempty(expr: Expr) -> bool:
+    """True when ``expr`` is a series or date-spine generator whose literal bounds make the
+    produced range non-empty, so an ``UNNEST`` of it drops no parent row.
+
+    Covers ``GENERATE_SERIES``/``GENERATE_ARRAY`` over numeric literals and
+    ``GENERATE_DATE_ARRAY`` over literal dates; both map into one comparable domain (dates via
+    their calendar ordinal), so a single test serves them. Decidable only from the call, so a
+    non-literal bound (a ``CAST(n AS INT64)`` count that can be ``0``, a column start/end that
+    can invert) leaves the range possibly empty and keeps the caller firing. Timestamp
+    generators are deferred: a raw literal compare is unsound across timezone offsets, so they
+    are excluded by type and stay firing. The generator analog of
+    :func:`array_literal_nonempty`: silence only on a positive proof."""
+    bounds = _generator_bounds(expr)
+    if bounds is None:
+        return False
+    start, end, step, exclusive = bounds
+    if step == 0:  # a zero step has no well-defined range
+        return False
+    # A positive step needs a low-to-high range, a negative step high-to-low; an exclusive end
+    # (some dialects' half-open form) rules out the single-point range.
+    if step > 0:
+        return start < end if exclusive else start <= end
+    return start > end if exclusive else start >= end
+
+
+def _generator_bounds(expr: Expr) -> tuple[float, float, float, bool] | None:
+    """The ``(start, end, step, exclusive-end)`` of a generator whose bounds and step are all
+    literals, or ``None`` when any is not one we can read. Numeric and date generators reduce
+    to the same numeric domain; the step value carries only a sign, never a magnitude that
+    affects non-emptiness (an inclusive range always holds its start)."""
+    if isinstance(expr, exp.GenerateSeries):
+        step_arg = expr.args.get("step")
+        step = 1.0 if step_arg is None else _numeric_literal(step_arg)
+        start = _numeric_literal(expr.args.get("start"))
+        end = _numeric_literal(expr.args.get("end"))
+        exclusive = bool(expr.args.get("is_end_exclusive"))
+    elif isinstance(expr, exp.GenerateDateArray):
+        step_arg = expr.args.get("step")
+        step = 1.0 if step_arg is None else _interval_sign(step_arg)
+        start = _date_ordinal(expr.args.get("start"))
+        end = _date_ordinal(expr.args.get("end"))
+        exclusive = False
+    else:
+        return None
+    if start is None or end is None or step is None:
+        return None
+    return start, end, step, exclusive
+
+
+def _numeric_literal(expr: Expr | None) -> float | None:
+    # A negative literal parses as exp.Neg wrapping a positive one, so look through it.
+    if isinstance(expr, exp.Neg):
+        inner = _numeric_literal(expr.this)
+        return None if inner is None else -inner
+    if isinstance(expr, exp.Literal) and not expr.args.get("is_string"):
+        return float(expr.this)
+    return None
+
+
+def _date_ordinal(expr: Expr | None) -> float | None:
+    # A date bound is a bare date string the generator coerces or a DATE-typed CAST of one.
+    # Parsing to a real date makes the comparison chronological and rejects any spelling that
+    # is not a calendar point, which stays unproven rather than guessed at.
+    if isinstance(expr, (exp.Cast, exp.TryCast)) and expr.to.is_type(exp.DataType.Type.DATE):
+        expr = expr.this
+    if not (isinstance(expr, exp.Literal) and expr.args.get("is_string")):
+        return None
+    try:
+        return float(date.fromisoformat(expr.this).toordinal())
+    except ValueError:
+        return None
+
+
+def _interval_sign(expr: Expr | None) -> float | None:
+    # Only the step's direction matters, so read the sign off the interval's magnitude (a
+    # string-form number like '1' or '-1') and leave a non-literal magnitude unproven. The
+    # unit (DAY, MONTH, ...) never affects non-emptiness.
+    if not isinstance(expr, exp.Interval) or not isinstance(expr.this, exp.Literal):
+        return None
+    try:
+        return float(expr.this.this)
+    except ValueError:
+        return None
 
 
 def _array_element_present(element: Expr) -> bool:

--- a/src/dblect/sql/vocab.py
+++ b/src/dblect/sql/vocab.py
@@ -43,11 +43,13 @@ def generator_provably_nonempty(expr: Expr) -> bool:
     """True when ``expr`` is a series or date-spine generator whose literal bounds make the
     produced range non-empty, so an ``UNNEST`` of it drops no parent row.
 
-    Covers ``GENERATE_SERIES``/``GENERATE_ARRAY`` over numeric literals and
-    ``GENERATE_DATE_ARRAY`` over literal dates; both map into one comparable domain (dates via
-    their calendar ordinal), so a single test serves them. Decidable only from the call, so a
-    non-literal bound (a ``CAST(n AS INT64)`` count that can be ``0``, a column start/end that
-    can invert) leaves the range possibly empty and keeps the caller firing. Timestamp
+    Covers ``GENERATE_SERIES``/``GENERATE_ARRAY`` over numeric literals and the calendar spine
+    over literal dates in either spelling: ``GENERATE_DATE_ARRAY`` and the Postgres/Redshift
+    ``generate_series`` over date-cast bounds with an interval step. All map into one comparable
+    domain (dates via their calendar ordinal), so a single test serves them. Decidable only from
+    the call, so a non-literal bound (a ``CAST(n AS INT64)`` count that can be ``0``, a column
+    start/end that can invert) leaves the range possibly empty and keeps the caller firing.
+    Timestamp
     generators are deferred: a raw literal compare is unsound across timezone offsets, so they
     are excluded by type and stay firing. The generator analog of
     :func:`array_literal_nonempty`: silence only on a positive proof."""
@@ -66,23 +68,25 @@ def generator_provably_nonempty(expr: Expr) -> bool:
 
 def _generator_bounds(expr: Expr) -> tuple[float, float, float, bool] | None:
     """The ``(start, end, step, exclusive-end)`` of a generator whose bounds and step are all
-    literals, or ``None`` when any is not one we can read. Numeric and date generators reduce
-    to the same numeric domain; the step value carries only a sign, never a magnitude that
-    affects non-emptiness (an inclusive range always holds its start)."""
-    if isinstance(expr, exp.GenerateSeries):
-        step_arg = expr.args.get("step")
-        step = 1.0 if step_arg is None else _numeric_literal(step_arg)
-        start = _numeric_literal(expr.args.get("start"))
-        end = _numeric_literal(expr.args.get("end"))
-        exclusive = bool(expr.args.get("is_end_exclusive"))
-    elif isinstance(expr, exp.GenerateDateArray):
-        step_arg = expr.args.get("step")
-        step = 1.0 if step_arg is None else _interval_sign(step_arg)
-        start = _date_ordinal(expr.args.get("start"))
-        end = _date_ordinal(expr.args.get("end"))
-        exclusive = False
-    else:
+    literals, or ``None`` when any is not one we can read. Numeric series and date spines reduce
+    to the same ordered scalar domain, chosen from the bounds rather than the function name: a
+    ``generate_series`` carries either numeric bounds (``generate_series(0, 23)``) or date-cast
+    bounds (the Postgres/Redshift calendar spine ``generate_series(d1, d2, interval '1 day')``),
+    and the date form is the same idiom as ``GENERATE_DATE_ARRAY``. The step value carries only a
+    sign, never a magnitude that affects non-emptiness (an inclusive range always holds its
+    start)."""
+    if not isinstance(expr, (exp.GenerateSeries, exp.GenerateDateArray)):
         return None
+    start_arg, end_arg, step_arg = (expr.args.get(k) for k in ("start", "end", "step"))
+    exclusive = bool(expr.args.get("is_end_exclusive"))
+    start = _numeric_literal(start_arg)
+    end = _numeric_literal(end_arg)
+    if start is not None and end is not None:
+        step = 1.0 if step_arg is None else _numeric_literal(step_arg)
+    else:
+        start = _date_ordinal(start_arg)
+        end = _date_ordinal(end_arg)
+        step = 1.0 if step_arg is None else _interval_sign(step_arg)
     if start is None or end is None or step is None:
         return None
     return start, end, step, exclusive
@@ -113,14 +117,29 @@ def _date_ordinal(expr: Expr | None) -> float | None:
 
 
 def _interval_sign(expr: Expr | None) -> float | None:
-    # Only the step's direction matters, so read the sign off the interval's magnitude (a
-    # string-form number like '1' or '-1') and leave a non-literal magnitude unproven. The
-    # unit (DAY, MONTH, ...) never affects non-emptiness.
-    if not isinstance(expr, exp.Interval) or not isinstance(expr.this, exp.Literal):
+    # Only the step's direction matters, so read the sign off the interval's magnitude and leave
+    # a non-literal or compound magnitude unproven. The unit (DAY, MONTH, ...) never affects
+    # non-emptiness. Two literal spellings reach here: the structured form (``INTERVAL 1 MONTH``,
+    # ``interval '1 day'``), where sqlglot splits the magnitude into its own literal, and the
+    # raw-string cast (``'1 day'::interval``), where the whole ``'<n> <unit>'`` string is one
+    # literal.
+    if isinstance(expr, (exp.Cast, exp.TryCast)) and expr.to.is_type(exp.DataType.Type.INTERVAL):
+        expr = expr.this
+    if isinstance(expr, exp.Interval) and isinstance(expr.this, exp.Literal):
+        magnitude = expr.this.this
+    elif isinstance(expr, exp.Literal) and expr.args.get("is_string"):
+        magnitude = expr.this
+    else:
+        return None
+    # A single-component magnitude is a signed number, optionally followed by one unit word
+    # ('1', '-1', '1 day'). A compound interval ('1 mon -1 day') has an ambiguous net direction,
+    # so it is left unproven rather than read off its leading term.
+    tokens = magnitude.split()
+    if len(tokens) > 2:
         return None
     try:
-        return float(expr.this.this)
-    except ValueError:
+        return float(tokens[0])
+    except (ValueError, IndexError):
         return None
 
 

--- a/tests/lineage/test_array_nonemptiness_propagation.py
+++ b/tests/lineage/test_array_nonemptiness_propagation.py
@@ -102,6 +102,50 @@ def test_array_literal_is_non_empty() -> None:
     assert values[_col("model.app.pivot", "metrics")] is ArrayNonEmpty.NON_EMPTY
 
 
+def test_generator_over_literal_bounds_is_non_empty() -> None:
+    # A GENERATE_ARRAY over literal bounds is an intrinsic constructor, the same kind of
+    # provably-non-empty array as ARRAY[...]; it clears through the column graph, so a
+    # downstream UNNEST of the column drops no row.
+    src = _source("source.app.raw.events")
+    values = _values(
+        src,
+        _model(
+            "model.app.spine",
+            "SELECT event_id, GENERATE_ARRAY(0, 23) AS hours FROM events",
+        ),
+    )
+    assert values[_col("model.app.spine", "hours")] is ArrayNonEmpty.NON_EMPTY
+
+
+def test_date_generator_over_literal_bounds_is_non_empty() -> None:
+    # A calendar spine over literal date bounds is an intrinsic constructor too; it clears
+    # through the column graph like the numeric generator and the literal array.
+    src = _source("source.app.raw.events")
+    values = _values(
+        src,
+        _model(
+            "model.app.calendar",
+            "SELECT event_id, GENERATE_DATE_ARRAY(DATE '2020-01-01', DATE '2020-12-31') AS days "
+            "FROM events",
+        ),
+    )
+    assert values[_col("model.app.calendar", "days")] is ArrayNonEmpty.NON_EMPTY
+
+
+def test_generator_over_column_bounds_is_unknown() -> None:
+    # A column upper bound can be a count of 0, giving an empty range; not provable, so the
+    # column carries no non-emptiness guarantee.
+    src = _source("source.app.raw.events")
+    values = _values(
+        src,
+        _model(
+            "model.app.counted",
+            "SELECT event_id, GENERATE_SERIES(1, cnt) AS ns FROM events",
+        ),
+    )
+    assert values[_col("model.app.counted", "ns")] is ArrayNonEmpty.UNKNOWN
+
+
 def test_array_of_filtered_set_subqueries_is_unknown() -> None:
     # ARRAY((SELECT AS STRUCT ... FROM unnest(...) WHERE ...)) is set-returning: the filter can
     # match nothing, so the array can be empty even though it is built inline. Concatenating two

--- a/tests/lineage/test_array_nonemptiness_propagation.py
+++ b/tests/lineage/test_array_nonemptiness_propagation.py
@@ -152,6 +152,23 @@ def test_postgres_date_generate_series_is_non_empty() -> None:
     assert values[_col("model.app.calendar", "days")] is ArrayNonEmpty.NON_EMPTY
 
 
+def test_timestamp_generator_over_literal_bounds_is_non_empty() -> None:
+    # A literal timestamp spine is the clock-domain intrinsic constructor; its bounds parse to
+    # ordered instants, so it clears cross-model like the date and numeric generators.
+    src = _source("source.app.raw.events")
+    values = _values(
+        src,
+        _model(
+            "model.app.ticks",
+            "SELECT event_id, "
+            "GENERATE_TIMESTAMP_ARRAY(TIMESTAMP '2020-01-01', TIMESTAMP '2020-01-02', "
+            "INTERVAL 1 HOUR) AS ticks "
+            "FROM events",
+        ),
+    )
+    assert values[_col("model.app.ticks", "ticks")] is ArrayNonEmpty.NON_EMPTY
+
+
 def test_generator_over_column_bounds_is_unknown() -> None:
     # A column upper bound can be a count of 0, giving an empty range; not provable, so the
     # column carries no non-emptiness guarantee.

--- a/tests/lineage/test_array_nonemptiness_propagation.py
+++ b/tests/lineage/test_array_nonemptiness_propagation.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 
 from dblect.adapters import profile_for_adapter
+from dblect.adapters.model import AdapterProfile
 from dblect.lineage.builder import build_manifest_graph
 from dblect.lineage.graph import ColumnRef, SourceKind, SourceRef
 from dblect.lineage.properties.array_nonemptiness import ArrayNonEmpty, array_nonemptiness
@@ -20,6 +21,7 @@ from dblect.lineage.property import propagate
 from dblect.manifest import Manifest, Node, ResourceType
 
 _BQ = profile_for_adapter("bigquery")
+_PG = profile_for_adapter("postgres")
 
 
 def _model(uid: str, sql: str) -> Node:
@@ -52,13 +54,13 @@ def _source(uid: str) -> Node:
     )
 
 
-def _values(*nodes: Node) -> Mapping[ColumnRef, ArrayNonEmpty]:
+def _values(*nodes: Node, profile: AdapterProfile = _BQ) -> Mapping[ColumnRef, ArrayNonEmpty]:
     manifest = Manifest(
         schema_version="v12",
-        adapter_type="bigquery",
+        adapter_type=profile.adapter_type,
         nodes={n.unique_id: n for n in nodes},
     )
-    graph = build_manifest_graph(manifest, dialect=_BQ.sqlglot_dialect).graph
+    graph = build_manifest_graph(manifest, dialect=profile.sqlglot_dialect).graph
     anns = propagate(graph, array_nonemptiness)
     return {ref: ann.value for ref, ann in anns.items()}
 
@@ -128,6 +130,24 @@ def test_date_generator_over_literal_bounds_is_non_empty() -> None:
             "SELECT event_id, GENERATE_DATE_ARRAY(DATE '2020-01-01', DATE '2020-12-31') AS days "
             "FROM events",
         ),
+    )
+    assert values[_col("model.app.calendar", "days")] is ArrayNonEmpty.NON_EMPTY
+
+
+def test_postgres_date_generate_series_is_non_empty() -> None:
+    # The Postgres/Redshift calendar spine spells the same idiom through generate_series over
+    # date-cast bounds with an interval step; the domain read off the bounds proves it
+    # non-empty, so it clears cross-model like the GENERATE_DATE_ARRAY form.
+    src = _source("source.app.raw.events")
+    values = _values(
+        src,
+        _model(
+            "model.app.calendar",
+            "SELECT event_id, "
+            "generate_series('2020-01-01'::date, '2020-12-31'::date, interval '1 day') AS days "
+            "FROM events",
+        ),
+        profile=_PG,
     )
     assert values[_col("model.app.calendar", "days")] is ArrayNonEmpty.NON_EMPTY
 

--- a/tests/sql/test_patterns.py
+++ b/tests/sql/test_patterns.py
@@ -680,6 +680,46 @@ def test_inner_unnest_of_scalar_subquery_array_literal_not_flagged() -> None:
     assert detect_inner_flatten_row_drop(_parse_d(sql, "bigquery")) == ()
 
 
+@pytest.mark.parametrize(
+    "sql",
+    [
+        # An hour-of-day spine: constant bounds 0 <= 23, so the range is non-empty
+        # unconditionally and the cross join drops no parent row.
+        "select t.id, hour from t cross join unnest(generate_series(0, 23)) as hour",
+        "select t.id, hour from t cross join unnest(generate_array(0, 23)) as hour",
+        # An explicit negative step running downward is likewise provably non-empty.
+        "select t.id, n from t cross join unnest(generate_series(10, 0, -2)) as n",
+        # A calendar spine over literal date bounds is the common date-dimension idiom.
+        "select t.id, d from t cross join "
+        "unnest(generate_date_array(date '2020-01-01', date '2020-12-31')) as d",
+    ],
+)
+def test_inner_unnest_of_provably_nonempty_generator_not_flagged(sql: str) -> None:
+    assert detect_inner_flatten_row_drop(_parse_d(sql, "bigquery")) == ()
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        # Descending literal bounds under the default (+1) step: an empty range, so the row
+        # drop is real.
+        "select t.id, n from t cross join unnest(generate_array(5, 1)) as n",
+        # A non-literal upper bound: a count of 0 yields an empty range, and dropping the row
+        # may be intended. Not provable from the call, so it stays firing.
+        "select t.id, n from t cross join unnest(generate_series(1, cast(t.cnt as int64))) as n",
+        # Column-bounded date generator: start > end or a zero-row input gives an empty array.
+        "select t.id, d from t cross join unnest(generate_date_array(t.a, t.b)) as d",
+        # A literal-bounded timestamp spine is deferred (timezone offsets defeat a raw literal
+        # compare), so it keeps firing even though the bounds are constants.
+        "select t.id, ts from t cross join unnest("
+        "generate_timestamp_array(timestamp '2020-01-01', timestamp '2020-01-02', interval 1 hour)"
+        ") as ts",
+    ],
+)
+def test_inner_unnest_of_not_provably_nonempty_generator_still_flagged(sql: str) -> None:
+    assert len(detect_inner_flatten_row_drop(_parse_d(sql, "bigquery"))) == 1
+
+
 def test_inner_unnest_of_column_still_flagged_without_a_predicate() -> None:
     # A column array's non-emptiness needs the lineage-grounded predicate; the bare
     # structural detector treats a column as opaque and keeps firing.

--- a/tests/sql/test_patterns.py
+++ b/tests/sql/test_patterns.py
@@ -692,6 +692,10 @@ def test_inner_unnest_of_scalar_subquery_array_literal_not_flagged() -> None:
         # A calendar spine over literal date bounds is the common date-dimension idiom.
         "select t.id, d from t cross join "
         "unnest(generate_date_array(date '2020-01-01', date '2020-12-31')) as d",
+        # A literal timestamp spine clears too: the bounds parse to ordered instants.
+        "select t.id, ts from t cross join unnest("
+        "generate_timestamp_array(timestamp '2020-01-01', timestamp '2020-01-02', interval 1 hour)"
+        ") as ts",
     ],
 )
 def test_inner_unnest_of_provably_nonempty_generator_not_flagged(sql: str) -> None:
@@ -709,11 +713,10 @@ def test_inner_unnest_of_provably_nonempty_generator_not_flagged(sql: str) -> No
         "select t.id, n from t cross join unnest(generate_series(1, cast(t.cnt as int64))) as n",
         # Column-bounded date generator: start > end or a zero-row input gives an empty array.
         "select t.id, d from t cross join unnest(generate_date_array(t.a, t.b)) as d",
-        # A literal-bounded timestamp spine is deferred (timezone offsets defeat a raw literal
-        # compare), so it keeps firing even though the bounds are constants.
-        "select t.id, ts from t cross join unnest("
-        "generate_timestamp_array(timestamp '2020-01-01', timestamp '2020-01-02', interval 1 hour)"
-        ") as ts",
+        # A column-bounded timestamp spine can invert or be empty, so it stays firing even though
+        # a literal-bounded one now clears.
+        "select t.id, ts from t cross join "
+        "unnest(generate_timestamp_array(t.a, t.b, interval 1 hour)) as ts",
     ],
 )
 def test_inner_unnest_of_not_provably_nonempty_generator_still_flagged(sql: str) -> None:

--- a/tests/sql/test_vocab.py
+++ b/tests/sql/test_vocab.py
@@ -21,9 +21,9 @@ from dblect.sql import parse_sql
 from dblect.sql.vocab import array_literal_nonempty, generator_provably_nonempty
 
 
-def _array(frag: str) -> Expr:
+def _array(frag: str, dialect: str = "bigquery") -> Expr:
     """The expression a single projection parses to, unwrapping its alias."""
-    select = parse_sql(f"SELECT {frag} AS a", dialect="bigquery")
+    select = parse_sql(f"SELECT {frag} AS a", dialect=dialect)
     assert isinstance(select, exp.Select)
     projected = select.expressions[0]
     return projected.this if isinstance(projected, exp.Alias) else projected
@@ -109,6 +109,36 @@ def test_non_array_expression_is_not_a_literal_array() -> None:
 )
 def test_generator_provably_nonempty(frag: str, nonempty: bool) -> None:
     assert generator_provably_nonempty(_array(frag)) is nonempty
+
+
+@pytest.mark.parametrize(
+    ("frag", "nonempty"),
+    [
+        # A Postgres/Redshift date spine spells the same idiom as GENERATE_DATE_ARRAY, through
+        # generate_series over date-cast bounds with an explicit interval step. The comparable
+        # domain is read off the bounds, not the function name, so the calendar proof reaches
+        # this form too. Ascending bounds under a positive step are non-empty.
+        ("generate_series('2020-01-01'::date, '2020-01-31'::date, interval '1 day')", True),
+        # Descending bounds under a negative step run downward: still non-empty.
+        ("generate_series('2020-01-31'::date, '2020-01-01'::date, interval '-1 day')", True),
+        # Ascending bounds under a negative step (or descending under a positive one) is empty.
+        ("generate_series('2020-01-01'::date, '2020-01-31'::date, interval '-1 day')", False),
+        ("generate_series('2020-01-31'::date, '2020-01-01'::date, interval '1 day')", False),
+        # The raw-string cast spelling of the step ('1 day'::interval) reads the same sign.
+        ("generate_series('2020-01-01'::date, '2020-01-31'::date, '1 day'::interval)", True),
+        ("generate_series('2020-01-31'::date, '2020-01-01'::date, '-1 day'::interval)", True),
+        # A compound interval ('1 mon -1 day') has an ambiguous net direction, so its sign is
+        # not read off the leading component and it stays unproven.
+        (
+            "generate_series('2020-01-01'::date, '2020-01-31'::date, '1 mon -1 day'::interval)",
+            False,
+        ),
+        # Column date bounds can invert or be empty: not provable from the call.
+        ("generate_series(a::date, b::date, interval '1 day')", False),
+    ],
+)
+def test_generator_provably_nonempty_postgres_date_series(frag: str, nonempty: bool) -> None:
+    assert generator_provably_nonempty(_array(frag, dialect="postgres")) is nonempty
 
 
 def test_non_generator_expression_is_not_a_nonempty_generator() -> None:

--- a/tests/sql/test_vocab.py
+++ b/tests/sql/test_vocab.py
@@ -1,11 +1,14 @@
-"""Array-literal non-emptiness recognition.
+"""Intrinsic array non-emptiness recognition.
 
-The detector and the ``array_nonemptiness`` property both read ``array_literal_nonempty`` to
-decide whether an array constructor is provably non-empty. The soundness line is between a
-bracket list (every element guaranteed present) and a set-returning subquery element (which
-can be empty), and it is subtle because BigQuery's array-subquery form and a bracket of
-parenthesised scalar subqueries parse to the same ``exp.Array`` shape, separated only by
-whether the element subquery reads a ``FROM``.
+The inner-flatten detector and the ``array_nonemptiness`` property both read these vocab
+predicates to decide whether an array constructor is provably non-empty from the node alone.
+For ``array_literal_nonempty`` the soundness line is between a bracket list (every element
+guaranteed present) and a set-returning subquery element (which can be empty), subtle because
+BigQuery's array-subquery form and a bracket of parenthesised scalar subqueries parse to the
+same ``exp.Array`` shape, separated only by whether the element subquery reads a ``FROM``. For
+``generator_provably_nonempty`` the line is at literal, order-comparable bounds with a readable
+step sign: numeric series and literal date spines are proved; column bounds and timestamp
+generators (unsound to compare across timezone offsets) are left firing.
 """
 
 from __future__ import annotations
@@ -15,7 +18,7 @@ import sqlglot.expressions as exp
 from sqlglot import Expr
 
 from dblect.sql import parse_sql
-from dblect.sql.vocab import array_literal_nonempty
+from dblect.sql.vocab import array_literal_nonempty, generator_provably_nonempty
 
 
 def _array(frag: str) -> Expr:
@@ -50,3 +53,63 @@ def test_array_literal_nonempty(frag: str, nonempty: bool) -> None:
 
 def test_non_array_expression_is_not_a_literal_array() -> None:
     assert array_literal_nonempty(_array("x + 1")) is False
+
+
+@pytest.mark.parametrize(
+    ("frag", "nonempty"),
+    [
+        # Literal ascending range under the default (+1) step: non-empty.
+        ("GENERATE_SERIES(0, 23)", True),
+        ("GENERATE_ARRAY(0, 23)", True),
+        # A single-point inclusive range is one element, still non-empty.
+        ("GENERATE_ARRAY(7, 7)", True),
+        # Descending literal bounds under the default (+1) step yield an empty range.
+        ("GENERATE_ARRAY(5, 1)", False),
+        # An explicit negative step running downward is non-empty; running upward is empty.
+        ("GENERATE_SERIES(10, 0, -2)", True),
+        ("GENERATE_SERIES(0, 10, -2)", False),
+        # A negative-literal range is decidable like any other.
+        ("GENERATE_SERIES(-5, -1)", True),
+        # Fractional literal bounds and step are still literals, so still decidable.
+        ("GENERATE_ARRAY(1.0, 2.0, 0.5)", True),
+        # A zero step has no well-defined range, so it is not proved non-empty.
+        ("GENERATE_ARRAY(0, 10, 0)", False),
+        # Non-literal bounds leave the range possibly empty: a count of 0, an empty input
+        # array. Not provable from the call, so it stays firing.
+        ("GENERATE_SERIES(1, CAST(n AS INT64))", False),
+        ("GENERATE_SERIES(0, ARRAY_LENGTH(m) - 1)", False),
+        # A date spine over literal bounds is the same intrinsic proof, mapped through the
+        # calendar: an ascending range under the default (+1 day) step is non-empty, whether
+        # the bounds are DATE-typed or bare date strings the generator coerces.
+        ("GENERATE_DATE_ARRAY(DATE '2020-01-01', DATE '2020-12-31')", True),
+        ("GENERATE_DATE_ARRAY('2020-01-01', '2020-12-31')", True),
+        ("GENERATE_DATE_ARRAY(DATE '2020-01-01', DATE '2020-01-01')", True),
+        # The interval's magnitude never changes non-emptiness (the start is always present);
+        # only its sign is read, so a month step over an ascending range is still non-empty.
+        ("GENERATE_DATE_ARRAY(DATE '2020-01-01', DATE '2020-12-31', INTERVAL 1 MONTH)", True),
+        # Descending bounds under the default (+1) step are empty; a negative step reverses it.
+        ("GENERATE_DATE_ARRAY(DATE '2020-12-31', DATE '2020-01-01')", False),
+        ("GENERATE_DATE_ARRAY(DATE '2020-12-31', DATE '2020-01-01', INTERVAL -1 DAY)", True),
+        ("GENERATE_DATE_ARRAY(DATE '2020-01-01', DATE '2020-12-31', INTERVAL -1 DAY)", False),
+        # A non-literal step magnitude is unreadable, so the sign is unknown and it stays firing.
+        ("GENERATE_DATE_ARRAY(DATE '2020-01-01', DATE '2020-12-31', INTERVAL n DAY)", False),
+        # Column bounds can invert or be empty; not provable from the call.
+        ("GENERATE_DATE_ARRAY(a, b)", False),
+        # A literal that is not a canonical date does not parse to a calendar point, so it is
+        # left unproven rather than guessed at.
+        ("GENERATE_DATE_ARRAY('2020-13-01', '2020-14-01')", False),
+        # Timestamp generators are deferred: a raw literal compare is unsound across timezone
+        # offsets, so they stay firing whether the bounds are literal or column.
+        (
+            "GENERATE_TIMESTAMP_ARRAY(TIMESTAMP '2020-01-01', TIMESTAMP '2020-01-02', INTERVAL 1 HOUR)",
+            False,
+        ),
+        ("GENERATE_TIMESTAMP_ARRAY(a, b, INTERVAL 1 HOUR)", False),
+    ],
+)
+def test_generator_provably_nonempty(frag: str, nonempty: bool) -> None:
+    assert generator_provably_nonempty(_array(frag)) is nonempty
+
+
+def test_non_generator_expression_is_not_a_nonempty_generator() -> None:
+    assert generator_provably_nonempty(_array("x + 1")) is False

--- a/tests/sql/test_vocab.py
+++ b/tests/sql/test_vocab.py
@@ -7,8 +7,9 @@ guaranteed present) and a set-returning subquery element (which can be empty), s
 BigQuery's array-subquery form and a bracket of parenthesised scalar subqueries parse to the
 same ``exp.Array`` shape, separated only by whether the element subquery reads a ``FROM``. For
 ``generator_provably_nonempty`` the line is at literal, order-comparable bounds with a readable
-step sign: numeric series and literal date spines are proved; column bounds and timestamp
-generators (unsound to compare across timezone offsets) are left firing.
+step sign: numeric series, literal date spines, and literal timestamp spines are proved
+(timestamps by parsing the bounds to real instants, deferring only a naive/aware mix that has no
+sound order); column bounds are left firing.
 """
 
 from __future__ import annotations
@@ -98,10 +99,49 @@ def test_non_array_expression_is_not_a_literal_array() -> None:
         # A literal that is not a canonical date does not parse to a calendar point, so it is
         # left unproven rather than guessed at.
         ("GENERATE_DATE_ARRAY('2020-13-01', '2020-14-01')", False),
-        # Timestamp generators are deferred: a raw literal compare is unsound across timezone
-        # offsets, so they stay firing whether the bounds are literal or column.
+        # A literal timestamp spine is proved by parsing its bounds to real instants and
+        # ordering them, so the common naive-literal clock spine clears like the date one.
         (
             "GENERATE_TIMESTAMP_ARRAY(TIMESTAMP '2020-01-01', TIMESTAMP '2020-01-02', INTERVAL 1 HOUR)",
+            True,
+        ),
+        # A single-point inclusive range is one element, still non-empty.
+        (
+            "GENERATE_TIMESTAMP_ARRAY(TIMESTAMP '2020-01-01', TIMESTAMP '2020-01-01', INTERVAL 1 HOUR)",
+            True,
+        ),
+        # Descending bounds under a positive step are empty; a negative step runs them downward.
+        (
+            "GENERATE_TIMESTAMP_ARRAY(TIMESTAMP '2020-01-02', TIMESTAMP '2020-01-01', INTERVAL 1 HOUR)",
+            False,
+        ),
+        (
+            "GENERATE_TIMESTAMP_ARRAY(TIMESTAMP '2020-01-02', TIMESTAMP '2020-01-01', INTERVAL -1 HOUR)",
+            True,
+        ),
+        # Offset-aware bounds order by absolute instant, so a compare across differing offsets is
+        # still sound: 12:00-05:00 is 17:00 UTC, after 00:00+00:00.
+        (
+            "GENERATE_TIMESTAMP_ARRAY("
+            "TIMESTAMP '2020-01-01 00:00:00+00:00', TIMESTAMP '2020-01-01 12:00:00-05:00', "
+            "INTERVAL 1 HOUR)",
+            True,
+        ),
+        # A naive bound and an offset-aware bound have no sound order (the naive bound's zone is
+        # unknown relative to the aware one), so the mix stays deferred in either order.
+        (
+            "GENERATE_TIMESTAMP_ARRAY("
+            "TIMESTAMP '2020-01-01', TIMESTAMP '2020-01-02 00:00:00+00:00', INTERVAL 1 HOUR)",
+            False,
+        ),
+        (
+            "GENERATE_TIMESTAMP_ARRAY("
+            "TIMESTAMP '2020-01-01 00:00:00+00:00', TIMESTAMP '2020-01-02', INTERVAL 1 HOUR)",
+            False,
+        ),
+        # A non-literal step magnitude leaves the sign unknown; column bounds are not literal.
+        (
+            "GENERATE_TIMESTAMP_ARRAY(TIMESTAMP '2020-01-01', TIMESTAMP '2020-01-02', INTERVAL n HOUR)",
             False,
         ),
         ("GENERATE_TIMESTAMP_ARRAY(a, b, INTERVAL 1 HOUR)", False),
@@ -135,6 +175,18 @@ def test_generator_provably_nonempty(frag: str, nonempty: bool) -> None:
         ),
         # Column date bounds can invert or be empty: not provable from the call.
         ("generate_series(a::date, b::date, interval '1 day')", False),
+        # The clock-domain spine runs through the same generate_series seam: literal timestamp
+        # bounds with an interval step clear when soundly ordered, and stay firing when reversed.
+        (
+            "generate_series('2020-01-01 00:00'::timestamp, '2020-01-02 00:00'::timestamp, "
+            "interval '1 hour')",
+            True,
+        ),
+        (
+            "generate_series('2020-01-02 00:00'::timestamp, '2020-01-01 00:00'::timestamp, "
+            "interval '1 hour')",
+            False,
+        ),
     ],
 )
 def test_generator_provably_nonempty_postgres_date_series(frag: str, nonempty: bool) -> None:


### PR DESCRIPTION
## Context

`inner_flatten_row_drop` fires on `CROSS JOIN UNNEST(<generator>)` even when the generator is provably non-empty, so the parent-row drop cannot happen. These are false positives on the same footing as the literal-`ARRAY[...]` exemption and the `array_nonemptiness` silencer. Shaken out by the #125 calibration pass.

## Approach

Add `generator_provably_nonempty` to the SQL vocabulary, the generator analog of `array_literal_nonempty`. It proves non-emptiness from the call alone, choosing the comparison domain from the bounds rather than the function name:

- **`GENERATE_SERIES` / `GENERATE_ARRAY`** over numeric literals: non-empty iff the literal bounds and step sign make the range non-empty (`step > 0 and a <= b`, or `step < 0 and a >= b`; default step `+1`).
- **Calendar spines** over literal dates, in either spelling: `GENERATE_DATE_ARRAY` and the Postgres/Redshift `generate_series(d1, d2, interval '1 day')` over date-cast bounds. Bounds parse to real calendar points via `date.fromisoformat`, so the comparison is chronological rather than lexicographic. The interval step contributes only its sign; its magnitude never affects non-emptiness, since an inclusive range always holds its start.
- **Clock spines** over literal timestamps, likewise in both spellings (`GENERATE_TIMESTAMP_ARRAY` and `generate_series` over timestamp-cast bounds). Bounds parse to real instants via `datetime.fromisoformat`.

Numeric, date, and timestamp bounds all reduce to one ordered scalar domain, so a single non-emptiness test serves them. A new array constructor is one vocab predicate plus one line in the operator table.

## Soundness posture — silence only on a positive proof

Stays firing when the range could legitimately be empty and the drop may be intended:

- non-literal bounds (a `CAST(n AS INT64)` count that can be `0`, column start/end that can invert),
- a non-literal step magnitude (`INTERVAL n DAY`), and a compound interval (`'1 mon -1 day'`) whose net direction is ambiguous,
- non-canonical date literals (fail to parse, left unproven),
- a **naive/aware timestamp mix**: same-kind timestamp bounds order soundly (naive by civil value, offset-aware by absolute instant, including across differing offsets), so parsing the bounds to instants is what lets the common ordered-literal spine clear. The one pairing left unproven is an offset-carrying bound against a naive one, whose two zones have no sound order.

## One fact, both consumers

The inline `UNNEST(<generator>)` path in the detector and the `array_nonemptiness` property both read the vocab predicate. The property gets it through the shared `_intrinsic_constructor_rule` operator (alongside `ARRAY[...]`), so a generated array defined in one model and unnested downstream clears cross-model too. Because the domain is read off the bounds, the single `generate_series` operator entry covers its numeric, date, and timestamp spellings.

## Testing

Test-first, enumerating the closed set at three boundaries:

- **vocab** (`test_vocab.py`): numeric ranges (non-empty/empty, negative step both directions, fractional bounds, zero step); date spines across `GENERATE_DATE_ARRAY` and Postgres `generate_series` (DATE-typed and bare strings, single-point, descending, month/negative-day steps, structured vs raw-string interval, compound-interval deferral, column bounds, non-canonical date); timestamp spines (naive, offset-aware across differing offsets, single-point, descending with positive/negative step), naive/aware mix in both orderings, non-literal step, column bounds.
- **detector** (`test_patterns.py`): inline `UNNEST(generate_*)` cleared vs. still firing, including the literal timestamp spine moving from firing to cleared.
- **property** (`test_array_nonemptiness_propagation.py`): numeric, date, and timestamp generators clear cross-model; column bounds stay `UNKNOWN`.

Each rule was confirmed to bite via injected mutations (over-claim on non-literal bounds, ignored interval sign, dropped compound-interval guard, dropped naive/aware kind guard). Full gate green: `ruff check`, `ruff format --check`, `pyright`, `pytest` (1251 passed).

Part of #125. Closes #191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
