### PR TITLE
release: PyPI publish workflow + reconcile 0.1.0 changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: release
+
+# Publishes to PyPI when a v* tag is pushed. The wheel and sdist are built on a
+# clean runner from the tagged commit, and upload uses PyPI Trusted Publishing
+# (OIDC): no API token is stored anywhere. The `pypi` environment matches the
+# trusted-publisher registration on PyPI and is the place to add a manual
+# approval gate if one is ever wanted.
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/dblect
+    permissions:
+      id-token: write # required for OIDC; this is what authorizes the upload
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build wheel and sdist
+        run: uv build
+
+      - name: Guard tag against the packaged version
+        # The tag drives the release, but the wheel's version comes from
+        # _version.py via hatchling. If they disagree the upload would ship a
+        # surprise, so require the built wheel to carry the tag's version and
+        # fail loudly before publishing a mismatch.
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          if [ ! -f "dist/dblect-${tag}-py3-none-any.whl" ]; then
+            echo "tag ${GITHUB_REF_NAME} has no matching wheel; built:" >&2
+            ls dist >&2
+            exit 1
+          fi
+
+      - name: Publish to PyPI
+        run: uv publish --trusted-publishing always


### PR DESCRIPTION
Two release-prep changes that both need to be on `main` before tagging `v0.1.0`.

## 1. PyPI publish workflow (`.github/workflows/release.yml`)
Follows the pending publisher already registered on PyPI (owner `dvryaboy`, repo `dblect`, workflow `release.yml`, environment `pypi`).
- Triggers on `push` of any `v*` tag.
- Builds wheel + sdist on a clean runner from the tagged commit (`uv build`).
- Uploads over **OIDC Trusted Publishing** (`uv publish --trusted-publishing always`) — no API token stored. `id-token: write` is the only elevated permission.
- **Version guard**: fails the run if the tag's version has no matching built wheel (`dist/dblect-<tag>-py3-none-any.whl`), keeping the tag and packaged `_version.py` in lockstep before upload.
- Runs under the `pypi` environment, a place to add a manual approval gate later.

## 2. Changelog reconciliation (`CHANGELOG.md`)
The `[0.1.0]` section was curated mid-development and missed ~20 user-facing PRs that landed since. Reconciled against the actual commit history and the built surface (verified adapter set, CLI commands, flags). Now covers SARIF output, `--base-manifest`, per-finding severity + `--fail-on`, issue codes, source-position back-mapping, target-path manifest resolution, catalog-backed init stubs, `dblect setup`/bootstrap skill, BigQuery validation + Postgres/Redshift/Snowflake profiles, the unified outer-join hazard cluster + cross-model fan-out, and the LIMIT/top-n determinism detectors. Since this is a first release, the internal pre-release Changed/Fixed churn folds into a comprehensive Added.

## After merge — the release
```
git checkout main && git pull
git tag -a v0.1.0 -m "dblect 0.1.0"
git push origin v0.1.0
```
The first run claims the `dblect` name and ships 0.1.0. Then create the GitHub release from the changelog:
```
gh release create v0.1.0 --title "v0.1.0" \
  --notes-file <(awk '/^## \[0.1.0\]/{f=1} f && /^\[[^]]+\]:/{exit} f' CHANGELOG.md)
```

## Note
The #125 calibration commits already landed on `main` before the release commit, so the shipped default severities are calibrated. The earlier plan to hold the tag for #125 is satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)