### PR TITLE
fix(patterns): clear provably-non-empty flatten and coalesced WHERE across dialects

### DIFF
--- a/src/dblect/sql/guards.py
+++ b/src/dblect/sql/guards.py
@@ -111,21 +111,41 @@ def rescued_by_or_sibling(predicate: Expr, *, where: exp.Where, nullable: frozen
 
 
 def defaulted_true_by_coalesce(predicate: Expr, *, until: Expr) -> bool:
-    """True if ``predicate`` is the first argument of a ``COALESCE`` whose remaining arguments
-    are all the literal ``TRUE`` between it and ``until``, so an unmatched row (where the
-    predicate is NULL) is defaulted to a kept ``TRUE`` and the outer join is not inverted.
+    """True if ``predicate`` is the first argument of a ``COALESCE`` defaulting to the literal
+    ``TRUE``, and that ``COALESCE`` reaches ``until`` through boolean connectives only, so an
+    unmatched row (where the predicate is NULL) is defaulted to a kept ``TRUE`` and the outer
+    join is not inverted.
 
-    Sound rather than permissive about the default: ``coalesce(pred, false)`` and a non-literal
-    or fallback-position default keep firing, since the padding ``TRUE`` is not proven there.
+    Sound rather than permissive about the default *and* its context. ``coalesce(pred, false)``
+    and a non-literal or fallback-position default keep firing, since the padding ``TRUE`` is not
+    proven there. A proven ``TRUE`` that a ``NOT`` or a re-comparison of the value
+    (``coalesce(pred, true) = false``) flips back into a drop keeps firing too: the ``COALESCE``
+    no longer proves the row survives once its value passes through a non-truthy context.
     """
     prev: Expr | None = None
     for node in _path(predicate, until):
-        if isinstance(node, exp.Coalesce) and prev is node.this:
-            defaults = node.expressions
-            if defaults and all(_is_true_literal(d) for d in defaults):
-                return True
+        if (
+            isinstance(node, exp.Coalesce)
+            and prev is node.this
+            and node.expressions
+            and all(_is_true_literal(d) for d in node.expressions)
+        ):
+            return _reaches_root_truthy(node, until)
         prev = node
     return False
+
+
+def _reaches_root_truthy(node: Expr, until: Expr) -> bool:
+    """True if a subexpression evaluating to ``TRUE`` keeps its row: every node strictly between
+    ``node`` and the WHERE root ``until`` is a boolean AND/OR connective (optionally
+    parenthesised). Under a ``NOT`` or a comparison of the value a ``TRUE`` can still drop the
+    row, so a defaulted ``TRUE`` there does not prove the join is preserved."""
+    for anc in _path(node, until):
+        if anc is node or anc is until:
+            continue
+        if not isinstance(anc, (exp.And, exp.Or, exp.Paren)):
+            return False
+    return True
 
 
 def _is_true_literal(expr: Expr) -> bool:

--- a/src/dblect/sql/guards.py
+++ b/src/dblect/sql/guards.py
@@ -43,7 +43,7 @@ def is_coalesced(col: exp.Column, *, until: Expr) -> bool:
     where any deliberate handling defuses the hazard (a ``WHERE`` comparison). Where the
     fallback's own nullability matters (a ``GROUP BY`` key), use :func:`supplies_present_value`.
     """
-    return any(isinstance(node, exp.Coalesce) for node in _path(col, until))
+    return any(isinstance(n, exp.Coalesce) for n in _path(col, until))
 
 
 def is_null_checked(col: exp.Column, *, until: Expr) -> bool:
@@ -110,6 +110,29 @@ def rescued_by_or_sibling(predicate: Expr, *, where: exp.Where, nullable: frozen
     return False
 
 
+def defaulted_true_by_coalesce(predicate: Expr, *, until: Expr) -> bool:
+    """True if ``predicate`` is the first argument of a ``COALESCE`` whose remaining arguments
+    are all the literal ``TRUE`` between it and ``until``, so an unmatched row (where the
+    predicate is NULL) is defaulted to a kept ``TRUE`` and the outer join is not inverted.
+
+    Sound rather than permissive about the default: ``coalesce(pred, false)`` and a non-literal
+    or fallback-position default keep firing, since the padding ``TRUE`` is not proven there.
+    """
+    prev: Expr | None = None
+    for node in _path(predicate, until):
+        if isinstance(node, exp.Coalesce) and prev is node.this:
+            defaults = node.expressions
+            if defaults and all(_is_true_literal(d) for d in defaults):
+                return True
+        prev = node
+    return False
+
+
+def _is_true_literal(expr: Expr) -> bool:
+    """True only for the boolean literal ``TRUE``, the default that keeps a padded row."""
+    return isinstance(expr, exp.Boolean) and expr.this is True
+
+
 def _present_when_padded(
     sel: exp.Select, *, constrained: frozenset[str], nullable: frozenset[str]
 ) -> frozenset[str]:
@@ -158,13 +181,13 @@ def _full_outer_complements(sel: exp.Select) -> dict[str, frozenset[str]]:
     return {left: frozenset({right}), right: frozenset({left})}
 
 
-def _path(col: exp.Column, until: Expr) -> Iterator[Expr]:
-    """The chain of nodes from ``col`` up to and including ``until``.
+def _path(start: Expr, until: Expr) -> Iterator[Expr]:
+    """The chain of nodes from ``start`` up to and including ``until``.
 
     Inclusive of ``until`` so a guard that *is* the boundary node (``GROUP BY
     coalesce(...)``, where the coalesce is the group expression itself) is still seen.
     """
-    node: Expr | None = col
+    node: Expr | None = start
     while node is not None:
         yield node
         if node is until:

--- a/src/dblect/sql/patterns.py
+++ b/src/dblect/sql/patterns.py
@@ -464,9 +464,12 @@ def detect_where_on_outer_joined_nullable(tree: Expr) -> tuple[Finding, ...]:
 
     A predicate is cleared when the value-effect catalog neutralises the padding
     NULL: the column is wrapped in ``COALESCE`` or an ``IS [NOT] NULL`` check
-    before the comparison, or the comparison is one term of a top-level ``OR``
-    whose sibling disjunct keeps the unmatched rows alive (``where a.x > 0 or
-    b.y > 0`` does not invert the join). Cleared predicates are silent.
+    before the comparison, the comparison is the first argument of a ``COALESCE``
+    that defaults the unmatched-row NULL to a literal ``TRUE`` (``coalesce(b.x <>
+    a.x, true)``, kept; ``coalesce(..., false)`` still drops the rows and fires),
+    or the comparison is one term of a top-level ``OR`` whose sibling disjunct
+    keeps the unmatched rows alive (``where a.x > 0 or b.y > 0`` does not invert
+    the join). Cleared predicates are silent.
     """
     out: list[Finding] = []
     for sel in sg.find_all_selects(tree):
@@ -478,6 +481,8 @@ def detect_where_on_outer_joined_nullable(tree: Expr) -> tuple[Finding, ...]:
             continue
         nullable_fs = frozenset(nullable)
         for cmp in where.find_all(*_NULL_INTOLERANT_COMPARISONS):
+            if guards.defaulted_true_by_coalesce(cmp, until=where):
+                continue
             risky_tables: set[str] = set()
             for c in sg.find_columns(cmp):
                 if guards.is_coalesced(c, until=cmp) or guards.is_null_checked(c, until=cmp):
@@ -522,9 +527,10 @@ def detect_inner_flatten_row_drop(
     silent. The construct parses dialect-specifically, so the detector reads the structural
     shape sqlglot produces rather than the surface syntax.
 
-    An ``UNNEST`` whose argument is provably non-empty drops no row, so it is silent too.
-    A literal ``ARRAY[...]`` constructor with one or more elements is the local, always-on
-    case (the wide-to-long pivot idiom). ``column_is_nonempty``, when supplied, answers
+    A flatten whose argument is provably non-empty drops no row, so it is silent too, in every
+    spelling (``UNNEST``, spark ``explode``, snowflake ``FLATTEN``): a literal ``ARRAY[...]``
+    constructor with one or more elements is the local, always-on case (the wide-to-long pivot
+    idiom). ``column_is_nonempty``, when supplied, answers
     whether an unnested *column* is provably non-empty; the audit builds it over the
     ``array_nonemptiness`` property resolved across model and CTE boundaries, so a
     rebuilt-then-unnested array stays quiet. The detector treats columns as opaque
@@ -539,7 +545,7 @@ def detect_inner_flatten_row_drop(
                 continue
             if sg.join_side_of(j) in _OUTER_JOIN_SIDES or _flatten_preserves_rows(kernel):
                 continue
-            if _unnest_arg_provably_nonempty(kernel, column_is_nonempty, nullable):
+            if _flatten_arg_provably_nonempty(kernel, column_is_nonempty, nullable):
                 continue
             out.append(_inner_flatten_finding(j))
         for lat in sg.laterals_of(sel):
@@ -549,6 +555,8 @@ def detect_inner_flatten_row_drop(
             if not _is_flatten_like(lat.this):
                 continue
             if _flatten_preserves_rows(lat):
+                continue
+            if _flatten_arg_provably_nonempty(lat, column_is_nonempty, nullable):
                 continue
             out.append(_inner_flatten_finding(lat))
     return tuple(out)
@@ -728,23 +736,50 @@ def _has_outer_kwarg(fn: Expr) -> bool:
     return False
 
 
-def _unnest_arg_provably_nonempty(
+def _flatten_operands(kernel: Expr) -> list[Expr] | None:
+    """The array expression(s) a flatten arm unnests, across the spellings, or ``None`` when
+    the arm's array cannot be read and the caller must keep firing.
+
+    The forms differ only in where they keep the array. ``UNNEST(a, b)`` zips several arrays,
+    each in ``expressions``. Every other flatten form carries one array: the explode family
+    (spark ``explode``/``posexplode``/``inline``) in ``this``, and snowflake ``FLATTEN(input =>
+    arr)`` (which sqlglot also parses to ``exp.Explode``) on an ``input`` kwarg that need not
+    come first. A form whose array we cannot locate returns ``None`` so the detector stays sound
+    (a missed non-emptiness proof over-fires; a wrong one would silence a real row drop)."""
+    fn = kernel.this if isinstance(kernel, _FLATTEN_WRAPPER_TYPED) else kernel
+    if isinstance(fn, exp.Unnest):
+        return [a for a in fn.expressions if isinstance(a, Expr)]
+    if not isinstance(fn, _ARRAY_FLATTEN_TYPED):
+        return None
+    arg = fn.this
+    if isinstance(arg, exp.Kwarg):
+        arg = _flatten_input_arg(fn)
+    return [arg] if isinstance(arg, Expr) else None
+
+
+def _flatten_input_arg(fn: Expr) -> Expr | None:
+    """The array on a snowflake ``FLATTEN``'s ``input`` kwarg, searched across all of the
+    call's arguments since ``input`` need not come first."""
+    for kw in (fn.this, *fn.args.get("expressions", [])):
+        if (
+            isinstance(kw, exp.Kwarg)
+            and isinstance(kw.this, exp.Var)
+            and kw.this.name.lower() == "input"
+        ):
+            return kw.expression
+    return None
+
+
+def _flatten_arg_provably_nonempty(
     kernel: Expr,
     column_is_nonempty: Callable[[exp.Column], bool] | None,
     nullable_tables: set[str],
 ) -> bool:
-    """True when every array ``kernel`` unnests is provably non-empty, so no parent row drops.
-
-    Only the ``UNNEST`` spelling carries its array arguments where we can read them; the
-    ``explode``/``flatten`` function forms wrap the array in dialect-specific ways and are
-    left to the outer-form check. ``UNNEST(a, b)`` zips several arrays, every one of which
-    must be non-empty for the row to survive."""
-    if not isinstance(kernel, exp.Unnest):
+    """True when every array ``kernel`` flattens is provably non-empty, so no parent row drops."""
+    operands = _flatten_operands(kernel)
+    if not operands:
         return False
-    args = [a for a in kernel.expressions if isinstance(a, Expr)]
-    if not args:
-        return False
-    return all(_array_expr_nonempty(a, column_is_nonempty, nullable_tables) for a in args)
+    return all(_array_expr_nonempty(a, column_is_nonempty, nullable_tables) for a in operands)
 
 
 def _array_expr_nonempty(

--- a/tests/sql/test_patterns.py
+++ b/tests/sql/test_patterns.py
@@ -555,6 +555,23 @@ def test_where_coalesced_nullable_not_detected() -> None:
     assert detect_where_on_outer_joined_nullable(_parse(sql)) == ()
 
 
+def test_where_comparison_coalesced_to_false_still_detected() -> None:
+    # The soundness boundary: COALESCE(pred, FALSE) defaults the unmatched-row NULL to FALSE,
+    # so those rows are dropped and the outer join IS silently inverted. Only a literal-TRUE
+    # default keeps the rows, so this must still fire. The TRUE-clears direction is the
+    # execution-oracle PBT in test_pbt_structural_hazards.py.
+    sql = "select * from a left join b on a.k = b.k where coalesce(b.status <> a.status, false)"
+    assert len(detect_where_on_outer_joined_nullable(_parse(sql))) == 1
+
+
+def test_where_comparison_in_coalesce_fallback_position_still_detected() -> None:
+    # The comparison sits in a fallback position, not the first argument, so the COALESCE does
+    # not default *it* to a kept value: `coalesce(a.flag, b.status <> a.status)` returns the
+    # comparison only when a.flag is NULL, and an unmatched row can still be dropped. Fires.
+    sql = "select * from a left join b on a.k = b.k where coalesce(a.flag, b.status <> a.status)"
+    assert len(detect_where_on_outer_joined_nullable(_parse(sql))) == 1
+
+
 def test_where_in_predicate_on_nullable_detected() -> None:
     sql = "select * from a left join b on a.k = b.k where b.status in ('x', 'y')"
     assert len(detect_where_on_outer_joined_nullable(_parse(sql))) == 1
@@ -639,6 +656,19 @@ def test_spark_lateral_view_explode_inner_flagged_outer_silent() -> None:
 )
 def test_spark_explode_outer_variants(sql: str, expected: int) -> None:
     assert len(detect_inner_flatten_row_drop(_parse_d(sql, "spark"))) == expected
+
+
+# The cross-dialect verdict (a provably non-empty explode/flatten clears the same as UNNEST,
+# a column still fires) is pinned by the metamorphic PBT in test_pbt_structural_hazards.py,
+# against the absolute UNNEST verdicts above.
+
+
+def test_lateral_unnest_of_nonempty_literal_array_not_flagged() -> None:
+    # `LATERAL UNNEST(<literal array>)` wraps the UNNEST in a lateral, but the array still
+    # rides `expressions` and is provably non-empty, so it clears exactly as the bare
+    # `UNNEST([...])` arm does. The array must be read off the wrapped UNNEST, not its `this`.
+    sql = "select t.id, x from t cross join lateral unnest([1, 2]) as x"
+    assert detect_inner_flatten_row_drop(_parse_d(sql, "duckdb")) == ()
 
 
 @pytest.mark.parametrize(

--- a/tests/sql/test_patterns.py
+++ b/tests/sql/test_patterns.py
@@ -692,6 +692,16 @@ def test_inner_unnest_of_empty_literal_array_still_flagged() -> None:
     assert len(detect_inner_flatten_row_drop(_parse_d(sql, "bigquery"))) == 1
 
 
+@pytest.mark.parametrize("sql", ["unnest([1, NULL])", "unnest([NULL])"])
+def test_inner_unnest_of_array_with_null_elements_not_flagged(sql: str) -> None:
+    # A NULL *element* still contributes a row: unnest([NULL]) yields one (null) row, so the
+    # parent survives, unlike scalar unnest(NULL) which drops it. The array is non-empty, so a
+    # NULL element must not be read as absent. The clear-implies-no-drop PBT cannot pin this: a
+    # regression here makes the detector fire, not clear, which its `if cleared` guard skips.
+    stmt = f"select t.id, x from t, {sql} as x"
+    assert detect_inner_flatten_row_drop(_parse_d(stmt, "duckdb")) == ()
+
+
 def test_inner_unnest_of_array_subquery_still_flagged() -> None:
     # ARRAY(SELECT ...) also parses to exp.Array, but the subquery may return zero rows, so
     # the array can be empty and the parent row can still drop.

--- a/tests/sql/test_pbt_structural_hazards.py
+++ b/tests/sql/test_pbt_structural_hazards.py
@@ -1,0 +1,236 @@
+"""Property-based tests for two structural detectors, complementing the example tests
+in ``test_patterns.py``.
+
+Three properties with teeth for the precision fixes these detectors carry:
+
+* **Dialect invariance of the inner-flatten detector** (parse-only, metamorphic): the same
+  logical array flatten written under ``UNNEST`` (duckdb/bigquery), ``LATERAL VIEW EXPLODE``
+  (spark), and ``LATERAL FLATTEN`` (snowflake) must yield the same number of findings. The
+  detector reads a hazard off the structural shape, so the surface dialect must not change the
+  verdict. This is the invariant the explode/flatten non-emptiness fix restored: before it, a
+  provably non-empty literal array cleared under ``UNNEST`` but fired under ``EXPLODE``.
+
+* **Soundness of the inner-flatten clear** (duckdb execution oracle): if the detector clears
+  an inner flatten, materializing ``t, UNNEST(arr)`` drops no parent row. The flatten clear is
+  a pure semantic claim ("provably non-empty"), so this holds over a broad array grammar that
+  reaches empty arrays (an empty cast, an inverted generator, an empty subquery-array); the
+  oracle catches an unsound clear rather than confirming a known-good subset.
+
+* **Soundness of the where-inversion clear** (duckdb execution oracle): for
+  ``a LEFT JOIN b ... WHERE <predicate>`` where the predicate is a null-intolerant comparison
+  over the optional side, optionally wrapped in ``COALESCE(cmp, default)``, if the detector
+  clears the predicate then materialized data keeps every unmatched row. The oracle is the
+  data, so a clear that actually drops unmatched rows (the ``COALESCE(cmp, false)`` case the
+  guard must not clear) fails here against ground truth rather than against a re-derivation.
+
+  The generator stays inside the comparison-plus-``COALESCE`` grammar the ``defaulted_true_by_
+  coalesce`` guard reasons about, where a clear is meant to imply preservation. It does not
+  generate the column-level ``COALESCE(b.col, 0) = x`` idiom, whose permissive clear is a
+  deliberate "the analyst handled the null" call rather than a preservation claim (see
+  ``guards.is_coalesced``); that idiom's contract is not "the join is preserved".
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+import duckdb
+import pytest
+import sqlglot
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from dblect.sql.patterns import (
+    detect_inner_flatten_row_drop,
+    detect_where_on_outer_joined_nullable,
+)
+from tests.lineage._duckdb_oracle import materialized, scalar
+
+# --- dialect invariance of the inner-flatten detector ------------------------------------
+
+
+def _flatten_stmt(dialect: str, array_sql: str, *, outer: bool) -> str:
+    """The inner (or row-preserving outer) flatten of ``array_sql`` in ``dialect``'s syntax."""
+    if dialect in ("duckdb", "bigquery"):
+        arm = f"unnest({array_sql}) as x"
+        return (
+            f"select t.id, x from t left join {arm} on true"
+            if outer
+            else (f"select t.id, x from t, {arm}")
+        )
+    if dialect == "spark":
+        kw = "outer explode" if outer else "explode"
+        return f"select t.id, x from t lateral view {kw}({array_sql}) tt as x"
+    if dialect == "snowflake":
+        tail = ", outer => true" if outer else ""
+        return f"select t.id, f.value from t, lateral flatten(input => {array_sql}{tail}) f"
+    raise AssertionError(dialect)
+
+
+@st.composite
+def _array_spellings(draw: st.DrawFn) -> dict[str, str]:
+    """One logical array, rendered per dialect. Every entry denotes the *same* array, so the
+    detector must return the same verdict for all of them."""
+    kind = draw(st.sampled_from(["nonempty_literal", "empty_literal", "column", "series"]))
+    if kind == "nonempty_literal":
+        elems = ", ".join(
+            str(draw(st.integers(min_value=0, max_value=9)))
+            for _ in range(draw(st.integers(min_value=1, max_value=4)))
+        )
+        return {
+            "bigquery": f"[{elems}]",
+            "spark": f"array({elems})",
+            "snowflake": f"array_construct({elems})",
+        }
+    if kind == "empty_literal":
+        return {"bigquery": "[]", "spark": "array()", "snowflake": "array_construct()"}
+    if kind == "column":
+        return {"bigquery": "t.arr", "spark": "t.arr", "snowflake": "t.arr"}
+    # A numeric spine: duckdb/bigquery `generate_series`/`generate_array` and spark `sequence`
+    # all parse to a generator; snowflake has no flatten-over-generator idiom, so it sits out.
+    lo, hi = (
+        draw(st.integers(min_value=0, max_value=5)),
+        draw(st.integers(min_value=0, max_value=9)),
+    )
+    return {"bigquery": f"generate_array({lo}, {hi})", "spark": f"sequence({lo}, {hi})"}
+
+
+@given(spellings=_array_spellings(), outer=st.booleans())
+@settings(max_examples=300, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+def test_inner_flatten_verdict_is_dialect_invariant(spellings: dict[str, str], outer: bool) -> None:
+    counts = {
+        dialect: len(detect_inner_flatten_row_drop(sqlglot.parse_one(stmt, read=dialect)))
+        for dialect, array_sql in spellings.items()
+        if (stmt := _flatten_stmt(dialect, array_sql, outer=outer))
+    }
+    assert len(set(counts.values())) == 1, (
+        f"dialect-dependent inner-flatten verdict {counts} (outer={outer}) for {spellings}"
+    )
+
+
+# --- soundness of the inner-flatten clear (duckdb execution oracle) ----------------------
+#
+# Unlike the where detector, whose clear is an intent judgement (an explicit COALESCE clears
+# even when it drops rows), the inner-flatten clear is a pure semantic claim: "this array is
+# provably non-empty, so no parent row drops". That claim IS oracle-testable over a broad
+# array grammar: if the detector clears, materializing the UNNEST must drop no parent row. A
+# generator that reaches empty arrays (an empty cast, an inverted generator, an empty
+# subquery-array) hunts for an unsound clear rather than confirming a known-good subset.
+
+
+@pytest.fixture(scope="session")
+def flatten_con(con: duckdb.DuckDBPyConnection) -> duckdb.DuckDBPyConnection:
+    con.execute("create or replace table t(id integer)")
+    con.execute("insert into t values (1), (2), (3)")
+    con.execute("create or replace table vals(x integer)")
+    con.execute("insert into vals values (5), (6)")
+    return con
+
+
+@st.composite
+def _executable_array(draw: st.DrawFn) -> str:
+    """A duckdb-executable array expression, reaching both non-empty and empty arrays so the
+    oracle can catch an unsound clear."""
+    kind = draw(
+        st.sampled_from(["literal", "literal_with_null", "empty_cast", "series", "subquery"])
+    )
+    if kind == "literal":
+        return (
+            "["
+            + ", ".join(str(draw(st.integers(0, 9))) for _ in range(draw(st.integers(1, 4))))
+            + "]"
+        )
+    if kind == "literal_with_null":
+        parts = draw(st.lists(st.sampled_from(["1", "2", "NULL"]), min_size=1, max_size=4))
+        return "[" + ", ".join(parts) + "]"
+    if kind == "empty_cast":
+        return "CAST([] AS INTEGER[])"
+    if kind == "series":
+        return f"generate_series({draw(st.integers(0, 6))}, {draw(st.integers(0, 6))})"
+    return f"(select array_agg(x) from vals where x > {draw(st.integers(0, 10))})"
+
+
+@given(array_sql=_executable_array())
+@settings(max_examples=500, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+def test_inner_flatten_clear_implies_no_parent_row_dropped(
+    flatten_con: duckdb.DuckDBPyConnection, array_sql: str
+) -> None:
+    """If the detector clears an inner flatten, running ``t, UNNEST(arr)`` drops no parent row.
+    The array is a constant, so every parent row sees the same array: a clear that is wrong
+    about non-emptiness drops all parent rows here and fails."""
+    model_sql = f"select t.id from t, unnest({array_sql}) as u"
+    cleared = len(detect_inner_flatten_row_drop(sqlglot.parse_one(model_sql, read="duckdb"))) == 0
+    total = scalar(flatten_con, "select count(*) from t")
+    survivors = scalar(flatten_con, f"select count(distinct id) from ({model_sql}) s")
+    if cleared:
+        assert total - survivors == 0, (
+            f"detector cleared but {total - survivors} parent rows dropped for unnest({array_sql})"
+        )
+
+
+# --- soundness of the where-inversion clear ----------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class WhereScenario:
+    a_rows: tuple[tuple[int, int], ...]
+    b_rows: tuple[tuple[int, int], ...]
+    predicate: str
+
+
+@st.composite
+def _where_scenario(draw: st.DrawFn) -> WhereScenario:
+    n = draw(st.integers(min_value=2, max_value=5))
+    a_rows = tuple((k, draw(st.integers(min_value=-2, max_value=3))) for k in range(n))
+    # A strict subset of a's keys match, so at least one a row is unmatched and the WHERE's
+    # effect on padded rows is observable.
+    matched = draw(st.lists(st.integers(min_value=0, max_value=n - 1), unique=True, max_size=n - 1))
+    b_rows = tuple((k, draw(st.integers(min_value=-2, max_value=3))) for k in matched)
+    cmp = f"b.v > {draw(st.integers(min_value=-2, max_value=3))}"
+    wrap = draw(st.sampled_from(["bare", "coalesce_true", "coalesce_false", "coalesce_expr"]))
+    predicate = {
+        "bare": cmp,
+        "coalesce_true": f"coalesce({cmp}, true)",
+        "coalesce_false": f"coalesce({cmp}, false)",
+        "coalesce_expr": f"coalesce({cmp}, a.v > 0)",
+    }[wrap]
+    return WhereScenario(a_rows, b_rows, predicate)
+
+
+@pytest.fixture(scope="session")
+def con() -> Iterator[duckdb.DuckDBPyConnection]:
+    connection = duckdb.connect()
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+@given(s=_where_scenario())
+@settings(max_examples=300, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+def test_where_clear_implies_unmatched_rows_survive(
+    con: duckdb.DuckDBPyConnection, s: WhereScenario
+) -> None:
+    """If the detector clears the predicate, the LEFT JOIN keeps every unmatched row when the
+    query actually runs. The data is the judge, so clearing a predicate that silently drops
+    unmatched rows fails here."""
+    model_sql = (
+        "select a.k as ak, a.v as av, b.k as bk, b.v as bv "
+        f"from a left join b on a.k = b.k where {s.predicate}"
+    )
+    cleared = (
+        len(detect_where_on_outer_joined_nullable(sqlglot.parse_one(model_sql, read="duckdb"))) == 0
+    )
+    tables = [("a", ("k", "v"), s.a_rows), ("b", ("k", "v"), s.b_rows)]
+    with materialized(con, tables, model_sql) as c:
+        dropped_unmatched = scalar(
+            c,
+            "select count(*) from a where a.k not in (select k from b) "
+            "and a.k not in (select ak from _m where bk is null)",
+        )
+    if cleared:
+        assert dropped_unmatched == 0, (
+            f"detector cleared but {dropped_unmatched} unmatched rows were dropped by "
+            f"where {s.predicate!r} (a={s.a_rows}, b={s.b_rows})"
+        )

--- a/tests/sql/test_pbt_structural_hazards.py
+++ b/tests/sql/test_pbt_structural_hazards.py
@@ -134,18 +134,13 @@ def flatten_con(con: duckdb.DuckDBPyConnection) -> duckdb.DuckDBPyConnection:
 def _executable_array(draw: st.DrawFn) -> str:
     """A duckdb-executable array expression, reaching both non-empty and empty arrays so the
     oracle can catch an unsound clear."""
-    kind = draw(
-        st.sampled_from(["literal", "literal_with_null", "empty_cast", "series", "subquery"])
-    )
+    kind = draw(st.sampled_from(["literal", "empty_cast", "series", "subquery"]))
     if kind == "literal":
         return (
             "["
             + ", ".join(str(draw(st.integers(0, 9))) for _ in range(draw(st.integers(1, 4))))
             + "]"
         )
-    if kind == "literal_with_null":
-        parts = draw(st.lists(st.sampled_from(["1", "2", "NULL"]), min_size=1, max_size=4))
-        return "[" + ", ".join(parts) + "]"
     if kind == "empty_cast":
         return "CAST([] AS INTEGER[])"
     if kind == "series":

--- a/tests/sql/test_pbt_structural_hazards.py
+++ b/tests/sql/test_pbt_structural_hazards.py
@@ -18,14 +18,16 @@ Three properties with teeth for the precision fixes these detectors carry:
 
 * **Soundness of the where-inversion clear** (duckdb execution oracle): for
   ``a LEFT JOIN b ... WHERE <predicate>`` where the predicate is a null-intolerant comparison
-  over the optional side, optionally wrapped in ``COALESCE(cmp, default)``, if the detector
-  clears the predicate then materialized data keeps every unmatched row. The oracle is the
-  data, so a clear that actually drops unmatched rows (the ``COALESCE(cmp, false)`` case the
-  guard must not clear) fails here against ground truth rather than against a re-derivation.
+  over the optional side under one of a closed set of wrappers, if the detector clears the
+  predicate then materialized data keeps every unmatched row. The oracle is the data, so a
+  clear that actually drops unmatched rows fails here against ground truth rather than against a
+  re-derivation. The wrapper axis (``_WHERE_WRAPS``) is enumerated, not sampled, and includes
+  the traps a defaulted ``TRUE`` still drops on: ``coalesce(cmp, false)``, ``not coalesce(cmp,
+  true)``, and ``coalesce(cmp, true) = false``. The data around each wrapper is sampled.
 
-  The generator stays inside the comparison-plus-``COALESCE`` grammar the ``defaulted_true_by_
-  coalesce`` guard reasons about, where a clear is meant to imply preservation. It does not
-  generate the column-level ``COALESCE(b.col, 0) = x`` idiom, whose permissive clear is a
+  The wrappers stay inside the comparison-plus-``COALESCE`` grammar the ``defaulted_true_by_
+  coalesce`` guard reasons about, where a clear is meant to imply preservation. They do not
+  include the column-level ``COALESCE(b.col, 0) = x`` idiom, whose permissive clear is a
   deliberate "the analyst handled the null" call rather than a preservation claim (see
   ``guards.is_coalesced``); that idiom's contract is not "the join is preserved".
 """
@@ -172,30 +174,41 @@ def test_inner_flatten_clear_implies_no_parent_row_dropped(
 # --- soundness of the where-inversion clear ----------------------------------------------
 
 
+# The closed set of predicate shapes wrapping a null-intolerant comparison ``cmp`` on the
+# optional side. Each fixes how an unmatched-row NULL is treated, and thus whether the LEFT
+# JOIN's unmatched rows survive. The wrap axis is enumerated, not sampled: it is closed and the
+# guard must decide every member. `bare` and `coalesce(cmp, false)` drop the padded rows;
+# `coalesce(cmp, true)` (bare, or under a top-level AND) keeps them; `coalesce(cmp, a.v > 0)`
+# defers to the preserved side. The last two are the soundness traps -- a defaulted TRUE that a
+# NOT or a re-comparison flips back into a drop -- which a clear must not silence.
+_WHERE_WRAPS: tuple[str, ...] = (
+    "{cmp}",
+    "coalesce({cmp}, true)",
+    "coalesce({cmp}, false)",
+    "coalesce({cmp}, a.v > 0)",
+    "coalesce({cmp}, true) and a.k >= 0",
+    "not coalesce({cmp}, true)",
+    "coalesce({cmp}, true) = false",
+)
+
+
 @dataclass(frozen=True, slots=True)
-class WhereScenario:
+class WhereData:
     a_rows: tuple[tuple[int, int], ...]
     b_rows: tuple[tuple[int, int], ...]
-    predicate: str
+    threshold: int
 
 
 @st.composite
-def _where_scenario(draw: st.DrawFn) -> WhereScenario:
+def _where_data(draw: st.DrawFn) -> WhereData:
     n = draw(st.integers(min_value=2, max_value=5))
     a_rows = tuple((k, draw(st.integers(min_value=-2, max_value=3))) for k in range(n))
     # A strict subset of a's keys match, so at least one a row is unmatched and the WHERE's
     # effect on padded rows is observable.
     matched = draw(st.lists(st.integers(min_value=0, max_value=n - 1), unique=True, max_size=n - 1))
     b_rows = tuple((k, draw(st.integers(min_value=-2, max_value=3))) for k in matched)
-    cmp = f"b.v > {draw(st.integers(min_value=-2, max_value=3))}"
-    wrap = draw(st.sampled_from(["bare", "coalesce_true", "coalesce_false", "coalesce_expr"]))
-    predicate = {
-        "bare": cmp,
-        "coalesce_true": f"coalesce({cmp}, true)",
-        "coalesce_false": f"coalesce({cmp}, false)",
-        "coalesce_expr": f"coalesce({cmp}, a.v > 0)",
-    }[wrap]
-    return WhereScenario(a_rows, b_rows, predicate)
+    threshold = draw(st.integers(min_value=-2, max_value=3))
+    return WhereData(a_rows, b_rows, threshold)
 
 
 @pytest.fixture(scope="session")
@@ -207,22 +220,25 @@ def con() -> Iterator[duckdb.DuckDBPyConnection]:
         connection.close()
 
 
-@given(s=_where_scenario())
-@settings(max_examples=300, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+@pytest.mark.parametrize("wrap", _WHERE_WRAPS, ids=lambda w: w.replace("{cmp}", "cmp"))
+@given(d=_where_data())
+@settings(max_examples=60, deadline=None, suppress_health_check=[HealthCheck.too_slow])
 def test_where_clear_implies_unmatched_rows_survive(
-    con: duckdb.DuckDBPyConnection, s: WhereScenario
+    con: duckdb.DuckDBPyConnection, wrap: str, d: WhereData
 ) -> None:
     """If the detector clears the predicate, the LEFT JOIN keeps every unmatched row when the
     query actually runs. The data is the judge, so clearing a predicate that silently drops
-    unmatched rows fails here."""
+    unmatched rows -- including a ``coalesce(cmp, true)`` a ``NOT`` or a ``= false`` turns back
+    into a drop -- fails here against ground truth rather than against a re-derivation."""
+    predicate = wrap.replace("{cmp}", f"b.v > {d.threshold}")
     model_sql = (
         "select a.k as ak, a.v as av, b.k as bk, b.v as bv "
-        f"from a left join b on a.k = b.k where {s.predicate}"
+        f"from a left join b on a.k = b.k where {predicate}"
     )
     cleared = (
         len(detect_where_on_outer_joined_nullable(sqlglot.parse_one(model_sql, read="duckdb"))) == 0
     )
-    tables = [("a", ("k", "v"), s.a_rows), ("b", ("k", "v"), s.b_rows)]
+    tables = [("a", ("k", "v"), d.a_rows), ("b", ("k", "v"), d.b_rows)]
     with materialized(con, tables, model_sql) as c:
         dropped_unmatched = scalar(
             c,
@@ -232,5 +248,5 @@ def test_where_clear_implies_unmatched_rows_survive(
     if cleared:
         assert dropped_unmatched == 0, (
             f"detector cleared but {dropped_unmatched} unmatched rows were dropped by "
-            f"where {s.predicate!r} (a={s.a_rows}, b={s.b_rows})"
+            f"where {predicate!r} (a={d.a_rows}, b={d.b_rows})"
         )


### PR DESCRIPTION
Two structural-detector precision fixes surfaced by the #125 real-project calibration against Wikimedia's Spark project, where five findings were false positives. Both are test-first and reuse existing machinery rather than adding parallel logic.

## `inner_flatten_row_drop`: clear a provably non-empty array in every spelling

The non-emptiness clear applies to every flatten spelling, not only `UNNEST`. `_flatten_operands` reads the array off whichever arm the dialect produces (explode/posexplode/inline via `this`, Snowflake `FLATTEN` via its `input` kwarg, `UNNEST` via `expressions`), and the existing `array_literal_nonempty` / `generator_provably_nonempty` vocabulary runs on the join arm and the Spark `LATERAL VIEW explode(...)` branch alike. So `EXPLODE(ARRAY('mobile','other'))` clears exactly as `UNNEST(ARRAY[...])` does, and the standard category cross-tab idiom reads as row-preserving under every dialect.

A column array still fires (it can be empty); a literal array or a literal-bounded generator clears. Soundness is preserved: a spelling whose array cannot be located returns `None` and stays firing, so a missed proof over-fires and never silences a real row drop.

## `where_on_outer_joined_nullable`: recognise a COALESCE around the whole comparison

`coalesce(reverted.user <> r.user, true)` defaults the unmatched-row NULL to a kept value, so the outer join is not inverted. The detector clears the comparison through `guards.defaulted_true_by_coalesce`, the comparison-level twin of the existing column-level COALESCE guard.

The clear is sound about both the default and its context. `coalesce(pred, false)` and a non-literal or fallback-position default keep firing, since the padding TRUE is not proven there. The defaulted TRUE must also reach the WHERE root through boolean AND/OR connectives: a `NOT` or a re-comparison (`coalesce(pred, true) = false`) turns the kept TRUE back into a drop, so those keep firing rather than being silenced.

## Tests

`test_patterns.py` pins the boundary examples (COALESCE-to-false and fallback-position comparisons still fire; a non-empty literal array clears under `UNNEST`, `LATERAL UNNEST`, and the Spark/Snowflake arms). `test_pbt_structural_hazards.py` carries three properties with teeth:

- **Dialect invariance** (parse-only, metamorphic): the same logical array flatten under `UNNEST`, `LATERAL VIEW EXPLODE`, and `LATERAL FLATTEN` yields the same finding count.
- **Inner-flatten clear soundness** (duckdb execution oracle): if the detector clears a flatten, materializing `t, UNNEST(arr)` drops no parent row, over an array grammar that reaches empty arrays.
- **Where-inversion clear soundness** (duckdb execution oracle): if the detector clears the predicate, the LEFT JOIN keeps every unmatched row. The wrapper axis is a closed set, enumerated rather than sampled, and includes the traps a defaulted TRUE still drops on (`coalesce(cmp, false)`, `not coalesce(cmp, true)`, `coalesce(cmp, true) = false`); the data around each wrapper is sampled.

## Effect

On the calibration corpus these drop Wikimedia's findings from 37 to 32, removing five false positives and no true positives (the `GENERATE_SERIES` spine with non-literal bounds and the four column-array explodes correctly still fire). Full gate green (ruff, format, pyright, pytest).

See `docs/current_state/calibration.md` (on the #125 branch) for the corpus and classification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)