### PR TITLE
feat(uniqueness): derive candidate keys from QUALIFY ROW_NUMBER()=1 dedup (#216)

### DIFF
--- a/src/dblect/lineage/properties/uniqueness.py
+++ b/src/dblect/lineage/properties/uniqueness.py
@@ -816,6 +816,15 @@ class _RelationWalk:
         from_alias, from_carried = resolved
         combined = _qualify(from_alias, from_carried.keys)
 
+        # A ``ROW_NUMBER() ... = 1`` dedup keys the output on its partition columns. Where the
+        # window is evaluated decides when the key holds: one computed inside the FROM subquery
+        # (filtered by an outer guard) is a key of the from relation, so it joins the from-side
+        # keys and must survive join preservation; one this SELECT computes (inline in the guard
+        # or a projected alias) is evaluated over the post-join, post-group rows, so it unions in
+        # after those steps.
+        rn_postjoin, rn_fromside = _rownumber_keys(sel, from_node=from_.this, from_alias=from_alias)
+        combined |= rn_fromside
+
         # WHERE filters cannot add duplicates, so keys (and conditional keys) are
         # preserved across it; the WHERE is the predicate flow's concern, not ours.
         joins = sg.joins_of(sel)
@@ -840,10 +849,7 @@ class _RelationWalk:
             gk = _group_key(group, from_alias=from_alias)
             combined = gk if gk is not None else frozenset[_QKey]()
 
-        # A ``ROW_NUMBER() ... = 1`` dedup makes its partition columns a key of the
-        # post-filter relation, independent of what came before, so it unions in. QUALIFY
-        # runs after GROUP BY, so it applies over whatever ``combined`` now holds.
-        combined = combined | _rownumber_keys(sel, from_node=from_.this, from_alias=from_alias)
+        combined |= rn_postjoin
 
         projection = _Projection.build(sel, from_alias=from_alias)
         keys = _project(sel, combined, projection)
@@ -991,19 +997,21 @@ def _group_key(group: exp.Group, *, from_alias: str) -> frozenset[_QKey] | None:
     return None if key is None else frozenset({key})
 
 
-def _rownumber_keys(sel: exp.Select, *, from_node: Expr, from_alias: str) -> frozenset[_QKey]:
-    """Candidate keys the ``ROW_NUMBER() ... = 1`` dedup idiom introduces.
+def _rownumber_keys(
+    sel: exp.Select, *, from_node: Expr, from_alias: str
+) -> tuple[frozenset[_QKey], frozenset[_QKey]]:
+    """Keys the ``ROW_NUMBER() ... = 1`` dedup idiom introduces, split by where the window is
+    evaluated: ``(post_join, from_side)``.
 
     A relation filtered to the first row per ``PARTITION BY c1..cn`` keeps one row per
-    partition, so ``{c1..cn}`` is a candidate key of the output. The dedup guard lives in a
-    ``QUALIFY`` clause or an outer ``WHERE``; the window itself is inline in that guard
-    (``QUALIFY ROW_NUMBER() OVER (...) = 1``), named by a projection of this SELECT
-    (``QUALIFY rn = 1``), or named by a projection of the FROM subquery the guard filters
-    (``... FROM (SELECT ..., ROW_NUMBER() OVER (...) AS rn FROM t) WHERE rn = 1``). Each
-    recognised guard contributes the partition columns as a key qualified to the FROM
-    relation, which the projection then maps onto output names. A window that is projected
-    but never filtered grounds nothing (no dedup happened), and a partition-less window
-    (the empty key, whole-relation uniqueness) is skipped rather than modelled here.
+    partition, so ``{c1..cn}`` is a candidate key. The dedup guard lives in ``QUALIFY`` or an
+    outer ``WHERE``; the window is inline in that guard (``QUALIFY ROW_NUMBER() OVER (...) = 1``),
+    named by a projection of this SELECT (``QUALIFY rn = 1``), or named by a projection of the
+    FROM subquery the guard filters (``FROM (SELECT ..., ROW_NUMBER() ... AS rn FROM t) WHERE rn
+    = 1``). The first two see the post-join rows and land in ``post_join``; the subquery window
+    is computed before the outer join, so its key is only a key of the from relation and lands
+    in ``from_side`` for the caller to carry through join preservation. A window projected but
+    never filtered, and a partition-less window (the empty key), ground nothing.
     """
     guards: list[Expr] = []
     qualify = sg.qualify_of(sel)
@@ -1013,7 +1021,8 @@ def _rownumber_keys(sel: exp.Select, *, from_node: Expr, from_alias: str) -> fro
     if where is not None and isinstance(where.this, Expr):
         guards.extend(sg.conjunctive_leaves(where.this))
 
-    out: set[_QKey] = set()
+    post_join: set[_QKey] = set()
+    from_side: set[_QKey] = set()
     for leaf in guards:
         operand = sg.rank_one_guard_operand(leaf)
         if operand is None:
@@ -1021,58 +1030,58 @@ def _rownumber_keys(sel: exp.Select, *, from_node: Expr, from_alias: str) -> fro
         inline = sg.row_number_window(operand)
         if inline is not None:
             key = _bare_column_key(sg.partition_of(inline), from_alias=from_alias)
+            if key is not None:
+                post_join.add(key)
         elif isinstance(operand, exp.Column):
-            key = _named_rownumber_key(operand, sel=sel, from_node=from_node, from_alias=from_alias)
-        else:
-            key = None
-        if key is not None:
-            out.add(key)
-    return frozenset(out)
+            own = _same_select_rownumber_key(operand, sel=sel, from_alias=from_alias)
+            if own is not None:
+                post_join.add(own)
+            else:
+                sub = _subquery_rownumber_key(operand, from_node=from_node, from_alias=from_alias)
+                if sub is not None:
+                    from_side.add(sub)
+    return frozenset(post_join), frozenset(from_side)
 
 
-def _named_rownumber_key(
-    ref: exp.Column, *, sel: exp.Select, from_node: Expr, from_alias: str
+def _same_select_rownumber_key(
+    ref: exp.Column, *, sel: exp.Select, from_alias: str
 ) -> _QKey | None:
-    """The partition key of a ``ROW_NUMBER()`` window named by ``ref`` (an ``rn`` the guard
-    filters on), resolved against the projection that defines the name.
-
-    The window is either a projection of this SELECT (``QUALIFY rn = 1`` naming a select
-    alias) or a projection of the FROM subquery the guard filters. A same-select alias
-    partitions over this scope's own columns, so its key qualifies to ``from_alias``
-    directly. A subquery alias partitions over the subquery's inner columns, so each
-    partition column maps through the subquery's projection onto the output name the outer
-    scope references (``from_alias`` is that subquery's alias). ``None`` if ``ref`` names no
-    row-number window, or a partition column the relevant projection does not expose.
-    """
+    """Partition key of a ``ROW_NUMBER()`` window this SELECT projects as ``ref`` (``QUALIFY rn =
+    1`` naming a select alias). The window is evaluated over this scope's own (post-join) rows, so
+    its partition qualifies to ``from_alias``. ``None`` if ``ref`` is qualified or names no such
+    window."""
+    if sg.column_table(ref) is not None:
+        return None
+    own = _output_projections(sel)
     name = sg.column_name(ref).lower()
+    window = sg.row_number_window(own[name]) if own is not None and name in own else None
+    return _bare_column_key(sg.partition_of(window), from_alias=from_alias) if window else None
+
+
+def _subquery_rownumber_key(ref: exp.Column, *, from_node: Expr, from_alias: str) -> _QKey | None:
+    """Partition key of a ``ROW_NUMBER()`` window the FROM subquery projects as ``ref``, filtered
+    by an outer guard. The window runs inside the subquery, so the key is only a key of the from
+    relation. ``None`` if ``from_node`` is not that subquery, ``ref`` names no such window, or a
+    partition column it does not expose."""
     qualifier = sg.column_table(ref)
-    if qualifier is None:
-        own = _output_projections(sel)
-        window = sg.row_number_window(own[name]) if own is not None and name in own else None
-        if window is not None:
-            return _bare_column_key(sg.partition_of(window), from_alias=from_alias)
-    if isinstance(from_node, exp.Subquery) and qualifier in (None, from_alias):
-        inner = from_node.this
-        if isinstance(inner, exp.Select):
-            projs = _output_projections(inner)
-            window = (
-                sg.row_number_window(projs[name]) if projs is not None and name in projs else None
-            )
-            if window is not None:
-                return _subquery_partition_key(window, inner=inner, sub_alias=from_alias)
-    return None
+    if not isinstance(from_node, exp.Subquery) or qualifier not in (None, from_alias):
+        return None
+    inner = from_node.this
+    if not isinstance(inner, exp.Select):
+        return None
+    projs = _output_projections(inner)
+    name = sg.column_name(ref).lower()
+    window = sg.row_number_window(projs[name]) if projs is not None and name in projs else None
+    return _subquery_partition_key(window, inner=inner, sub_alias=from_alias) if window else None
 
 
 def _subquery_partition_key(
     window: exp.Window, *, inner: exp.Select, sub_alias: str
 ) -> _QKey | None:
-    """A subquery-aliased window's partition columns, lifted to the outer scope.
-
-    The partition columns name columns of ``inner``; the outer scope sees them only under
-    the output names ``inner`` projects them as, qualified by the subquery alias. Each
-    partition column maps through ``inner``'s projection onto an output name; ``None`` if a
-    partition column is not a bare column or ``inner`` does not project it (so the outer
-    scope cannot name it, and no key holds on the output)."""
+    """A subquery-aliased window's partition columns, lifted to the outer scope by mapping each
+    through ``inner``'s projection onto the output name (qualified by the subquery alias) the
+    outer scope references. ``None`` if a partition column is not a bare column or ``inner`` does
+    not project it, so the outer scope cannot name it and no key holds."""
     inner_from = sg.from_of(inner)
     if inner_from is None or not isinstance(inner_from.this, exp.Table | exp.Subquery):
         return None

--- a/src/dblect/lineage/properties/uniqueness.py
+++ b/src/dblect/lineage/properties/uniqueness.py
@@ -840,6 +840,11 @@ class _RelationWalk:
             gk = _group_key(group, from_alias=from_alias)
             combined = gk if gk is not None else frozenset[_QKey]()
 
+        # A ``ROW_NUMBER() ... = 1`` dedup makes its partition columns a key of the
+        # post-filter relation, independent of what came before, so it unions in. QUALIFY
+        # runs after GROUP BY, so it applies over whatever ``combined`` now holds.
+        combined = combined | _rownumber_keys(sel, from_node=from_.this, from_alias=from_alias)
+
         projection = _Projection.build(sel, from_alias=from_alias)
         keys = _project(sel, combined, projection)
         conditional: frozenset[ConditionalKey] = frozenset()
@@ -963,15 +968,128 @@ def _qualify(alias: str, keys: frozenset[Key]) -> frozenset[_QKey]:
     return frozenset(frozenset((alias, col) for col in key) for key in keys)
 
 
+def _bare_column_key(exprs: Collection[Expr], *, from_alias: str) -> _QKey | None:
+    """A key over a list of bare output columns, qualified to ``from_alias`` where a
+    column is unqualified. ``None`` for a shape with no nameable key: an empty list (no
+    columns to key on) or an entry that is not a plain column (positional or computed).
+    Column names stay in their source case, matching the projection's own key of
+    ``(table, name)``; case-folding of the output name is the projection's job."""
+    if not exprs:
+        return None
+    cols: list[_QCol] = []
+    for e in exprs:
+        if not isinstance(e, exp.Column):
+            return None
+        cols.append((sg.column_table(e) or from_alias, sg.column_name(e)))
+    return frozenset(cols)
+
+
 def _group_key(group: exp.Group, *, from_alias: str) -> frozenset[_QKey] | None:
     """The key a GROUP BY introduces, or ``None`` for a shape we cannot size
     (positional or expression group keys), which drops tracked keys."""
+    key = _bare_column_key(group.expressions, from_alias=from_alias)
+    return None if key is None else frozenset({key})
+
+
+def _rownumber_keys(sel: exp.Select, *, from_node: Expr, from_alias: str) -> frozenset[_QKey]:
+    """Candidate keys the ``ROW_NUMBER() ... = 1`` dedup idiom introduces.
+
+    A relation filtered to the first row per ``PARTITION BY c1..cn`` keeps one row per
+    partition, so ``{c1..cn}`` is a candidate key of the output. The dedup guard lives in a
+    ``QUALIFY`` clause or an outer ``WHERE``; the window itself is inline in that guard
+    (``QUALIFY ROW_NUMBER() OVER (...) = 1``), named by a projection of this SELECT
+    (``QUALIFY rn = 1``), or named by a projection of the FROM subquery the guard filters
+    (``... FROM (SELECT ..., ROW_NUMBER() OVER (...) AS rn FROM t) WHERE rn = 1``). Each
+    recognised guard contributes the partition columns as a key qualified to the FROM
+    relation, which the projection then maps onto output names. A window that is projected
+    but never filtered grounds nothing (no dedup happened), and a partition-less window
+    (the empty key, whole-relation uniqueness) is skipped rather than modelled here.
+    """
+    guards: list[Expr] = []
+    qualify = sg.qualify_of(sel)
+    if qualify is not None and isinstance(qualify.this, Expr):
+        guards.extend(sg.conjunctive_leaves(qualify.this))
+    where = sg.where_of(sel)
+    if where is not None and isinstance(where.this, Expr):
+        guards.extend(sg.conjunctive_leaves(where.this))
+
+    out: set[_QKey] = set()
+    for leaf in guards:
+        operand = sg.rank_one_guard_operand(leaf)
+        if operand is None:
+            continue
+        inline = sg.row_number_window(operand)
+        if inline is not None:
+            key = _bare_column_key(sg.partition_of(inline), from_alias=from_alias)
+        elif isinstance(operand, exp.Column):
+            key = _named_rownumber_key(operand, sel=sel, from_node=from_node, from_alias=from_alias)
+        else:
+            key = None
+        if key is not None:
+            out.add(key)
+    return frozenset(out)
+
+
+def _named_rownumber_key(
+    ref: exp.Column, *, sel: exp.Select, from_node: Expr, from_alias: str
+) -> _QKey | None:
+    """The partition key of a ``ROW_NUMBER()`` window named by ``ref`` (an ``rn`` the guard
+    filters on), resolved against the projection that defines the name.
+
+    The window is either a projection of this SELECT (``QUALIFY rn = 1`` naming a select
+    alias) or a projection of the FROM subquery the guard filters. A same-select alias
+    partitions over this scope's own columns, so its key qualifies to ``from_alias``
+    directly. A subquery alias partitions over the subquery's inner columns, so each
+    partition column maps through the subquery's projection onto the output name the outer
+    scope references (``from_alias`` is that subquery's alias). ``None`` if ``ref`` names no
+    row-number window, or a partition column the relevant projection does not expose.
+    """
+    name = sg.column_name(ref).lower()
+    qualifier = sg.column_table(ref)
+    if qualifier is None:
+        own = _output_projections(sel)
+        window = sg.row_number_window(own[name]) if own is not None and name in own else None
+        if window is not None:
+            return _bare_column_key(sg.partition_of(window), from_alias=from_alias)
+    if isinstance(from_node, exp.Subquery) and qualifier in (None, from_alias):
+        inner = from_node.this
+        if isinstance(inner, exp.Select):
+            projs = _output_projections(inner)
+            window = (
+                sg.row_number_window(projs[name]) if projs is not None and name in projs else None
+            )
+            if window is not None:
+                return _subquery_partition_key(window, inner=inner, sub_alias=from_alias)
+    return None
+
+
+def _subquery_partition_key(
+    window: exp.Window, *, inner: exp.Select, sub_alias: str
+) -> _QKey | None:
+    """A subquery-aliased window's partition columns, lifted to the outer scope.
+
+    The partition columns name columns of ``inner``; the outer scope sees them only under
+    the output names ``inner`` projects them as, qualified by the subquery alias. Each
+    partition column maps through ``inner``'s projection onto an output name; ``None`` if a
+    partition column is not a bare column or ``inner`` does not project it (so the outer
+    scope cannot name it, and no key holds on the output)."""
+    inner_from = sg.from_of(inner)
+    if inner_from is None or not isinstance(inner_from.this, exp.Table | exp.Subquery):
+        return None
+    inner_alias = inner_from.this.alias_or_name
+    inner_proj = _Projection.build(inner, from_alias=inner_alias)
+    partition = sg.partition_of(window)
+    if not partition:
+        return None
     cols: list[_QCol] = []
-    for g in group.expressions:
-        if not isinstance(g, exp.Column):
+    for p in partition:
+        if not isinstance(p, exp.Column):
             return None
-        cols.append((sg.column_table(g) or from_alias, sg.column_name(g)))
-    return frozenset({frozenset(cols)})
+        names = inner_proj.names_for((sg.column_table(p) or inner_alias, sg.column_name(p)))
+        if not names:
+            return None
+        cols.append((sub_alias, min(names)))
+    return frozenset(cols)
 
 
 def _output_names(sel: exp.Select) -> list[str]:

--- a/src/dblect/sql/_sqlglot.py
+++ b/src/dblect/sql/_sqlglot.py
@@ -130,6 +130,44 @@ def fn_of(w: exp.Window) -> Expr | None:
     return cast("Expr | None", w.this)
 
 
+def row_number_window(node: Expr) -> exp.Window | None:
+    """``node`` as a ``ROW_NUMBER() OVER (...)`` window, or ``None``.
+
+    ``ROW_NUMBER`` assigns a distinct rank within each partition, so ``= 1`` keeps
+    exactly one row per partition; ``RANK`` / ``DENSE_RANK`` share a rank across ties,
+    so several rows can carry rank 1 and the partition is not a key. Only ``RowNumber``
+    grounds the dedup key, so the match is on that node type alone.
+    """
+    if isinstance(node, exp.Window) and isinstance(node.this, exp.RowNumber):
+        return node
+    return None
+
+
+def _is_literal_one(node: Expr) -> bool:
+    return isinstance(node, exp.Literal) and not node.args.get("is_string") and node.this == "1"
+
+
+def rank_one_guard_operand(leaf: Expr) -> Expr | None:
+    """The operand a ``= 1`` / ``<= 1`` dedup guard constrains to the top rank, or ``None``.
+
+    Recognises ``X = 1``, ``1 = X``, ``X <= 1`` and ``1 >= X`` with a literal integer ``1``.
+    These are exactly the guards that select the first row per partition (a row number is
+    ``>= 1``, so ``<= 1`` coincides with ``= 1``). Every other comparison (``= 2``, ``< 3``,
+    ``> 1``, ``>= 1``, ``BETWEEN``) keeps more than the single top row, so it returns ``None``
+    and grounds no key. ``X`` is returned unevaluated for the caller to test as a window.
+    """
+    if isinstance(leaf, exp.EQ):
+        if _is_literal_one(leaf.expression):
+            return leaf.this
+        if _is_literal_one(leaf.this):
+            return leaf.expression
+    elif isinstance(leaf, exp.LTE) and _is_literal_one(leaf.expression):
+        return leaf.this  # X <= 1
+    elif isinstance(leaf, exp.GTE) and _is_literal_one(leaf.this):
+        return leaf.expression  # 1 >= X
+    return None
+
+
 def window_output_alias(w: exp.Window) -> str | None:
     """The SELECT-list alias a window is projected under (``rn`` in ``row_number() ... as rn``).
 
@@ -322,7 +360,7 @@ def equality_cols_on_alias(predicate: Expr, alias: str) -> frozenset[str] | None
     "can't simplify to a clean join-key" and conservatively skip.
     """
     cols: set[str] = set()
-    for leaf in _conjunctive_leaves(predicate):
+    for leaf in conjunctive_leaves(predicate):
         if not isinstance(leaf, exp.EQ):
             return None
         left = leaf.this
@@ -350,7 +388,7 @@ def equality_cols_by_alias(predicate: Expr) -> dict[str, frozenset[str]] | None:
     An alias maps to its columns only when it appears exactly once in every conjunct, the rule
     :func:`equality_cols_on_alias` enforces; aliases that fail it are simply absent.
     """
-    leaves = _conjunctive_leaves(predicate)
+    leaves = conjunctive_leaves(predicate)
     sides: list[tuple[tuple[str | None, str], tuple[str | None, str]]] = []
     for leaf in leaves:
         if not isinstance(leaf, exp.EQ):
@@ -381,7 +419,7 @@ def equality_literal_columns(predicate: Expr) -> tuple[exp.Column, ...]:
     conjunct does not poison the rest: each pin stands on its own conjunct).
     """
     out: list[exp.Column] = []
-    for leaf in _conjunctive_leaves(predicate):
+    for leaf in conjunctive_leaves(predicate):
         if not isinstance(leaf, exp.EQ):
             continue
         sides = (leaf.this, leaf.expression)
@@ -405,7 +443,7 @@ def equality_column_pairs(predicate: Expr) -> tuple[tuple[exp.Column, exp.Column
     for the literal-pin case. Non-equality and non-column leaves are skipped, each pair
     standing on its own conjunct."""
     out: list[tuple[exp.Column, exp.Column]] = []
-    for leaf in _conjunctive_leaves(predicate):
+    for leaf in conjunctive_leaves(predicate):
         if not isinstance(leaf, exp.EQ):
             continue
         left, right = leaf.this, leaf.expression
@@ -419,10 +457,10 @@ def equality_column_pairs(predicate: Expr) -> tuple[tuple[exp.Column, exp.Column
     return tuple(out)
 
 
-def _conjunctive_leaves(predicate: Expr) -> list[Expr]:
+def conjunctive_leaves(predicate: Expr) -> list[Expr]:
     """Flatten an ``AND``-only conjunction into its leaves; non-AND nodes are leaves."""
     if isinstance(predicate, exp.And):
-        return [*_conjunctive_leaves(predicate.this), *_conjunctive_leaves(predicate.expression)]
+        return [*conjunctive_leaves(predicate.this), *conjunctive_leaves(predicate.expression)]
     return [predicate]
 
 

--- a/src/dblect/sql/_sqlglot.py
+++ b/src/dblect/sql/_sqlglot.py
@@ -131,13 +131,9 @@ def fn_of(w: exp.Window) -> Expr | None:
 
 
 def row_number_window(node: Expr) -> exp.Window | None:
-    """``node`` as a ``ROW_NUMBER() OVER (...)`` window, or ``None``.
-
-    ``ROW_NUMBER`` assigns a distinct rank within each partition, so ``= 1`` keeps
-    exactly one row per partition; ``RANK`` / ``DENSE_RANK`` share a rank across ties,
-    so several rows can carry rank 1 and the partition is not a key. Only ``RowNumber``
-    grounds the dedup key, so the match is on that node type alone.
-    """
+    """``node`` as a ``ROW_NUMBER() OVER (...)`` window, or ``None``. Only ``ROW_NUMBER`` grounds
+    a dedup key: it ranks distinctly within a partition, so ``= 1`` keeps exactly one row, whereas
+    ``RANK`` / ``DENSE_RANK`` share a rank across ties and can keep several."""
     if isinstance(node, exp.Window) and isinstance(node.this, exp.RowNumber):
         return node
     return None
@@ -149,13 +145,9 @@ def _is_literal_one(node: Expr) -> bool:
 
 def rank_one_guard_operand(leaf: Expr) -> Expr | None:
     """The operand a ``= 1`` / ``<= 1`` dedup guard constrains to the top rank, or ``None``.
-
-    Recognises ``X = 1``, ``1 = X``, ``X <= 1`` and ``1 >= X`` with a literal integer ``1``.
-    These are exactly the guards that select the first row per partition (a row number is
-    ``>= 1``, so ``<= 1`` coincides with ``= 1``). Every other comparison (``= 2``, ``< 3``,
-    ``> 1``, ``>= 1``, ``BETWEEN``) keeps more than the single top row, so it returns ``None``
-    and grounds no key. ``X`` is returned unevaluated for the caller to test as a window.
-    """
+    Recognises ``X = 1``, ``1 = X``, ``X <= 1`` and ``1 >= X`` with a literal integer ``1`` (a
+    row number is ``>= 1``, so ``<= 1`` coincides with ``= 1``). Any other comparison keeps more
+    than the top row and grounds no key. ``X`` is returned unevaluated for the caller to test."""
     if isinstance(leaf, exp.EQ):
         if _is_literal_one(leaf.expression):
             return leaf.this

--- a/tests/lineage/test_pbt_uniqueness_soundness.py
+++ b/tests/lineage/test_pbt_uniqueness_soundness.py
@@ -159,13 +159,14 @@ class SourceSpec:
 
 @dataclass(frozen=True)
 class ModelSpec:
-    shape: str  # filter | inner_join | left_join | group_by | distinct
+    shape: str  # filter | inner_join | left_join | group_by | distinct | qualify
     select_cols: tuple[str, ...]
     left_join_col: str | None = None
     right_join_col: str | None = None
     filter_col: str | None = None
     filter_threshold: int | None = None
     group_cols: tuple[str, ...] | None = None
+    partition_cols: tuple[str, ...] | None = None
 
 
 @dataclass(frozen=True)
@@ -202,11 +203,21 @@ def _rows(draw: st.DrawFn, source: SourceSpec) -> tuple[tuple[int, ...], ...]:
 
 @st.composite
 def _scenario(draw: st.DrawFn) -> Scenario:
-    shape = draw(st.sampled_from(("filter", "inner_join", "left_join", "group_by", "distinct")))
+    shape = draw(
+        st.sampled_from(("filter", "inner_join", "left_join", "group_by", "distinct", "qualify"))
+    )
     is_join = shape in ("inner_join", "left_join")
     sources = (_S0, _S1) if is_join else (_S0,)
 
-    if is_join:
+    if shape == "qualify":
+        # Dedup s0 to one row per partition subset; the derived key is that subset.
+        part = tuple(
+            sorted(
+                draw(st.lists(st.sampled_from(_S0.columns), min_size=1, max_size=3, unique=True))
+            )
+        )
+        model = ModelSpec(shape=shape, select_cols=_S0.columns, partition_cols=part)
+    elif is_join:
         model = ModelSpec(
             shape=shape,
             select_cols=("k0", "a1"),
@@ -242,6 +253,13 @@ def _scenario_sql(m: ModelSpec) -> str:
         )
     if m.shape == "filter":
         return f"SELECT k0, a0 FROM s0 WHERE {m.filter_col} >= {m.filter_threshold}"
+    if m.shape == "qualify":
+        assert m.partition_cols is not None
+        cols = ", ".join(m.select_cols)
+        part = ", ".join(m.partition_cols)
+        return (
+            f"SELECT {cols} FROM s0 QUALIFY ROW_NUMBER() OVER (PARTITION BY {part} ORDER BY k0) = 1"
+        )
     assert m.group_cols is not None
     cols = ", ".join(m.group_cols)
     if m.shape == "group_by":

--- a/tests/lineage/test_uniqueness_rownumber.py
+++ b/tests/lineage/test_uniqueness_rownumber.py
@@ -3,23 +3,22 @@
 The ``QUALIFY ROW_NUMBER() OVER (PARTITION BY k) = 1`` pattern (and its subquery
 twin, a projected ``ROW_NUMBER() AS rn`` filtered by an outer ``WHERE rn = 1``) keeps
 one row per partition, so the partition columns are a candidate key of the output.
-These pin that rule at the propagation boundary and its soundness edges: only
-``ROW_NUMBER`` grounds it (``RANK`` / ``DENSE_RANK`` tie), only ``= 1`` / ``<= 1``
-ground it, only a partition that resolves to output columns grounds it, and only a
-window the query actually filters on grounds it.
 
-The property enumerates the guard-form x rank-function x comparator space over a
-random partition subset: the sound configurations derive exactly that subset as the
-key, and every unsound variant derives nothing. The source carries no declared key,
-so the rule under test is the only thing that can ground one.
+``test_rownumber_key_derivation_matches_the_contract`` enumerates the closed decision
+space (rank-function x guard-form x comparator x partition shape): the sound
+configurations derive exactly the partition subset, every unsound variant derives
+nothing. The standalone tests pin dimensions outside that grid (projection renaming, a
+qualified alias, an expression partition, a partition column absent from the output, an
+equality on an ordinary column) and the from-side/join boundary. Every model's source
+declares no key, so the rule under test is the only thing that can ground one.
 """
 
 from __future__ import annotations
 
+import itertools
 from dataclasses import dataclass
 
-from hypothesis import given
-from hypothesis import strategies as st
+import pytest
 
 from dblect.adapters import profile_for_adapter
 from dblect.lineage.builder import build_relation_graph
@@ -34,12 +33,12 @@ _MODEL = "model.test.deduped"
 _POOL = ("c0", "c1", "c2")  # every model projects all three, so a partition subset maps
 
 
-def _source() -> Node:
+def _source(unique_id: str = _RAW, name: str = "events") -> Node:
     return Node(
-        unique_id=_RAW,
-        name="events",
+        unique_id=unique_id,
+        name=name,
         resource_type=ResourceType.SOURCE,
-        fqn=("test", "events"),
+        fqn=("test", name),
         package_name="test",
         schema="raw",
         raw_code=None,
@@ -49,7 +48,7 @@ def _source() -> Node:
     )
 
 
-def _model(sql: str) -> Node:
+def _model(sql: str, *, deps: frozenset[str]) -> Node:
     return Node(
         unique_id=_MODEL,
         name="deduped",
@@ -61,17 +60,18 @@ def _model(sql: str) -> Node:
         compiled_code=sql,
         original_file_path=None,
         columns={},
-        depends_on=frozenset({_RAW}),
+        depends_on=deps,
     )
 
 
-def _keys(sql: str) -> frozenset[Key]:
-    """The model's inferred candidate keys. The source declares none, so any key here
-    is one the SQL proves."""
+def _keys(sql: str, *extra_sources: Node) -> frozenset[Key]:
+    """The model's inferred candidate keys. The sources declare none, so any key here is one
+    the SQL proves. Extra sources model additional FROM/JOIN relations (each keyless)."""
+    model = _model(sql, deps=frozenset({_RAW, *(s.unique_id for s in extra_sources)}))
     manifest = Manifest(
         schema_version="v12",
         adapter_type="duckdb",
-        nodes={n.unique_id: n for n in (_source(), _model(sql))},
+        nodes={n.unique_id: n for n in (_source(), *extra_sources, model)},
     )
     anns = propagate(build_relation_graph(manifest).graph, uniqueness_property(manifest, _DUCKDB))
     return next(ann.value.keys for ref, ann in anns.items() if ref.unique_id == _MODEL)
@@ -81,45 +81,17 @@ def _key(*cols: str) -> Key:
     return frozenset(cols)
 
 
-# --- canonical forms --------------------------------------------------------------
-
-
-def test_qualify_inline_grounds_the_partition_key() -> None:
-    sql = (
-        "SELECT c0, c1, c2 FROM events QUALIFY ROW_NUMBER() OVER (PARTITION BY c1 ORDER BY c0) = 1"
-    )
-    assert _keys(sql) == {_key("c1")}
-
-
-def test_qualify_named_grounds_the_partition_key() -> None:
-    sql = (
-        "SELECT c0, c1, c2, ROW_NUMBER() OVER (PARTITION BY c1, c2 ORDER BY c0) AS rn "
-        "FROM events QUALIFY rn = 1"
-    )
-    assert _keys(sql) == {_key("c1", "c2")}
-
-
-def test_subquery_where_grounds_the_partition_key() -> None:
-    sql = (
-        "SELECT c0, c1, c2 FROM ("
-        "SELECT c0, c1, c2, ROW_NUMBER() OVER (PARTITION BY c1 ORDER BY c0) AS rn FROM events"
-        ") sub WHERE rn = 1"
-    )
-    assert _keys(sql) == {_key("c1")}
+# --- dimensions outside the enumerated grid ---------------------------------------
 
 
 def test_subquery_where_qualified_alias_grounds_the_partition_key() -> None:
+    """The outer guard may qualify the alias (``sub.rn``), not only bare ``rn``."""
     sql = (
         "SELECT c0, c1, c2 FROM ("
         "SELECT c0, c1, c2, ROW_NUMBER() OVER (PARTITION BY c2 ORDER BY c0) AS rn FROM events"
         ") sub WHERE sub.rn = 1"
     )
     assert _keys(sql) == {_key("c2")}
-
-
-def test_le_one_guard_grounds_the_partition_key() -> None:
-    sql = "SELECT c0, c1, c2 FROM events QUALIFY ROW_NUMBER() OVER (PARTITION BY c1) <= 1"
-    assert _keys(sql) == {_key("c1")}
 
 
 def test_partition_key_renames_through_the_projection() -> None:
@@ -129,46 +101,6 @@ def test_partition_key_renames_through_the_projection() -> None:
         "QUALIFY ROW_NUMBER() OVER (PARTITION BY c1 ORDER BY c0) = 1"
     )
     assert _keys(sql) == {_key("grp")}
-
-
-# --- soundness edges: no key ------------------------------------------------------
-
-
-def test_rank_grounds_no_key() -> None:
-    """Ties under RANK yield several rows at rank 1, so the partition is not a key."""
-    sql = "SELECT c0, c1, c2 FROM events QUALIFY RANK() OVER (PARTITION BY c1 ORDER BY c0) = 1"
-    assert _keys(sql) == frozenset()
-
-
-def test_dense_rank_grounds_no_key() -> None:
-    sql = (
-        "SELECT c0, c1, c2 FROM events QUALIFY DENSE_RANK() OVER (PARTITION BY c1 ORDER BY c0) = 1"
-    )
-    assert _keys(sql) == frozenset()
-
-
-def test_threshold_two_grounds_no_key() -> None:
-    sql = "SELECT c0, c1, c2 FROM events QUALIFY ROW_NUMBER() OVER (PARTITION BY c1) = 2"
-    assert _keys(sql) == frozenset()
-
-
-def test_greater_than_one_grounds_no_key() -> None:
-    """``> 1`` keeps every row past the first per partition, not a single one."""
-    sql = "SELECT c0, c1, c2 FROM events QUALIFY ROW_NUMBER() OVER (PARTITION BY c1) > 1"
-    assert _keys(sql) == frozenset()
-
-
-def test_partitionless_row_number_grounds_no_key() -> None:
-    """A partition-less ``ROW_NUMBER() = 1`` selects one row for the whole relation (the
-    empty key). We skip that strictly-stronger statement rather than model it here."""
-    sql = "SELECT c0, c1, c2 FROM events QUALIFY ROW_NUMBER() OVER (ORDER BY c0) = 1"
-    assert _keys(sql) == frozenset()
-
-
-def test_projected_but_unfiltered_row_number_grounds_no_key() -> None:
-    """A ``ROW_NUMBER()`` computed but never filtered does not dedup anything."""
-    sql = "SELECT c0, c1, c2, ROW_NUMBER() OVER (PARTITION BY c1 ORDER BY c0) AS rn FROM events"
-    assert _keys(sql) == frozenset()
 
 
 def test_partition_on_expression_grounds_no_key() -> None:
@@ -189,17 +121,33 @@ def test_plain_equality_on_a_non_window_column_grounds_no_key() -> None:
     assert _keys(sql) == frozenset()
 
 
-# --- property: the guard-form x rank-function x comparator space -------------------
+def test_subquery_dedup_key_drops_across_a_fanning_join() -> None:
+    """The subquery window is computed before the outer join, so the outer ``WHERE rn = 1``
+    dedups the subquery yet a fanning join to a keyless target re-multiplies it. The partition
+    is a key of the subquery, not of the joined output, so the derived key must ride through
+    join preservation rather than bypass it: no key holds here. The inline-QUALIFY twin, whose
+    window sees the post-join rows, stays keyed and is covered by the enumeration."""
+    sql = (
+        "SELECT sub.c1 AS c1, t.x AS x FROM ("
+        "SELECT c0, c1, ROW_NUMBER() OVER (PARTITION BY c1 ORDER BY c0) AS rn FROM events"
+        ") sub JOIN other t ON sub.c1 = t.c1 WHERE sub.rn = 1"
+    )
+    assert _keys(sql, _source("source.test.raw.other", "other")) == frozenset()
+
+
+# --- enumeration: rank-function x guard-form x comparator x partition shape --------
 
 _RANK_FNS = ("ROW_NUMBER", "RANK", "DENSE_RANK")
 _FILTERED_FORMS = ("qualify_inline", "qualify_named", "subquery_where")
+_FORMS = (*_FILTERED_FORMS, "unfiltered")
 _COMPARATORS = ("= 1", "<= 1", "= 2", "> 1", "< 3", ">= 1")
+_PARTITIONS = ((), ("c1",), ("c1", "c2"))  # empty (whole-relation), single, multi
 
 
 @dataclass(frozen=True)
 class _Config:
     rank_fn: str
-    form: str  # qualify_inline | qualify_named | subquery_where | unfiltered
+    form: str
     comparator: str
     partition: tuple[str, ...]  # empty means partition-less
 
@@ -234,22 +182,17 @@ class _Config:
         return f"SELECT {cols}, {window} AS rn FROM events"
 
 
-@st.composite
-def _configs(draw: st.DrawFn) -> _Config:
-    partition = tuple(
-        sorted(draw(st.lists(st.sampled_from(_POOL), min_size=0, max_size=3, unique=True)))
-    )
-    return _Config(
-        rank_fn=draw(st.sampled_from(_RANK_FNS)),
-        form=draw(st.sampled_from((*_FILTERED_FORMS, "unfiltered"))),
-        comparator=draw(st.sampled_from(_COMPARATORS)),
-        partition=partition,
-    )
+_CONFIGS = [
+    _Config(rank_fn=r, form=f, comparator=c, partition=p)
+    for r, f, c, p in itertools.product(_RANK_FNS, _FORMS, _COMPARATORS, _PARTITIONS)
+]
 
 
-@given(config=_configs())
+@pytest.mark.parametrize(
+    "config", _CONFIGS, ids=lambda c: f"{c.rank_fn}-{c.form}{c.comparator}-p{len(c.partition)}"
+)
 def test_rownumber_key_derivation_matches_the_contract(config: _Config) -> None:
-    """A ROW_NUMBER dedup on a non-empty partition, guarded by ``= 1`` / ``<= 1`` in any of
-    the filtered forms, derives exactly the partition key; every other configuration derives
-    nothing. The source declares no key, so the rule under test is the only key source."""
+    """A ROW_NUMBER dedup on a non-empty partition, guarded by ``= 1`` / ``<= 1`` in any of the
+    filtered forms, derives exactly the partition key; every other configuration derives
+    nothing."""
     assert _keys(config.sql()) == config.expected

--- a/tests/lineage/test_uniqueness_rownumber.py
+++ b/tests/lineage/test_uniqueness_rownumber.py
@@ -1,0 +1,255 @@
+"""Candidate keys from the ``ROW_NUMBER() ... = 1`` dedup idiom.
+
+The ``QUALIFY ROW_NUMBER() OVER (PARTITION BY k) = 1`` pattern (and its subquery
+twin, a projected ``ROW_NUMBER() AS rn`` filtered by an outer ``WHERE rn = 1``) keeps
+one row per partition, so the partition columns are a candidate key of the output.
+These pin that rule at the propagation boundary and its soundness edges: only
+``ROW_NUMBER`` grounds it (``RANK`` / ``DENSE_RANK`` tie), only ``= 1`` / ``<= 1``
+ground it, only a partition that resolves to output columns grounds it, and only a
+window the query actually filters on grounds it.
+
+The property enumerates the guard-form x rank-function x comparator space over a
+random partition subset: the sound configurations derive exactly that subset as the
+key, and every unsound variant derives nothing. The source carries no declared key,
+so the rule under test is the only thing that can ground one.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from dblect.adapters import profile_for_adapter
+from dblect.lineage.builder import build_relation_graph
+from dblect.lineage.properties.uniqueness import Key, uniqueness_property
+from dblect.lineage.property import propagate
+from dblect.manifest import Manifest, Node, ResourceType
+
+_DUCKDB = profile_for_adapter("duckdb")
+
+_RAW = "source.test.raw.events"
+_MODEL = "model.test.deduped"
+_POOL = ("c0", "c1", "c2")  # every model projects all three, so a partition subset maps
+
+
+def _source() -> Node:
+    return Node(
+        unique_id=_RAW,
+        name="events",
+        resource_type=ResourceType.SOURCE,
+        fqn=("test", "events"),
+        package_name="test",
+        schema="raw",
+        raw_code=None,
+        compiled_code=None,
+        original_file_path=None,
+        columns={},
+    )
+
+
+def _model(sql: str) -> Node:
+    return Node(
+        unique_id=_MODEL,
+        name="deduped",
+        resource_type=ResourceType.MODEL,
+        fqn=("test", "deduped"),
+        package_name="test",
+        schema="analytics",
+        raw_code=sql,
+        compiled_code=sql,
+        original_file_path=None,
+        columns={},
+        depends_on=frozenset({_RAW}),
+    )
+
+
+def _keys(sql: str) -> frozenset[Key]:
+    """The model's inferred candidate keys. The source declares none, so any key here
+    is one the SQL proves."""
+    manifest = Manifest(
+        schema_version="v12",
+        adapter_type="duckdb",
+        nodes={n.unique_id: n for n in (_source(), _model(sql))},
+    )
+    anns = propagate(build_relation_graph(manifest).graph, uniqueness_property(manifest, _DUCKDB))
+    return next(ann.value.keys for ref, ann in anns.items() if ref.unique_id == _MODEL)
+
+
+def _key(*cols: str) -> Key:
+    return frozenset(cols)
+
+
+# --- canonical forms --------------------------------------------------------------
+
+
+def test_qualify_inline_grounds_the_partition_key() -> None:
+    sql = (
+        "SELECT c0, c1, c2 FROM events QUALIFY ROW_NUMBER() OVER (PARTITION BY c1 ORDER BY c0) = 1"
+    )
+    assert _keys(sql) == {_key("c1")}
+
+
+def test_qualify_named_grounds_the_partition_key() -> None:
+    sql = (
+        "SELECT c0, c1, c2, ROW_NUMBER() OVER (PARTITION BY c1, c2 ORDER BY c0) AS rn "
+        "FROM events QUALIFY rn = 1"
+    )
+    assert _keys(sql) == {_key("c1", "c2")}
+
+
+def test_subquery_where_grounds_the_partition_key() -> None:
+    sql = (
+        "SELECT c0, c1, c2 FROM ("
+        "SELECT c0, c1, c2, ROW_NUMBER() OVER (PARTITION BY c1 ORDER BY c0) AS rn FROM events"
+        ") sub WHERE rn = 1"
+    )
+    assert _keys(sql) == {_key("c1")}
+
+
+def test_subquery_where_qualified_alias_grounds_the_partition_key() -> None:
+    sql = (
+        "SELECT c0, c1, c2 FROM ("
+        "SELECT c0, c1, c2, ROW_NUMBER() OVER (PARTITION BY c2 ORDER BY c0) AS rn FROM events"
+        ") sub WHERE sub.rn = 1"
+    )
+    assert _keys(sql) == {_key("c2")}
+
+
+def test_le_one_guard_grounds_the_partition_key() -> None:
+    sql = "SELECT c0, c1, c2 FROM events QUALIFY ROW_NUMBER() OVER (PARTITION BY c1) <= 1"
+    assert _keys(sql) == {_key("c1")}
+
+
+def test_partition_key_renames_through_the_projection() -> None:
+    """The key rests on output names: a partition column aliased out is keyed by its alias."""
+    sql = (
+        "SELECT c0, c1 AS grp, c2 FROM events "
+        "QUALIFY ROW_NUMBER() OVER (PARTITION BY c1 ORDER BY c0) = 1"
+    )
+    assert _keys(sql) == {_key("grp")}
+
+
+# --- soundness edges: no key ------------------------------------------------------
+
+
+def test_rank_grounds_no_key() -> None:
+    """Ties under RANK yield several rows at rank 1, so the partition is not a key."""
+    sql = "SELECT c0, c1, c2 FROM events QUALIFY RANK() OVER (PARTITION BY c1 ORDER BY c0) = 1"
+    assert _keys(sql) == frozenset()
+
+
+def test_dense_rank_grounds_no_key() -> None:
+    sql = (
+        "SELECT c0, c1, c2 FROM events QUALIFY DENSE_RANK() OVER (PARTITION BY c1 ORDER BY c0) = 1"
+    )
+    assert _keys(sql) == frozenset()
+
+
+def test_threshold_two_grounds_no_key() -> None:
+    sql = "SELECT c0, c1, c2 FROM events QUALIFY ROW_NUMBER() OVER (PARTITION BY c1) = 2"
+    assert _keys(sql) == frozenset()
+
+
+def test_greater_than_one_grounds_no_key() -> None:
+    """``> 1`` keeps every row past the first per partition, not a single one."""
+    sql = "SELECT c0, c1, c2 FROM events QUALIFY ROW_NUMBER() OVER (PARTITION BY c1) > 1"
+    assert _keys(sql) == frozenset()
+
+
+def test_partitionless_row_number_grounds_no_key() -> None:
+    """A partition-less ``ROW_NUMBER() = 1`` selects one row for the whole relation (the
+    empty key). We skip that strictly-stronger statement rather than model it here."""
+    sql = "SELECT c0, c1, c2 FROM events QUALIFY ROW_NUMBER() OVER (ORDER BY c0) = 1"
+    assert _keys(sql) == frozenset()
+
+
+def test_projected_but_unfiltered_row_number_grounds_no_key() -> None:
+    """A ``ROW_NUMBER()`` computed but never filtered does not dedup anything."""
+    sql = "SELECT c0, c1, c2, ROW_NUMBER() OVER (PARTITION BY c1 ORDER BY c0) AS rn FROM events"
+    assert _keys(sql) == frozenset()
+
+
+def test_partition_on_expression_grounds_no_key() -> None:
+    """A partition on an expression, not a bare output column, has no nameable key."""
+    sql = "SELECT c0, c1, c2 FROM events QUALIFY ROW_NUMBER() OVER (PARTITION BY c1 + c2) = 1"
+    assert _keys(sql) == frozenset()
+
+
+def test_partition_column_absent_from_output_grounds_no_key() -> None:
+    """Dedup on ``c1`` but ``c1`` is not projected: the key cannot be named on the output."""
+    sql = "SELECT c0, c2 FROM events QUALIFY ROW_NUMBER() OVER (PARTITION BY c1 ORDER BY c0) = 1"
+    assert _keys(sql) == frozenset()
+
+
+def test_plain_equality_on_a_non_window_column_grounds_no_key() -> None:
+    """A ``WHERE status = 1`` on an ordinary column is not a dedup guard."""
+    sql = "SELECT c0, c1, c2 FROM events WHERE c1 = 1"
+    assert _keys(sql) == frozenset()
+
+
+# --- property: the guard-form x rank-function x comparator space -------------------
+
+_RANK_FNS = ("ROW_NUMBER", "RANK", "DENSE_RANK")
+_FILTERED_FORMS = ("qualify_inline", "qualify_named", "subquery_where")
+_COMPARATORS = ("= 1", "<= 1", "= 2", "> 1", "< 3", ">= 1")
+
+
+@dataclass(frozen=True)
+class _Config:
+    rank_fn: str
+    form: str  # qualify_inline | qualify_named | subquery_where | unfiltered
+    comparator: str
+    partition: tuple[str, ...]  # empty means partition-less
+
+    @property
+    def sound(self) -> bool:
+        return (
+            self.rank_fn == "ROW_NUMBER"
+            and self.form in _FILTERED_FORMS
+            and self.comparator in ("= 1", "<= 1")
+            and len(self.partition) > 0
+        )
+
+    @property
+    def expected(self) -> frozenset[Key]:
+        return frozenset({frozenset(self.partition)}) if self.sound else frozenset()
+
+    def sql(self) -> str:
+        cols = ", ".join(_POOL)
+        part = ", ".join(self.partition)
+        over = f"OVER (PARTITION BY {part} ORDER BY c0)" if self.partition else "OVER (ORDER BY c0)"
+        window = f"{self.rank_fn}() {over}"
+        if self.form == "qualify_inline":
+            return f"SELECT {cols} FROM events QUALIFY {window} {self.comparator}"
+        if self.form == "qualify_named":
+            return f"SELECT {cols}, {window} AS rn FROM events QUALIFY rn {self.comparator}"
+        if self.form == "subquery_where":
+            return (
+                f"SELECT {cols} FROM (SELECT {cols}, {window} AS rn FROM events) sub "
+                f"WHERE rn {self.comparator}"
+            )
+        # unfiltered: the window is projected but no clause filters it.
+        return f"SELECT {cols}, {window} AS rn FROM events"
+
+
+@st.composite
+def _configs(draw: st.DrawFn) -> _Config:
+    partition = tuple(
+        sorted(draw(st.lists(st.sampled_from(_POOL), min_size=0, max_size=3, unique=True)))
+    )
+    return _Config(
+        rank_fn=draw(st.sampled_from(_RANK_FNS)),
+        form=draw(st.sampled_from((*_FILTERED_FORMS, "unfiltered"))),
+        comparator=draw(st.sampled_from(_COMPARATORS)),
+        partition=partition,
+    )
+
+
+@given(config=_configs())
+def test_rownumber_key_derivation_matches_the_contract(config: _Config) -> None:
+    """A ROW_NUMBER dedup on a non-empty partition, guarded by ``= 1`` / ``<= 1`` in any of
+    the filtered forms, derives exactly the partition key; every other configuration derives
+    nothing. The source declares no key, so the rule under test is the only key source."""
+    assert _keys(config.sql()) == config.expected

--- a/tests/uniqueness/test_cross_model_fanout.py
+++ b/tests/uniqueness/test_cross_model_fanout.py
@@ -282,3 +282,61 @@ def test_sum_grouped_to_unique_bucket_is_silent() -> None:
     )
     manifest = _shop(items_unique_on="item_id", mart_sql=mart_sql)
     assert _findings(manifest, _MART) == ()
+
+
+# --- acceptance: a window-deduped dimension key reaches the cross-model consumer -----------
+#
+# The end-to-end payoff of deriving a key from ``QUALIFY ROW_NUMBER() = 1``. A dimension is
+# deduped to one row per key by the window idiom, so a staging model joining to it on that key
+# cannot fan out and stays keyed at the order grain; the downstream ``SUM(amount)`` then reads
+# one row per order and does not double count. The derived key flows through the join
+# preservation rule into the consumer's grain check. Swapping ``ROW_NUMBER`` for ``RANK``
+# removes the key (ties break it), the join can fan out, and the same ``SUM`` fires: the
+# derived key is exactly what clears the finding.
+
+_REGIONS = "source.shop.raw.regions"
+_DIM = "model.shop.dim_region_latest"
+_STG_ORDERS = "model.shop.stg_orders"
+_REV = "model.shop.region_revenue"
+
+_STG_ORDERS_SQL = (
+    "SELECT o.order_id, o.amount, d.region "
+    "FROM orders o JOIN dim_region_latest d ON o.region_id = d.region_id"
+)
+_REV_SQL = "SELECT order_id, SUM(amount) AS total FROM stg_orders GROUP BY order_id"
+
+
+def _dim_sql(rank_fn: str) -> str:
+    return (
+        f"SELECT region_id, region FROM regions "
+        f"QUALIFY {rank_fn}() OVER (PARTITION BY region_id ORDER BY region) = 1"
+    )
+
+
+def _revenue_manifest(rank_fn: str) -> Manifest:
+    nodes = [
+        _source(_ORDERS),
+        _unique("test.shop.orders_pk", column="order_id", target=_ORDERS),
+        _source(_REGIONS),  # regions carries no declared key: only the dedup can prove one
+        _model(_DIM, _dim_sql(rank_fn)),
+        _model(_STG_ORDERS, _STG_ORDERS_SQL),
+        _model(_REV, _REV_SQL),
+    ]
+    return Manifest(
+        schema_version="v12", adapter_type="duckdb", nodes={n.unique_id: n for n in nodes}
+    )
+
+
+def test_row_number_deduped_dimension_clears_the_cross_model_fanout() -> None:
+    """``ROW_NUMBER() = 1`` proves ``dim_region_latest`` unique on ``region_id``, so the join is
+    one-to-one, staging stays keyed on ``order_id``, and ``SUM(amount)`` reads one row per order.
+    The finding clears only because the window dedup grounded the dimension's key."""
+    assert _findings(_revenue_manifest("ROW_NUMBER"), _REV) == ()
+
+
+def test_rank_deduped_dimension_leaves_the_cross_model_fanout() -> None:
+    """The contrast that pins it: with ``RANK`` the dimension proves no key (ties keep several
+    rows per ``region_id``), the join can fan out, staging loses the order grain, and the same
+    ``SUM(amount)`` double counts. Same shape, no derived key, the finding stands."""
+    findings = _revenue_manifest("RANK")
+    assert [f.kind for f in _findings(findings, _REV)] == [FindingKind.CROSS_MODEL_FANOUT]


### PR DESCRIPTION
## What

The uniqueness substrate derived candidate keys from `DISTINCT`, `GROUP BY`, `UNION`, non-fanning joins, `unique` tests, native constraints, and surrogate hashes, but nothing from the window-dedup idiom `QUALIFY ROW_NUMBER() OVER (PARTITION BY k ORDER BY ...) = 1`. This is the canonical "keep one row per key" pattern (latest-record dedup, snapshot-latest), so a model that establishes its grain this way reported no key, weakening every downstream consumer of `CandidateKeySet`.

`_RelationWalk._select` now reads the dedup guard and unions the partition columns in as a candidate key, which the existing projection maps onto output names. Closes #216.

## Contract

A SELECT filtered to `ROW_NUMBER() OVER (PARTITION BY c1..cn ORDER BY ...) = 1` is unique on `{c1..cn}`. Three surface forms are recognised:

- inline `QUALIFY ROW_NUMBER() OVER (...) = 1`
- `QUALIFY rn = 1` naming a select-list alias
- a subquery projecting `ROW_NUMBER() OVER (...) AS rn` consumed by an outer `WHERE rn = 1` (partition columns mapped through the subquery's projection onto the outer scope)

`= 1` and `<= 1` are the sound guards (a row number is `>= 1`).

## Soundness edges (each pinned by a counterexample test)

- Only `ROW_NUMBER` grounds the key; `RANK` / `DENSE_RANK` tie, so several rows carry rank 1.
- Only `= 1` / `<= 1` ground it; `= 2`, `> 1`, `< 3`, `>= 1` do not.
- A partition that is not a bare output column (an expression, or absent from the projection) grounds nothing.
- A `ROW_NUMBER()` projected but never filtered grounds nothing (no dedup happened).
- A partition-less `ROW_NUMBER() = 1` (the empty key, whole-relation uniqueness) is skipped rather than modelled.

## Implementation

- `uniqueness.py`: `_rownumber_keys` + `_named_rownumber_key` + `_subquery_partition_key`, wired into `_select`. `_group_key` refactored onto a shared `_bare_column_key` (the second caller needed the same "bare columns -> key, else None" logic).
- `_sqlglot.py`: new `row_number_window` / `rank_one_guard_operand` structural helpers; `_conjunctive_leaves` promoted to public `conjunctive_leaves` for the new caller.

## Testing (test-first; proven to bite by misclassifying RANK)

- `tests/lineage/test_uniqueness_rownumber.py`: enumerated edge tests plus a property test over the guard-form x rank-function x comparator space (sound configs derive exactly the partition subset; every unsound variant derives nothing).
- `tests/lineage/test_pbt_uniqueness_soundness.py`: a `qualify` shape added to the duckdb-oracle PBT, so the derived key is validated as genuinely unique over materialized rows.
- `tests/uniqueness/test_cross_model_fanout.py`: two acceptance tests showing the derived key flow end-to-end through join preservation into the cross-model consumer. A `ROW_NUMBER`-deduped dimension clears the `SUM(amount)` fan-out finding; the same shape with `RANK` (no key) leaves it firing.

Full gate green: `ruff check`, `ruff format --check`, `pyright`, and the full `pytest` suite (1317 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)