### PR TITLE
fix(patterns): collapse null_group to one finding per GROUP BY clause

### DIFF
--- a/src/dblect/sql/patterns.py
+++ b/src/dblect/sql/patterns.py
@@ -223,6 +223,10 @@ def detect_null_group_after_outer_join(tree: Expr) -> tuple[Finding, ...]:
     buckets are the two booleans), or a ``COALESCE`` whose fallback the join keeps
     present (``coalesce(meta.key, base.key)`` recovers the preserved-side key). A
     ``COALESCE`` of two nullable sides still fires: the merged key can be NULL.
+
+    The GROUP BY clause is one decision site, so several offending targets in it yield
+    one finding naming every offending target, not one per column. Per-column emission
+    inflated a single grouping mistake into a burst of findings.
     """
     out: list[Finding] = []
     for sel in sg.find_all_selects(tree):
@@ -233,8 +237,10 @@ def detect_null_group_after_outer_join(tree: Expr) -> tuple[Finding, ...]:
         if g is None:
             continue
         nullable_fs = frozenset(nullable)
+        risky_tables: set[str] = set()
+        risky_targets: list[str] = []
         for grp_expr in g.expressions:
-            risky: set[str] = set()
+            hit: set[str] = set()
             for c in sg.find_columns(grp_expr):
                 table = sg.column_table(c)
                 if table is None or table not in nullable:
@@ -243,19 +249,23 @@ def detect_null_group_after_outer_join(tree: Expr) -> tuple[Finding, ...]:
                     c, until=grp_expr, nullable=nullable_fs
                 ):
                     continue
-                risky.add(table)
-            if risky:
-                tables = ", ".join(sorted(risky))
-                out.append(
-                    finding_at(
-                        FindingKind.NULL_GROUP_AFTER_OUTER_JOIN,
-                        message=(
-                            f"GROUP BY {sg.render_sql(grp_expr)} references column(s) from "
-                            f"nullable join side ({tables}); unmatched rows collapse into a NULL group"
-                        ),
-                        node=grp_expr,
-                    )
+                hit.add(table)
+            if hit:
+                risky_tables |= hit
+                risky_targets.append(sg.render_sql(grp_expr))
+        if risky_tables:
+            tables = ", ".join(sorted(risky_tables))
+            targets = ", ".join(risky_targets)
+            out.append(
+                finding_at(
+                    FindingKind.NULL_GROUP_AFTER_OUTER_JOIN,
+                    message=(
+                        f"GROUP BY {targets} references column(s) from nullable join side "
+                        f"({tables}); unmatched rows collapse into a NULL group"
+                    ),
+                    node=g,
                 )
+            )
     return tuple(out)
 
 

--- a/tests/sql/test_patterns.py
+++ b/tests/sql/test_patterns.py
@@ -169,6 +169,52 @@ def test_null_group_is_not_null_key_not_detected() -> None:
     assert detect_null_group_after_outer_join(_parse(sql)) == ()
 
 
+# --- GROUP BY on outer-joined nullable: one finding per clause, not per column (#125) ---
+
+
+def test_null_group_multiple_nullable_targets_collapse_to_one_finding() -> None:
+    # The GROUP BY clause is one decision site. Several nullable-side grouped targets are the
+    # same mistake seen N ways, so the detector emits one finding naming every offending
+    # target, rather than one per column (which inflated the corpus false-positive count).
+    sql = """
+    select b.x, b.y, b.z, count(*) as n
+    from a left join b on a.k = b.k
+    group by b.x, b.y, b.z
+    """
+    findings = detect_null_group_after_outer_join(_parse(sql))
+    assert len(findings) == 1
+    assert findings[0].kind is FindingKind.NULL_GROUP_AFTER_OUTER_JOIN
+    # Every offending target is named, so the single finding loses no information.
+    for target in ("b.x", "b.y", "b.z"):
+        assert target in findings[0].message
+
+
+def test_null_group_mixed_targets_reports_only_the_nullable_ones() -> None:
+    # A GROUP BY mixing a preserved-side key (a.k) with a nullable-side one (b.y) still fires
+    # once, and names only the target that actually collapses. The preserved key is not a
+    # hazard and must not appear as one.
+    sql = """
+    select a.k, b.y, count(*) as n
+    from a left join b on a.k = b.k
+    group by a.k, b.y
+    """
+    findings = detect_null_group_after_outer_join(_parse(sql))
+    assert len(findings) == 1
+    assert "b.y" in findings[0].message
+    assert "a.k" not in findings[0].message
+
+
+def test_null_group_collapsed_finding_spans_the_group_by_clause() -> None:
+    sql = (
+        "select b.x, b.y, count(*) as n\n"  # line 1
+        "from a\n"  # line 2
+        "left join b on a.k = b.k\n"  # line 3
+        "group by b.x, b.y\n"  # line 4
+    )
+    [finding] = detect_null_group_after_outer_join(_parse(sql))
+    assert (finding.line_start, finding.line_end) == (4, 4)
+
+
 # --- WHERE on outer-joined nullable: top-level OR-sibling rescue (#168) ---
 
 
@@ -610,6 +656,18 @@ def test_inner_unnest_duckdb_flagged(sql: str) -> None:
 def test_left_join_unnest_duckdb_not_flagged() -> None:
     sql = "select t.id, u.x from t left join unnest(t.arr) as u(x) on true"
     assert detect_inner_flatten_row_drop(_parse_d(sql, "duckdb")) == ()
+
+
+def test_inner_flatten_reports_one_finding_per_arm() -> None:
+    # Unlike GROUP BY (one decision site per clause), each flatten arm is its own location
+    # with its own inner-vs-outer fix, so two risky arms in one SELECT stay two findings.
+    # Each points at its own arm; collapsing them would lose the location and conflate two
+    # independent row-drop hazards.
+    sql = "select t.id, x, y from t, unnest(t.a) as x, unnest(t.b) as y"
+    findings = detect_inner_flatten_row_drop(_parse_d(sql, "duckdb"))
+    assert len(findings) == 2
+    # Each finding points at its own arm (the exact snippet rendering is incidental).
+    assert [any(arm in f.sql_snippet for f in findings) for arm in ("t.a", "t.b")] == [True, True]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
`null_group_after_outer_join` emitted one finding per offending grouped column, so a single grouping decision surfaced as a burst of findings. On the #125 calibration corpus, one `GROUP BY` site (`base_moderator_actions_logging`) produced nine findings, inflating the corpus false-positive count nine-fold for what is one decision.

## Change

The GROUP BY clause is one decision site. The detector now aggregates every offending nullable-side target and emits **one finding per clause**, naming each target so nothing is lost, anchored at the GROUP BY node. A single-target GROUP BY renders the same message as before (a one-element join is the bare expression), so existing single-column findings are byte-identical.

`inner_flatten_row_drop` deliberately stays **one finding per flatten arm**: unlike a GROUP BY clause, each arm (`FROM t, UNNEST(t.a)` vs `UNNEST(t.b)`, or two separate `LATERAL VIEW`s) is a distinct location with its own inner-vs-outer fix. Collapsing them would conflate independent row-drop hazards and lose the location. A test pins that per-arm contract.

## Tests

- A GROUP BY with three nullable-side targets yields one finding naming all three (was three findings).
- A mixed GROUP BY names only the nullable targets, not the preserved key.
- The collapsed finding spans the GROUP BY clause.
- `inner_flatten` with two risky arms stays two findings, each pointing at its own arm.

Full gate green (ruff, format, pyright, 1290 pytest).

This is a calibration follow-up from #125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)