### PR TITLE
fix(sql): fail fast on sqlglot's incompatible compiled build

### DIFF
--- a/src/dblect/analysis.py
+++ b/src/dblect/analysis.py
@@ -32,7 +32,7 @@ from dblect.audit import AuditReport, LocatedFinding, run_audit
 from dblect.check.findings import CheckFinding, CheckReport
 from dblect.check.run import build_check_graphs, run_check
 from dblect.manifest import Manifest
-from dblect.sql import parse_manifest_models
+from dblect.sql import ensure_pure_sqlglot, parse_manifest_models
 from dblect.types import ContractRegistry
 
 # The sealed set of findings any analysis surfaces: one member per detector family.
@@ -107,6 +107,11 @@ def analyze(
     The declaration family already reads these off the shared build; this hands the same facts
     to the structural one.
     """
+    # Fail fast on sqlglot's compiled build: dblect subclasses sqlglot's Expression
+    # and MappingSchema, which the mypyc-compiled `sqlglotc` cannot instantiate. This
+    # is the single door both the CLI and programmatic callers pass through, so one
+    # clear error here replaces a cryptic TypeError deep in the build.
+    ensure_pure_sqlglot()
     parsed, trees = parse_manifest_models(manifest, dialect=profile.sqlglot_dialect)
     graphs = build_check_graphs(manifest, profile, registry=registry, trees=trees)
     check = run_check(manifest, profile, resolution_floor=resolution_floor, graphs=graphs)

--- a/src/dblect/cli/__init__.py
+++ b/src/dblect/cli/__init__.py
@@ -182,6 +182,7 @@ def check(
     from dblect.report import render_json, render_text
     from dblect.sarif import render_sarif
     from dblect.severity import exceeds_threshold
+    from dblect.sql import SqlglotCompatibilityError
 
     if base_catalog is not None and base_manifest is None:
         raise typer.BadParameter("--base-catalog has no effect without --base-manifest")
@@ -193,23 +194,29 @@ def check(
     profile = _resolve_profile(loaded.adapter_type, dialect_override, command="check")
 
     load_result = load_declarations(project_dir)
-    report = analyze(
-        loaded, profile, registry=load_result.registry, resolution_floor=resolution_floor
-    )
-    report = replace(report, check=replace(report.check, load_issues=load_result.issues))
-    if base_manifest is not None:
-        base = _analyze_base(
-            base_manifest=base_manifest,
-            base_catalog=base_catalog,
-            dialect_override=dialect_override,
-            registry=load_result.registry,
-            resolution_floor=resolution_floor,
+    try:
+        report = analyze(
+            loaded, profile, registry=load_result.registry, resolution_floor=resolution_floor
         )
-        # Narrow only the merged ``findings`` view: that is what every renderer and the
-        # exit code read. The family sub-reports keep their project-wide coverage
-        # metadata (models scanned, contracts resolved), which describes the whole run,
-        # not the introduced subset.
-        report = replace(report, findings=introduced_findings(report.findings, base.findings))
+        report = replace(report, check=replace(report.check, load_issues=load_result.issues))
+        if base_manifest is not None:
+            base = _analyze_base(
+                base_manifest=base_manifest,
+                base_catalog=base_catalog,
+                dialect_override=dialect_override,
+                registry=load_result.registry,
+                resolution_floor=resolution_floor,
+            )
+            # Narrow only the merged ``findings`` view: that is what every renderer and the
+            # exit code read. The family sub-reports keep their project-wide coverage
+            # metadata (models scanned, contracts resolved), which describes the whole run,
+            # not the introduced subset.
+            report = replace(report, findings=introduced_findings(report.findings, base.findings))
+    except SqlglotCompatibilityError as e:
+        # An unsupported sqlglot build is an environment problem, not a finding; report it
+        # as a clean run failure rather than a traceback.
+        typer.echo(f"check: {e}", err=True)
+        raise typer.Exit(code=1) from e
     match output_format:
         case OutputFormat.JSON:
             rendered = render_json(report)

--- a/src/dblect/sql/__init__.py
+++ b/src/dblect/sql/__init__.py
@@ -7,6 +7,11 @@ from dblect.sql.aggregates import (
     duplicate_sensitive,
     strips_duplicates,
 )
+from dblect.sql.compat import (
+    SqlglotCompatibilityError,
+    ensure_pure_sqlglot,
+    sqlglot_supports_subclassing,
+)
 from dblect.sql.findings import (
     Finding,
     FindingKind,
@@ -72,6 +77,7 @@ __all__ = [
     "ResultStatement",
     "SQLParseError",
     "SingleResult",
+    "SqlglotCompatibilityError",
     "WindowSummary",
     "aggregate_behavior",
     "all_findings",
@@ -83,6 +89,7 @@ __all__ = [
     "detect_unordered_window",
     "detect_where_on_outer_joined_nullable",
     "duplicate_sensitive",
+    "ensure_pure_sqlglot",
     "expr_trees",
     "finding_at",
     "list_aggregations",
@@ -95,6 +102,7 @@ __all__ = [
     "parse_result_statement",
     "parse_sql",
     "scan_all",
+    "sqlglot_supports_subclassing",
     "strips_duplicates",
     "suppression_code",
     "suppression_hint",

--- a/src/dblect/sql/compat.py
+++ b/src/dblect/sql/compat.py
@@ -1,0 +1,59 @@
+"""Guard against sqlglot's compiled build, which dblect cannot use.
+
+``sqlglotc`` (pulled by ``sqlglot[c]``) is a mypyc-compiled build of sqlglot: it
+overlays compiled ``.so`` modules that Python loads in preference to the ``.py``
+sources, and sqlglot activates it automatically whenever the package is importable.
+dblect extends sqlglot by subclassing its ``Expression`` (the synthetic lineage
+nodes ``UnionConfluence`` and ``OuterJoinNull``) and its ``MappingSchema`` (a
+column-type memo). mypyc lets an interpreted class *define* a subclass of a compiled
+one but rejects *instantiating* it, so under the compiled build those constructions
+raise ``TypeError: interpreted classes cannot inherit from compiled`` mid-analysis,
+and some sites degrade to dropped models (silently missing findings) instead.
+
+Full compatibility would mean rearchitecting those node types, and the compiled
+tokenizer buys no measurable speedup at dblect's scale, so the supported posture is
+pure-Python sqlglot. This module detects the incompatible build and lets callers fail
+fast with an actionable message rather than crash cryptically or under-report.
+"""
+
+from __future__ import annotations
+
+import sqlglot.expressions as exp
+
+
+class SqlglotCompatibilityError(RuntimeError):
+    """The active sqlglot is the compiled build, which dblect cannot run against."""
+
+
+def sqlglot_supports_subclassing() -> bool:
+    """Whether an interpreted subclass of a sqlglot class can be instantiated.
+
+    Exercises the exact capability dblect depends on: it constructs a throwaway
+    subclass of ``exp.Expression`` and instantiates it. Pure-Python sqlglot allows
+    this; the mypyc-compiled build raises ``TypeError`` at instantiation. The base
+    ``Expression`` takes no required constructor arguments, so a failure here is the
+    compiled-inheritance rejection rather than an argument mismatch.
+    """
+    try:
+        type("_probe", (exp.Expression,), {})()  # pyright: ignore[reportPrivateImportUsage]
+    except TypeError:
+        return False
+    return True
+
+
+def ensure_pure_sqlglot() -> None:
+    """Raise :class:`SqlglotCompatibilityError` when the compiled sqlglot is active.
+
+    A no-op on pure-Python sqlglot. Callers run this at an analysis entry point so a
+    compiled build present in the environment surfaces as one clear, self-service
+    error instead of a ``TypeError`` from deep in the lineage builder.
+    """
+    if sqlglot_supports_subclassing():
+        return
+    raise SqlglotCompatibilityError(
+        "dblect cannot run against sqlglot's compiled build (sqlglotc, installed by "
+        "the sqlglot[c] extra): dblect subclasses sqlglot's Expression and "
+        "MappingSchema, which the mypyc-compiled build forbids. Install the "
+        "pure-Python sqlglot instead, e.g. `pip uninstall sqlglotc` (or reinstall "
+        "sqlglot without the [c] extra)."
+    )

--- a/tests/sql/test_compat.py
+++ b/tests/sql/test_compat.py
@@ -1,0 +1,101 @@
+"""The sqlglot-build compatibility guard.
+
+dblect defines synthetic AST nodes (``UnionConfluence``, ``OuterJoinNull``) and a
+caching schema by subclassing sqlglot's ``Expression`` / ``MappingSchema``. sqlglot's
+compiled build (``sqlglotc``, pulled by ``sqlglot[c]``) is mypyc-compiled, and mypyc
+forbids an interpreted class from *instantiating* a subclass of a compiled one. So a
+compiled sqlglot present in the environment (installed deliberately, or dragged in by
+a co-resident tool) makes analysis raise ``TypeError: interpreted classes cannot
+inherit from compiled`` deep in the build, or degrade to missing findings.
+
+The contract pinned here: analysis fails fast at the door with an actionable error
+naming the culprit and its remedy, rather than a cryptic mid-run traceback or silent
+under-reporting.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dblect.adapters import profile_for_adapter
+from dblect.analysis import analyze
+from dblect.manifest import Manifest, Node, ResourceType
+from dblect.sql import compat
+from dblect.sql.compat import (
+    SqlglotCompatibilityError,
+    ensure_pure_sqlglot,
+    sqlglot_supports_subclassing,
+)
+
+_DUCKDB = profile_for_adapter("duckdb")
+
+
+def _manifest(sql: str = "SELECT 1 AS a") -> Manifest:
+    node = Node(
+        unique_id="model.pkg.m",
+        name="m",
+        resource_type=ResourceType.MODEL,
+        fqn=("pkg", "m"),
+        package_name="pkg",
+        schema=None,
+        raw_code=sql,
+        compiled_code=sql,
+        original_file_path="models/m.sql",
+        columns={},
+    )
+    return Manifest(schema_version="x", adapter_type="duckdb", nodes={node.unique_id: node})
+
+
+def _compiled_sqlglot_active() -> bool:
+    # sqlglotc overlays compiled `.so` modules into the `sqlglot` package (its top-level
+    # is `sqlglot`, so `import sqlglotc` is not a reliable signal). A compiled module
+    # loaded in preference to its `.py` source is the observable marker.
+    import sqlglot.parser
+
+    return sqlglot.parser.__file__.endswith((".so", ".pyd"))
+
+
+def test_detection_true_on_pure_sqlglot() -> None:
+    # The test environment installs pure-Python sqlglot, whose classes an interpreted
+    # subclass can instantiate. This also proves the probe does not false-positive by
+    # relying on some other constructor requirement.
+    assert sqlglot_supports_subclassing() is True
+
+
+def test_guard_is_silent_on_pure_sqlglot() -> None:
+    # Returns None, raises nothing: the common path stays a no-op.
+    assert ensure_pure_sqlglot() is None
+
+
+def test_guard_raises_actionable_error_when_subclassing_unsupported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(compat, "sqlglot_supports_subclassing", lambda: False)
+    with pytest.raises(SqlglotCompatibilityError) as excinfo:
+        ensure_pure_sqlglot()
+    message = str(excinfo.value)
+    # Names the culprit and both spellings a user would search for, and the remedy.
+    assert "sqlglotc" in message
+    assert "sqlglot[c]" in message
+    assert "uninstall" in message.lower()
+
+
+@pytest.mark.skipif(
+    not _compiled_sqlglot_active(),
+    reason="requires sqlglot's compiled build (sqlglotc) to be active",
+)
+def test_real_compiled_build_is_detected_and_refused() -> None:
+    # End-to-end against the actual compiled build, not a monkeypatched detector: the
+    # probe reports the incompatibility and the guard raises. Skipped in the pure-Python
+    # environment CI runs in; exercised wherever the compiled build is installed.
+    assert sqlglot_supports_subclassing() is False
+    with pytest.raises(SqlglotCompatibilityError):
+        ensure_pure_sqlglot()
+
+
+def test_analyze_fails_fast_through_the_guard(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The single analysis door runs the guard before any build, so a compiled sqlglot
+    # surfaces as this clear error rather than a TypeError from the lineage builder.
+    monkeypatch.setattr(compat, "sqlglot_supports_subclassing", lambda: False)
+    with pytest.raises(SqlglotCompatibilityError):
+        analyze(_manifest(), _DUCKDB)


### PR DESCRIPTION
## Problem

If sqlglot's **compiled build** is present in the environment — `sqlglotc`, pulled by the `sqlglot[c]` extra, installed deliberately or dragged in by a co-resident tool — dblect crashes. sqlglot auto-loads the compiled `.so` modules whenever the package is importable, so a user need not opt into it through dblect.

The root cause is that dblect extends sqlglot by **subclassing its compiled classes**:
- `UnionConfluence(Expression)` — synthetic AST node for UNION ALL lineage
- `OuterJoinNull(exp.Expression)` — synthetic marker for outer-join nullability
- `_CachingMappingSchema(MappingSchema)` — a column-type memo

mypyc lets an interpreted class *define* a subclass of a compiled one but rejects *instantiating* it (`TypeError: interpreted classes cannot inherit from compiled`). So analysis either crashed with a cryptic traceback deep in the lineage builder, or degraded to silently dropped models — the worst failure mode for a correctness tool.

Full compatibility would mean rearchitecting those node types, and the compiled tokenizer showed no measurable speedup at dblect's scale, so the supported posture is pure-Python sqlglot.

## Change

- New `dblect/sql/compat.py`: `sqlglot_supports_subclassing()` (an instantiation probe — the exact capability, not a version-string or internal-attribute proxy), `ensure_pure_sqlglot()`, and `SqlglotCompatibilityError`.
- `analyze()` calls the guard at the single door both the CLI and programmatic callers pass through.
- The CLI `check` command translates the exception into a clean `check: …` stderr message and exit 1, matching the existing error-handling conventions.

Result under a compiled build:
```
check: dblect cannot run against sqlglot's compiled build (sqlglotc, installed by the
sqlglot[c] extra): dblect subclasses sqlglot's Expression and MappingSchema, which the
mypyc-compiled build forbids. Install the pure-Python sqlglot instead, e.g.
`pip uninstall sqlglotc` (or reinstall sqlglot without the [c] extra).
```

## Tests

`tests/sql/test_compat.py` (test-first): pure-env detection and silence, actionable-message content, `analyze()` fail-fast wiring, plus a skipif test that pins the contract against the real compiled build when it is installed (skipped in the pure-Python CI env). Each assertion was verified to bite by injecting the corresponding violation.

- Full suite: 1303 passed, 1 skipped.
- Gate clean: `ruff check`, `ruff format --check`, `pyright`.
- Verified end-to-end against a real `sqlglotc==30.8.0` install: `dblect check` now exits 1 with the clean error (previously an uncaught `TypeError`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)