### PR TITLE
test: remove seven redundant test cases found by subject-under-test audit

### DIFF
--- a/tests/cli/test_check.py
+++ b/tests/cli/test_check.py
@@ -101,13 +101,6 @@ def test_exits_non_zero_when_findings_present(
     assert result.exit_code == 1
 
 
-def test_exits_zero_with_no_fail_override(jaffle_manifest_path: Path, runner: CliRunner) -> None:
-    result = runner.invoke(
-        app, ["check", "--manifest", str(jaffle_manifest_path), "--no-fail", "."]
-    )
-    assert result.exit_code == 0
-
-
 def test_fail_on_error_passes_warn_only_run(jaffle_manifest_path: Path, runner: CliRunner) -> None:
     # jaffle's structural finding is null_group_after_outer_join, an error-level
     # correctness hazard, so --fail-on error still fails it. The warn-vs-error
@@ -116,12 +109,6 @@ def test_fail_on_error_passes_warn_only_run(jaffle_manifest_path: Path, runner: 
     result = runner.invoke(
         app, ["check", "--manifest", str(jaffle_manifest_path), "--fail-on", "error", "."]
     )
-    assert result.exit_code == 1, result.output
-
-
-def test_fail_on_default_is_warn(jaffle_manifest_path: Path, runner: CliRunner) -> None:
-    # No --fail-on given: the default warn threshold fails the error-level finding.
-    result = runner.invoke(app, ["check", "--manifest", str(jaffle_manifest_path), "."])
     assert result.exit_code == 1, result.output
 
 
@@ -245,12 +232,6 @@ def test_env_var_overrides_project_target_path(
     )
     assert result.exit_code == 0, result.output
     assert "null_group_after_outer_join" in result.output
-
-
-def test_missing_manifest_and_no_dbt_project_fails(tmp_path: Path, runner: CliRunner) -> None:
-    result = runner.invoke(app, ["check", str(tmp_path)])
-    assert result.exit_code != 0
-    assert "dbt_project.yml" in result.output
 
 
 def test_explicit_manifest_missing_fails(tmp_path: Path, runner: CliRunner) -> None:

--- a/tests/lineage/test_fanout_grain.py
+++ b/tests/lineage/test_fanout_grain.py
@@ -23,10 +23,6 @@ def _keys(*key_sets: set[str]) -> CandidateKeySet:
     return CandidateKeySet(frozenset(frozenset(k) for k in key_sets))
 
 
-def test_grain_preserved_when_the_origin_key_is_a_key() -> None:
-    assert grain_preserved(_keys({"order_id"}), frozenset({"order_id"}))
-
-
 def test_grain_preserved_when_a_finer_key_survives() -> None:
     """A relation keyed on a subset of the origin is even finer, so each origin row still
     appears once."""
@@ -45,5 +41,7 @@ def test_grain_not_preserved_when_no_key_is_known() -> None:
 
 
 def test_any_surviving_subset_key_preserves_the_grain() -> None:
-    """Several candidate keys: one that refines the origin is enough."""
+    """Several candidate keys: one that refines the origin is enough. The matching key here is
+    the origin key itself, so this also pins the equality boundary, that a key equal to the
+    origin refines it."""
     assert grain_preserved(_keys({"x"}, {"order_id"}), frozenset({"order_id"}))

--- a/tests/sql/test_anti_join.py
+++ b/tests/sql/test_anti_join.py
@@ -73,18 +73,16 @@ def test_multi_column_correlation_carries_every_predicate_column() -> None:
 # --- soundness edges --------------------------------------------------------------
 
 
-def test_left_is_null_on_a_join_key_column_is_an_anti_join() -> None:
-    """The ``IS NULL`` on a join-key column keeps exactly the unmatched rows: a matched row has
-    ``l.k = r.k`` so ``r.k`` is non-NULL there, and the filter excludes it. Sound with no
-    nullability oracle, because the equality match itself proves the column non-NULL."""
-    a = _only("SELECT l.a FROM l LEFT JOIN r ON l.k = r.k WHERE r.k IS NULL")
-    assert a.form is AntiJoinForm.LEFT_IS_NULL
-
-
 def test_left_is_null_on_a_non_key_column_is_not_recognised() -> None:
-    """``IS NULL`` on a column absent from the join key can leak matched rows: a matched row may
-    carry a NULL there, survive the filter, and the result is not the anti-join. The classifier
-    stays oracle-free and does not claim it; deciding it needs the nullability substrate."""
+    """The join-key column is where the idiom is sound, and this is the foil that bounds it.
+
+    On a join-key column (``_LEFT_IS_NULL`` above) the ``IS NULL`` keeps exactly the unmatched
+    rows: a matched row has ``l.k = r.k`` so ``r.k`` is non-NULL there, and the filter excludes
+    it. That holds with no nullability oracle, because the equality match itself proves the
+    column non-NULL. On a column absent from the join key the argument evaporates: a matched row
+    may carry a NULL there, survive the filter, and the result is not the anti-join. The
+    classifier stays oracle-free and does not claim it; deciding it needs the nullability
+    substrate."""
     sel = sqlglot.parse_one("SELECT l.a FROM l LEFT JOIN r ON l.k = r.k WHERE r.attr IS NULL")
     assert anti_joins_of(sel) == ()  # type: ignore[arg-type]
 

--- a/tests/sql/test_jaffle.py
+++ b/tests/sql/test_jaffle.py
@@ -38,11 +38,6 @@ def _parsed(node: Node) -> Expr:
     return parse_sql(node.compiled_code, dialect="duckdb")
 
 
-def test_every_jaffle_model_parses(jaffle: Manifest) -> None:
-    for node in _models_with_code(jaffle).values():
-        _parsed(node)
-
-
 def test_customers_model_flags_null_group_risk(jaffle: Manifest) -> None:
     node = jaffle.nodes["model.jaffle_shop.customers"]
     findings = detect_null_group_after_outer_join(_parsed(node))

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -317,7 +317,7 @@ def test_suppressed_declaration_finding_reaches_sarif() -> None:
     assert result["suppressions"][0]["justification"].endswith("@ L4")
 
 
-@pytest.mark.parametrize("fmt", ["text", "json", "sarif"])
+@pytest.mark.parametrize("fmt", ["text", "sarif"])
 def test_cli_check_emits_requested_format(jaffle_manifest_path: Path, fmt: str) -> None:
     from typer.testing import CliRunner
 


### PR DESCRIPTION
An audit indexed every test in the suite (1,229 entries) by the source symbol and closed-type branch it exercises, read from the source rather than from test names, then looked for collisions across files. 57 symbols turned out to be exercised from two or more files; 11 of those became duplicate candidates.

Each candidate then went through a bite check: name a concrete source edit that should fail the claimed survivor, apply it, and confirm the candidate adds no unique failure. Seven survived that check as genuinely redundant and are deleted here. Four were refuted by it and are kept.

## Deleted

| Test | Covered by | Why |
|---|---|---|
| `test_check.py::test_fail_on_default_is_warn` | `test_exits_non_zero_when_findings_present` | Byte-identical invocation and assertion |
| `test_check.py::test_exits_zero_with_no_fail_override` | `test_structural_finding_with_explicit_manifest` | Same argv; survivor asserts a strict superset |
| `test_check.py::test_missing_manifest_and_no_dbt_project_fails` | `test_missing_project_and_manifest_is_actionable` | Subset, and the survivor asserts against the ANSI-stripped surface |
| `test_sarif.py::test_cli_check_emits_requested_format[json]` | `test_check.py::test_json_finding_carries_severity`, `::test_json_format_produces_stable_schema` | Asserted only the exit code while the survivors parse the payload |
| `test_fanout_grain.py::test_grain_preserved_when_the_origin_key_is_a_key` | `test_any_surviving_subset_key_preserves_the_grain` | Survivor contains the same matching key against the same origin |
| `test_anti_join.py::test_left_is_null_on_a_join_key_column_is_an_anti_join` | `test_the_four_surface_forms_classify_to_one_operator` | Parses the `_LEFT_IS_NULL` constant that test already classifies |
| `test_jaffle.py::test_every_jaffle_model_parses` | `test_scan_all_surfaces_jaffle_null_group` | Asserted only that parsing does not raise, over the same node set |

Only the `json` case leaves the `test_cli_check_emits_requested_format` parametrize. `text` stays as the only positional-less invocation and `sarif` as the only schema validation.

Two arguments that would otherwise have been lost are preserved as prose rather than deleted with their tests. The anti-join soundness rationale (the idiom is sound with no nullability oracle, because the equality match itself proves the join-key column non-NULL) moves into its foil, so the recognised and not-recognised halves now read as one argument. The equality-boundary note moves into `test_any_surviving_subset_key_preserves_the_grain`.

## Verification

Every deletion was confirmed by injecting a fault into `src/` and observing that the survivor fails on it, so each branch stays pinned. Two examples: renaming the `schema_version` key in `render_json` fails `test_json_format_produces_stable_schema` while the deleted sarif case passed; flipping `LEFT_IS_NULL` to `NATIVE` in `anti_join.py` failed both members of that pair together.

The `--no-fail` deletion also got the reverse injection (`typer.echo(rendered)` to `typer.echo("")`), which fails only the survivor. The dominance runs one way, so this is subsumption rather than overlap.

Collected tests go 1547 to 1540. Diffing collected ids before and after shows exactly these seven removed and none added. Full gate green: `ruff check`, `ruff format --check`, `pyright` (0 errors), `pytest` (1540 passed).

## Kept, with reasons

Four candidates were refuted. The one worth recording: the negative-step `generate_series(10, 0, -2)` case in `test_patterns.py` is the only parameter in the entire suite that fails when `patterns.py` re-derives generator non-emptiness sign-blindly, because its siblings `(0, 23)` and `(5, 1)` are sign-agnostic. It guards the delegation boundary to `vocab.py` against exactly the parallel-helper drift `CLAUDE.md` warns about.

The audit also examined 213 pairs it deliberately kept, concentrated in the `JoinSide` families in `test_functional_dependency_propagation.py` and `test_uniqueness_propagation.py`, where each closed-type value reaches a separate guard arm.

## Follow-up, not addressed here

`test_fail_on_default_is_warn` was misnamed, and deleting it reveals a gap rather than creating one: it could not discriminate WARN from ERROR, because jaffle's only finding is error-level and crosses every threshold. The CLI wiring of the default threshold is therefore not covered today. `test_fail_on_error_passes_warn_only_run` has the same blind spot and its own comment concedes it.

Closing this needs a fixture whose top finding is warn-level, so `--fail-on error` exits 0 while the default exits 1. Every CLI test currently leans on the vendored jaffle manifest and there is no synthetic-manifest builder, so it is a fixture decision worth taking on its own. The predicate itself remains well covered at the unit level in `tests/test_fail_threshold.py` across every severity and threshold pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MM6KgbJ1SqACE7i8rFzVdv