### PR TITLE
test(cli): strip ANSI before flag substring assertions in baseline check

### DIFF
--- a/tests/cli/_output.py
+++ b/tests/cli/_output.py
@@ -1,0 +1,18 @@
+"""Helpers for asserting against ``dblect`` CLI output in tests.
+
+Typer/Rich renders ``BadParameter`` inside a Panel and highlights CLI flags like
+``--dialect`` or ``--base-manifest`` with colour escapes when a colour-capable
+terminal is detected (which CI runners report). That highlighting splits the literal
+flag across ANSI sequences, so substring checks must strip the escapes first.
+"""
+
+from __future__ import annotations
+
+import re
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+
+def plain(text: str) -> str:
+    """Return ``text`` with ANSI colour/formatting escapes removed."""
+    return _ANSI_RE.sub("", text)

--- a/tests/cli/test_check.py
+++ b/tests/cli/test_check.py
@@ -10,7 +10,6 @@ codes, and the JSON schema. The declaration side and init are pinned in
 from __future__ import annotations
 
 import json
-import re
 import shutil
 from pathlib import Path
 
@@ -19,15 +18,7 @@ from typer.testing import CliRunner
 
 from dblect.cli import app
 
-# Typer/Rich renders BadParameter inside a Panel and highlights CLI flags like
-# ``--dialect`` with colour escapes when a colour-capable terminal is detected
-# (which CI runners report). That highlighting splits the literal substring
-# ``--dialect`` across ANSI sequences, so substring checks must strip first.
-_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
-
-
-def _plain(text: str) -> str:
-    return _ANSI_RE.sub("", text)
+from ._output import plain as _plain
 
 
 @pytest.fixture

--- a/tests/cli/test_check_baseline.py
+++ b/tests/cli/test_check_baseline.py
@@ -22,6 +22,8 @@ from typer.testing import CliRunner
 
 from dblect.cli import app
 
+from ._output import plain
+
 _CASES = Path(__file__).parent.parent / "fixtures" / "scenarios" / "cases"
 _CURRENCY_CREEP = _CASES / "currency_creep"
 _HEAD_MANIFEST = _CURRENCY_CREEP / "manifest.json"
@@ -94,4 +96,4 @@ def test_an_introduced_finding_fails_the_run(runner: CliRunner, base_without_mar
 def test_missing_base_manifest_is_an_error(runner: CliRunner, tmp_path: Path) -> None:
     result = _run(runner, "--base-manifest", str(tmp_path / "nope.json"))
     assert result.exit_code != 0
-    assert "--base-manifest" in result.output
+    assert "--base-manifest" in plain(result.output)


### PR DESCRIPTION
## What

`tests/cli/test_check_baseline.py::test_missing_base_manifest_is_an_error` fails under CI (e.g. on #221, #216) even though those PRs do not touch the CLI. It is a preexisting break that the previous month-old main CI run predates.

## Root cause

The test asserts a raw substring:

```python
assert "--base-manifest" in result.output
```

Typer/Rich renders the `BadParameter` message inside a colour panel and highlights CLI flags with ANSI escapes when a colour-capable terminal is detected (which CI runners report). That splits the literal flag across escape sequences — `\x1b[1;36m-\x1b[0m\x1b[1;36m-base\x1b[0m\x1b[1;36m-manifest\x1b[0m` — so `--base-manifest` is no longer a contiguous substring. It passes locally (no colour in the CliRunner) and fails on CI.

`tests/cli/test_check.py` already documented and handled exactly this for `--dialect` via a local `_plain` helper. The baseline test never applied it.

## Fix

Hoist the ANSI-stripping helper into `tests/cli/_output.py` and use it from both modules; strip ANSI before the `--base-manifest` substring check.

Verified under `FORCE_COLOR=1`: old raw assertion → fails, new `plain()` assertion → passes; both CLI test files green; `ruff check`, `ruff format --check`, `pyright` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)