### PR TITLE
fix(sql): read GROUP BY and ORDER BY by their semantics, not their surface form

### DIFF
--- a/src/dblect/nullability/detector.py
+++ b/src/dblect/nullability/detector.py
@@ -87,6 +87,11 @@ def detect_null_group_on_nullable_key(
     local case belongs to ``null_group_after_outer_join``). Only bare-column group keys
     are reasoned about; a computed key like ``date_trunc(col)`` needs an equivalence we
     do not model and is skipped.
+
+    A key named positionally or by output name is read through :func:`sg.group_targets` to the
+    projection it names, so ``group by 1`` over a nullable column carries the same hazard as
+    spelling the column out. The finding then lands on that projection, which is where the
+    grouped expression is actually written.
     """
     out: list[Finding] = []
     for sel in sg.find_all_selects(tree):
@@ -99,10 +104,7 @@ def detect_null_group_on_nullable_key(
         nullable = nullable_by_name.get(target.name)
         if not nullable:
             continue
-        group = sg.group_of(sel)
-        if group is None:
-            continue
-        for grp_expr in group.expressions:
+        for grp_expr in sg.group_targets(sel):
             if not isinstance(grp_expr, exp.Column):
                 continue
             qualifier = sg.column_table(grp_expr)

--- a/src/dblect/nullability/detector.py
+++ b/src/dblect/nullability/detector.py
@@ -90,8 +90,8 @@ def detect_null_group_on_nullable_key(
 
     A key named positionally or by output name is read through :func:`sg.group_targets` to the
     projection it names, so ``group by 1`` over a nullable column carries the same hazard as
-    spelling the column out. The finding then lands on that projection, which is where the
-    grouped expression is actually written.
+    spelling the column out. The finding names that projection and lands on the GROUP BY, the
+    decision site an analyst following the line number is looking for.
     """
     out: list[Finding] = []
     for sel in sg.find_all_selects(tree):
@@ -104,7 +104,8 @@ def detect_null_group_on_nullable_key(
         nullable = nullable_by_name.get(target.name)
         if not nullable:
             continue
-        for grp_expr in sg.group_targets(sel):
+        for grouped in sg.group_targets(sel):
+            grp_expr = grouped.expression
             if not isinstance(grp_expr, exp.Column):
                 continue
             qualifier = sg.column_table(grp_expr)
@@ -112,7 +113,11 @@ def detect_null_group_on_nullable_key(
                 continue
             column = sg.column_name(grp_expr).lower()
             if column in nullable:
-                out.append(_finding(grp_expr, source=target.name, column=column))
+                out.append(
+                    _finding(
+                        grp_expr, written_at=grouped.written_at, source=target.name, column=column
+                    )
+                )
     return tuple(out)
 
 
@@ -333,7 +338,9 @@ def _alias_to_relation(sel: exp.Select) -> dict[str, str]:
     return out
 
 
-def _finding(grp_expr: exp.Column, *, source: str, column: str) -> Finding:
+def _finding(grp_expr: exp.Column, *, written_at: Expr, source: str, column: str) -> Finding:
+    """Named after the resolved group key, located at the clause that wrote it. The two part
+    company when the key is spelled positionally or by output name."""
     return finding_at(
         FindingKind.NULL_GROUP_ON_NULLABLE_KEY,
         message=(
@@ -342,7 +349,7 @@ def _finding(grp_expr: exp.Column, *, source: str, column: str) -> Finding:
             f"that downstream code rarely accounts for. Filter the nulls before grouping, "
             f"or make the orphan-handling intent explicit."
         ),
-        node=grp_expr,
+        node=written_at,
     )
 
 

--- a/src/dblect/sql/_sqlglot.py
+++ b/src/dblect/sql/_sqlglot.py
@@ -13,7 +13,7 @@ documents its key and what shape it returns.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from enum import StrEnum
 from typing import cast
 
@@ -63,28 +63,145 @@ def group_of(sel: exp.Select) -> exp.Group | None:
 
 
 def group_targets(sel: exp.Select) -> tuple[Expr, ...]:
-    """The expressions ``sel`` groups by, with positional ordinals resolved to the projections
-    they name.
+    """The expressions ``sel`` groups by, with positional ordinals and output-alias references
+    resolved to the projections they name.
 
-    ``GROUP BY 1`` names the first projection, so a reader walking the ``Group`` node's
-    arguments finds an ``exp.Literal`` where the semantics are the projected expression. Every
-    structural check over grouping keys wants the expression, so the resolution belongs here
-    rather than in each caller. We resolve by lookup instead of rewriting the tree, so the
-    caller's nodes keep the source positions that findings report line numbers from.
+    ``GROUP BY 1`` and ``GROUP BY revenue_day`` both name a projection, so a reader walking the
+    ``Group`` node's arguments finds an ``exp.Literal`` or a table-less ``exp.Column`` where the
+    semantics are the projected expression. Every structural check over grouping keys wants that
+    expression, so the resolution belongs here rather than in each caller. We resolve by lookup
+    instead of rewriting the tree, so the caller's nodes keep the source positions that findings
+    report line numbers from.
 
     Every adapter dblect targets reads a bare integer in GROUP BY as a position, so this needs
     no dialect gate.
 
-    An ordinal we cannot resolve is returned unchanged, leaving callers to treat it as the
-    opaque target it is: one past the end of the projection list, or into a prefix holding a
-    ``SELECT *`` that expands to an unknown number of columns, so position N is not the Nth
-    listed projection.
+    A target we cannot resolve is returned unchanged, leaving callers to treat it as the opaque
+    target it is. For an ordinal that means one past the end of the projection list, or into a
+    prefix holding a ``SELECT *`` that expands to an unknown number of columns, so position N is
+    not the Nth listed projection. For a name it means no projection carries it as an output
+    name, or :func:`_shadows_an_input_column` cannot rule out an input column of that name.
     """
     group = group_of(sel)
     if group is None:
         return ()
     projections = cast("list[Expr]", sel.expressions)
-    return tuple(_resolve_ordinal(target, projections) for target in group.expressions)
+    projected = _projection_expressions_by_output_name(sel)
+    return tuple(
+        _resolve_group_target(target, sel, projections, projected) for target in group.expressions
+    )
+
+
+def _resolve_group_target(
+    target: Expr, sel: exp.Select, projections: Sequence[Expr], projected: Mapping[str, Expr]
+) -> Expr:
+    resolved = _resolve_ordinal(target, projections)
+    return resolved if resolved is not target else _resolve_name(target, sel, projected)
+
+
+def _resolve_name(target: Expr, sel: exp.Select, projected: Mapping[str, Expr]) -> Expr:
+    """``target`` resolved to the projection it names, if it is an output-name reference.
+
+    Only an unqualified column name can name a projection; ``t.k`` binds to the table.
+
+    A name matching a projection that is *itself* the bare column of that name resolves
+    unconditionally: SQL would bind the name to that input column, and the projection is that
+    same column, so the two readings agree and the shadowing question does not arise. This is
+    the ``select orders.customer_id ... group by customer_id`` idiom. Any other projection is
+    a renaming, where an input column of the same name would win over the output name, so it
+    resolves only when :func:`_shadows_an_input_column` finds no such column.
+    """
+    if not isinstance(target, exp.Column) or target.args.get("table") is not None:
+        return target
+    if not isinstance(target.this, exp.Identifier):
+        return target
+    name = column_name(target)
+    projection = projected.get(name)
+    if projection is None:
+        return target
+    if isinstance(projection, exp.Column) and column_name(projection) == name:
+        return projection
+    return target if _shadows_an_input_column(name, sel) else projection
+
+
+def _projection_expressions_by_output_name(sel: exp.Select) -> dict[str, Expr]:
+    """Each output name in ``sel``'s projection mapped to the expression behind it.
+
+    An output name carried by two projections names neither unambiguously, so it is dropped
+    rather than resolved to whichever came last. Such a query does not run anyway: an engine
+    binds the first and then rejects the second as ungrouped.
+    """
+    out: dict[str, Expr] = {}
+    duplicated: set[str] = set()
+    for proj in sel.expressions:
+        if isinstance(proj, exp.Alias):
+            name, expression = proj.alias_or_name, cast("Expr", proj.this)
+        elif isinstance(proj, exp.Column) and isinstance(proj.this, exp.Identifier):
+            name, expression = column_name(proj), proj
+        else:
+            continue
+        if name in out:
+            duplicated.add(name)
+        out[name] = expression
+    return {name: e for name, e in out.items() if name not in duplicated}
+
+
+def _shadows_an_input_column(name: str, sel: exp.Select) -> bool:
+    """Whether ``name`` may bind to an input column of ``sel`` rather than to its output alias.
+
+    SQL resolves a GROUP BY name against the input columns first and only then against the
+    output aliases, so ``select b.amt * 2 as amt ... group by amt`` groups by ``b.amt``. Naming
+    the input columns exactly needs a schema, which the AST layer does not have, so we treat any
+    column of that name referenced elsewhere in the query as evidence the name is taken and
+    decline to resolve. That is conservative in the direction of the behaviour before aliases
+    resolved at all: an input column the query never mentions still slips through, which is the
+    known-permissive edge of this rule.
+
+    ``GROUP BY`` and ``ORDER BY`` are excluded from the sweep because both resolve names against
+    output aliases themselves, so a reference there is not evidence of an input column.
+    """
+    for key, arg in sel.args.items():
+        if key in ("group", "order"):
+            continue
+        nodes = cast("list[object]", arg) if isinstance(arg, list) else [cast("object", arg)]
+        for node in nodes:
+            if isinstance(node, Expr) and any(column_name(c) == name for c in find_columns(node)):
+                return True
+    return False
+
+
+def statement_order_targets(sel: exp.Select) -> tuple[Expr, ...]:
+    """The statement-level ``ORDER BY`` targets of ``sel``, with ordinals resolved and each
+    target's ``exp.Ordered`` wrapper removed.
+
+    Unlike the ORDER BY inside a window or an aggregate, where a literal is a constant that
+    orders nothing (see :func:`imposes_row_order`), a statement-level ``ORDER BY 1`` is a
+    positional reference to the first projection.
+    """
+    order = cast("exp.Order | None", sel.args.get("order"))
+    if order is None:
+        return ()
+    projections = cast("list[Expr]", sel.expressions)
+    targets = (t.this if isinstance(t, exp.Ordered) else t for t in order.expressions)
+    return tuple(_resolve_ordinal(t, projections) for t in targets)
+
+
+def imposes_row_order(order: exp.Order | None) -> bool:
+    """Whether ``order`` actually pins the order of the rows it governs.
+
+    An ORDER BY inside a window or an aggregate takes expressions, never the positional
+    references a statement-level ORDER BY accepts, so a literal there is a constant: every row
+    sorts equal and the ranking falls back to whatever physical order the engine happened to
+    have. An ordering whose targets reference no column therefore pins nothing, and the caller's
+    "no ORDER BY" hazard applies to it unchanged.
+
+    A target referencing a column counts even when the column sits inside a subquery, where the
+    value is constant per row and so orders nothing either. That keeps the answer conservative:
+    the caller stays silent rather than reporting a hazard this rule cannot yet prove.
+    """
+    if order is None or not order.expressions:
+        return False
+    return any(find_columns(e) for e in order.expressions)
 
 
 def _resolve_ordinal(target: Expr, projections: Sequence[Expr]) -> Expr:

--- a/src/dblect/sql/_sqlglot.py
+++ b/src/dblect/sql/_sqlglot.py
@@ -14,6 +14,7 @@ documents its key and what shape it returns.
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from enum import StrEnum
 from typing import cast
 
@@ -77,10 +78,8 @@ def group_targets(sel: exp.Select) -> tuple[Expr, ...]:
     no dialect gate.
 
     A target we cannot resolve is returned unchanged, leaving callers to treat it as the opaque
-    target it is. For an ordinal that means one past the end of the projection list, or into a
-    prefix holding a ``SELECT *`` that expands to an unknown number of columns, so position N is
-    not the Nth listed projection. For a name it means no projection carries it as an output
-    name, or :func:`_shadows_an_input_column` cannot rule out an input column of that name.
+    target it is. :func:`_resolve_ordinal` and :func:`_resolve_name` each document when they
+    decline.
     """
     group = group_of(sel)
     if group is None:
@@ -96,7 +95,7 @@ def _resolve_group_target(
     target: Expr, sel: exp.Select, projections: Sequence[Expr], projected: Mapping[str, Expr]
 ) -> Expr:
     resolved = _resolve_ordinal(target, projections)
-    return resolved if resolved is not target else _resolve_name(target, sel, projected)
+    return resolved if resolved is not None else _resolve_name(target, sel, projected)
 
 
 def _resolve_name(target: Expr, sel: exp.Select, projected: Mapping[str, Expr]) -> Expr:
@@ -159,7 +158,15 @@ def _shadows_an_input_column(name: str, sel: exp.Select) -> bool:
 
     ``GROUP BY`` and ``ORDER BY`` are excluded from the sweep because both resolve names against
     output aliases themselves, so a reference there is not evidence of an input column.
+
+    A projection that expands to unknown width settles the question the other way: ``select
+    a.*`` carries every column of ``a`` without naming one, so any name may be among them and
+    the sweep has nothing to find. Treating that as "no input column" would resolve the alias
+    and report against an expression the engine never grouped by, turning the permissive edge
+    above into a false positive, so an unexpanded star declines every name in the query.
     """
+    if any(_expands_to_unknown_width(p) for p in sel.expressions):
+        return True
     for key, arg in sel.args.items():
         if key in ("group", "order"):
             continue
@@ -170,7 +177,25 @@ def _shadows_an_input_column(name: str, sel: exp.Select) -> bool:
     return False
 
 
-def statement_order_targets(sel: exp.Select) -> tuple[Expr, ...]:
+@dataclass(frozen=True)
+class OrderTarget:
+    """One statement-level ``ORDER BY`` target, and which namespace its expression is in.
+
+    A positional target resolves to the named projection's own expression, so it arrives in the
+    query's *source* namespace, already past the ``AS`` binding. A target spelled as a name is
+    in the *output* namespace, where a caller matching against source columns still has to
+    translate it through the projection's aliases.
+
+    Conflating the two re-translates a resolved source column whenever some *other* projection
+    is aliased to that name: in ``select id as x, other as id ... order by 1`` the ordinal
+    resolves to ``id``, which a second pass through the alias map would turn into ``other``.
+    """
+
+    expression: Expr
+    in_source_namespace: bool
+
+
+def statement_order_targets(sel: exp.Select) -> tuple[OrderTarget, ...]:
     """The statement-level ``ORDER BY`` targets of ``sel``, with ordinals resolved and each
     target's ``exp.Ordered`` wrapper removed.
 
@@ -183,7 +208,14 @@ def statement_order_targets(sel: exp.Select) -> tuple[Expr, ...]:
         return ()
     projections = cast("list[Expr]", sel.expressions)
     targets = (t.this if isinstance(t, exp.Ordered) else t for t in order.expressions)
-    return tuple(_resolve_ordinal(t, projections) for t in targets)
+    return tuple(_order_target(t, projections) for t in targets)
+
+
+def _order_target(target: Expr, projections: Sequence[Expr]) -> OrderTarget:
+    resolved = _resolve_ordinal(target, projections)
+    if resolved is None:
+        return OrderTarget(target, in_source_namespace=False)
+    return OrderTarget(resolved, in_source_namespace=True)
 
 
 def imposes_row_order(order: exp.Order | None) -> bool:
@@ -204,21 +236,23 @@ def imposes_row_order(order: exp.Order | None) -> bool:
     return any(find_columns(e) for e in order.expressions)
 
 
-def _resolve_ordinal(target: Expr, projections: Sequence[Expr]) -> Expr:
-    """``target`` resolved through the projection list if it is a positional reference.
+def _resolve_ordinal(target: Expr, projections: Sequence[Expr]) -> Expr | None:
+    """The projection ``target`` names positionally, or ``None`` when it names none.
 
     Only a bare positive integer literal is positional. A string (``GROUP BY 'x'``), a float,
     and a negation (which parses as ``Neg`` over the literal, not a literal) are grouped
-    values, so they pass through untouched.
+    values, so they name no position. Nor does an index past the end of the projection list,
+    or one reaching over a ``SELECT *`` that expands to an unknown number of columns, so
+    position N is not the Nth listed projection.
     """
     if not (isinstance(target, exp.Literal) and target.is_int):
-        return target
+        return None
     index = int(target.this)
     if not 1 <= index <= len(projections):
-        return target
+        return None
     prefix = projections[:index]
     if any(_expands_to_unknown_width(p) for p in prefix):
-        return target
+        return None
     return prefix[-1].unalias()
 
 

--- a/src/dblect/sql/_sqlglot.py
+++ b/src/dblect/sql/_sqlglot.py
@@ -13,6 +13,7 @@ documents its key and what shape it returns.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from enum import StrEnum
 from typing import cast
 
@@ -59,6 +60,60 @@ def laterals_of(sel: exp.Select) -> list[exp.Lateral]:
 
 def group_of(sel: exp.Select) -> exp.Group | None:
     return cast("exp.Group | None", sel.args.get("group"))
+
+
+def group_targets(sel: exp.Select) -> tuple[Expr, ...]:
+    """The expressions ``sel`` groups by, with positional ordinals resolved to the projections
+    they name.
+
+    ``GROUP BY 1`` names the first projection, so a reader walking the ``Group`` node's
+    arguments finds an ``exp.Literal`` where the semantics are the projected expression. Every
+    structural check over grouping keys wants the expression, so the resolution belongs here
+    rather than in each caller. We resolve by lookup instead of rewriting the tree, so the
+    caller's nodes keep the source positions that findings report line numbers from.
+
+    Every adapter dblect targets reads a bare integer in GROUP BY as a position, so this needs
+    no dialect gate.
+
+    An ordinal we cannot resolve is returned unchanged, leaving callers to treat it as the
+    opaque target it is: one past the end of the projection list, or into a prefix holding a
+    ``SELECT *`` that expands to an unknown number of columns, so position N is not the Nth
+    listed projection.
+    """
+    group = group_of(sel)
+    if group is None:
+        return ()
+    projections = cast("list[Expr]", sel.expressions)
+    return tuple(_resolve_ordinal(target, projections) for target in group.expressions)
+
+
+def _resolve_ordinal(target: Expr, projections: Sequence[Expr]) -> Expr:
+    """``target`` resolved through the projection list if it is a positional reference.
+
+    Only a bare positive integer literal is positional. A string (``GROUP BY 'x'``), a float,
+    and a negation (which parses as ``Neg`` over the literal, not a literal) are grouped
+    values, so they pass through untouched.
+    """
+    if not (isinstance(target, exp.Literal) and target.is_int):
+        return target
+    index = int(target.this)
+    if not 1 <= index <= len(projections):
+        return target
+    prefix = projections[:index]
+    if any(_expands_to_unknown_width(p) for p in prefix):
+        return target
+    return prefix[-1].unalias()
+
+
+def _expands_to_unknown_width(projection: Expr) -> bool:
+    """Whether ``projection`` stands for an unknown number of output columns.
+
+    A bare ``*`` or a qualified ``t.*`` does; ``count(*)`` does not, so this looks at the
+    projection itself rather than searching it for a ``Star``.
+    """
+    return isinstance(projection, exp.Star) or (
+        isinstance(projection, exp.Column) and isinstance(projection.this, exp.Star)
+    )
 
 
 def on_of(j: exp.Join) -> Expr | None:
@@ -459,17 +514,17 @@ def conjunctive_leaves(predicate: Expr) -> list[Expr]:
 def line_range(e: Expr) -> tuple[int, int] | None:
     """The 1-indexed (start, end) source-line span covered by `e`.
 
-    sqlglot only stamps token-position metadata onto ``Identifier`` nodes, so
-    we walk descendants and take min/max over their `meta["line"]`. Returns
-    `None` if no identifier carries a usable line number (rare; some literal-
-    only expressions like ``select 1`` have no identifier children).
+    sqlglot stamps token-position metadata onto the leaves it builds from a single token,
+    which is mostly ``Identifier`` but also ``Literal``, so we walk every descendant and take
+    min/max over the ``meta["line"]`` values we find. Reading identifiers alone left the
+    literal-only expressions with no span at all, which is how ``GROUP BY 1`` reported a
+    finding against line 0. Returns ``None`` when no descendant carries a usable line number.
 
-    Line numbers refer to the SQL the parser saw (the model's
-    ``compiled_code``).
+    Line numbers refer to the SQL the parser saw (the model's ``compiled_code``).
     """
     lines: list[int] = []
-    for ident in e.find_all(exp.Identifier):
-        line = ident.meta.get("line") if ident.meta else None
+    for node in e.walk():
+        line = node.meta.get("line") if node.meta else None
         if isinstance(line, int):
             lines.append(line)
     if not lines:

--- a/src/dblect/sql/_sqlglot.py
+++ b/src/dblect/sql/_sqlglot.py
@@ -145,35 +145,169 @@ def _projection_expressions_by_output_name(sel: exp.Select) -> dict[str, Expr]:
     return {name: e for name, e in out.items() if name not in duplicated}
 
 
+@dataclass(frozen=True)
+class _InputColumns:
+    """What a scope's sources contribute to its input columns.
+
+    ``names`` are the input columns the AST names outright. ``has_unknown_width`` records that
+    some source (or the scope's own projection) carries a star, so columns beyond ``names`` are
+    present but unnamed.
+    """
+
+    names: frozenset[str]
+    has_unknown_width: bool
+
+
 def _shadows_an_input_column(name: str, sel: exp.Select) -> bool:
     """Whether ``name`` may bind to an input column of ``sel`` rather than to its output alias.
 
     SQL resolves a GROUP BY name against the input columns first and only then against the
-    output aliases, so ``select b.amt * 2 as amt ... group by amt`` groups by ``b.amt``. Naming
-    the input columns exactly needs a schema, which the AST layer does not have, so we treat any
-    column of that name referenced elsewhere in the query as evidence the name is taken and
-    decline to resolve. That is conservative in the direction of the behaviour before aliases
-    resolved at all: an input column the query never mentions still slips through, which is the
-    known-permissive edge of this rule.
+    output aliases, so ``select b.amt * 2 as amt ... group by amt`` groups by ``b.amt``.
 
-    ``GROUP BY`` and ``ORDER BY`` are excluded from the sweep because both resolve names against
-    output aliases themselves, so a reference there is not evidence of an input column.
+    The name shadows when it is one of the enumerated input columns, and either way one thing
+    short-circuits to "declines": a star of unknown width, whether the scope's own projection
+    (``select a.*``) or one it reads from (``(select * from raw) p``), carries columns any of
+    which may be the queried name. A source that aliases the name into existence
+    (``(select v as amt from raw) p``) is caught by the first test, since that name is among the
+    enumerated columns.
 
-    A projection that expands to unknown width settles the question the other way: ``select
-    a.*`` carries every column of ``a`` without naming one, so any name may be among them and
-    the sweep has nothing to find. Treating that as "no input column" would resolve the alias
-    and report against an expression the engine never grouped by, turning the permissive edge
-    above into a false positive, so an unexpanded star declines every name in the query.
+    Otherwise we fall back to evidence: a column of that name referenced somewhere that could
+    bind to one of this scope's own sources. This is the case a base table forces, its columns
+    being unknowable without a schema, and it leaves the **known-permissive edge** of this rule,
+    an input column of a base table the query never mentions, which still slips through. Where
+    every source enumerates its columns and the name is not among them, no valid reference to it
+    can exist, so this path resolves the alias just the same.
+
+    Not evidence: a reference from a scope that cannot bind to this one. An unused CTE's body
+    and an uncorrelated subquery both describe other scopes' columns, so they say nothing about
+    what this scope's sources carry. A correlated reference does reach back out, so a column
+    qualified with one of this scope's source aliases counts wherever it is written. ``GROUP BY``
+    and ``ORDER BY`` are skipped because both resolve names against output aliases themselves,
+    so a reference there is not evidence of an input column.
     """
-    if any(_expands_to_unknown_width(p) for p in sel.expressions):
+    inputs = _input_columns(sel)
+    if name in inputs.names or inputs.has_unknown_width:
         return True
+    return _name_bound_against_scope(name, sel)
+
+
+def _input_columns(sel: exp.Select) -> _InputColumns:
+    """What ``sel``'s sources contribute to its input columns, as far as the AST names them."""
+    names: set[str] = set()
+    has_unknown_width = any(_expands_to_unknown_width(p) for p in sel.expressions)
+    ctes = _visible_ctes(sel)
+    for source in _sources_of(sel):
+        body = _relation_body(source, ctes)
+        if body is None:  # a base table: unknowable, evidence fallback
+            continue
+        outputs = _output_names(body)
+        names |= outputs.names
+        has_unknown_width = has_unknown_width or outputs.has_unknown_width
+    return _InputColumns(frozenset(names), has_unknown_width)
+
+
+def _relation_body(source: Expr, ctes: Mapping[str, exp.Select]) -> exp.Select | None:
+    """The SELECT behind ``source`` when it is one we can read: a derived table, or a table
+    reference naming a CTE in scope. A base table (or anything else in FROM position, such as a
+    table function or an UNNEST) has no body here and its columns stay unknown."""
+    if isinstance(source, exp.Subquery) and isinstance(source.this, exp.Select):
+        return source.this
+    if isinstance(source, exp.Table):
+        return ctes.get(source.name.lower())
+    return None
+
+
+@dataclass(frozen=True)
+class _OutputNames:
+    """The names a SELECT projects, and whether a star leaves some of them unnamed."""
+
+    names: frozenset[str]
+    has_unknown_width: bool
+
+
+def _output_names(sel: exp.Select) -> _OutputNames:
+    """Every name ``sel`` projects. A star sets ``has_unknown_width``, since it stands for
+    columns we cannot name. A bare expression contributes no name (the engine picks one that no
+    clean identifier a GROUP BY writes will match), but it does not widen the output the way a
+    star does, so it is simply skipped."""
+    names: set[str] = set()
+    has_unknown_width = False
+    for proj in sel.expressions:
+        if _expands_to_unknown_width(proj):
+            has_unknown_width = True
+        elif isinstance(proj, exp.Alias):
+            names.add(proj.alias_or_name)
+        elif isinstance(proj, exp.Column) and isinstance(proj.this, exp.Identifier):
+            names.add(column_name(proj))
+    return _OutputNames(frozenset(names), has_unknown_width)
+
+
+def _visible_ctes(sel: exp.Select) -> dict[str, exp.Select]:
+    """Every CTE ``sel`` can reference, by lower-cased name, walking out through the enclosing
+    statements. An inner definition shadows an outer one of the same name, so the first binding
+    found walking outward wins."""
+    out: dict[str, exp.Select] = {}
+    node: Expr | None = sel
+    while node is not None:
+        if isinstance(node, exp.Select):
+            for cte in node.ctes:
+                if isinstance(cte.this, exp.Select):
+                    out.setdefault(cte.alias_or_name.lower(), cte.this)
+        node = node.parent
+    return out
+
+
+def _sources_of(sel: exp.Select) -> list[Expr]:
+    """The relations ``sel`` reads from: its FROM, its JOINs, and its laterals."""
+    from_ = from_of(sel)
+    sources: list[Expr] = [] if from_ is None else [cast("Expr", from_.this)]
+    sources.extend(cast("Expr", j.this) for j in joins_of(sel))
+    sources.extend(laterals_of(sel))
+    return sources
+
+
+# Clauses whose column references are not evidence that a name binds to an input column.
+# GROUP BY and ORDER BY resolve names against output aliases themselves, so a reference there
+# is the very thing being resolved. A CTE list describes other scopes; where a CTE is actually
+# read, :func:`_input_columns` takes its output names instead. Both spellings of the WITH key
+# are listed for the same reason :func:`from_of` accepts two: sqlglot's compiled build suffixes
+# keys that collide with Python keywords.
+_NOT_INPUT_EVIDENCE = frozenset({"group", "order", "with", "with_"})
+
+
+def _name_bound_against_scope(name: str, sel: exp.Select) -> bool:
+    """Whether a column named ``name`` is referenced anywhere that could bind to ``sel``'s own
+    sources: written directly in ``sel``'s scope, or qualified with one of its source aliases
+    from inside a correlated subquery."""
+    aliases = {a.lower() for a in (name_of(s) for s in _sources_of(sel)) if a}
     for key, arg in sel.args.items():
-        if key in ("group", "order"):
+        if key in _NOT_INPUT_EVIDENCE:
             continue
         nodes = cast("list[object]", arg) if isinstance(arg, list) else [cast("object", arg)]
         for node in nodes:
-            if isinstance(node, Expr) and any(column_name(c) == name for c in find_columns(node)):
-                return True
+            if not isinstance(node, Expr):
+                continue
+            for c in find_columns(node):
+                if column_name(c) != name:
+                    continue
+                table = column_table(c)
+                if node_in_scope(c, sel) or (table is not None and table.lower() in aliases):
+                    return True
+    return False
+
+
+def node_in_scope(node: Expr, sel: exp.Select) -> bool:
+    """True when ``node``'s nearest enclosing SELECT is ``sel`` (not a nested sub-SELECT).
+
+    A node's scope decides which relations' columns it can refer to, so any check that reads a
+    node against ``sel``'s sources, keys, or grouping has to exclude nodes that actually belong
+    to a nested SELECT, where those are a different scope's.
+    """
+    cur: Expr | None = node.parent
+    while cur is not None:
+        if isinstance(cur, exp.Select):
+            return cur is sel
+        cur = cur.parent
     return False
 
 

--- a/src/dblect/sql/_sqlglot.py
+++ b/src/dblect/sql/_sqlglot.py
@@ -67,15 +67,10 @@ def group_of(sel: exp.Select) -> exp.Group | None:
 class GroupTarget:
     """One ``GROUP BY`` target: the expression it denotes, and the node the query writes.
 
-    ``expression`` is the projection an ordinal or an output name resolves to, which is what a
-    structural check reasons over. ``written_at`` is the node inside the ``Group`` clause, and it
-    is where a finding about the *grouping decision* belongs: ``GROUP BY 1`` is diagnosed at the
-    ``GROUP BY``, which is the line an analyst goes looking at. A finding about something written
-    *inside* the target instead (a ``now()`` call, say) belongs at ``expression``, since that is
-    where the offending call is spelled out.
-
-    The two are the same node for a target written out in full, and for one we decline to
-    resolve.
+    A finding about the *grouping decision* belongs at ``written_at``, so ``GROUP BY 1`` is
+    diagnosed at the clause an analyst reads. One about something written inside the target (a
+    ``now()`` call) belongs at ``expression``, where that call is spelled out. The two nodes
+    coincide for a target written in full.
     """
 
     expression: Expr
@@ -83,23 +78,17 @@ class GroupTarget:
 
 
 def group_targets(sel: exp.Select) -> tuple[GroupTarget, ...]:
-    """The targets ``sel`` groups by, with positional ordinals and output-name references
-    resolved to the projections they name.
+    """The targets ``sel`` groups by, with ordinals and output-name references resolved to the
+    projections they name.
 
     ``GROUP BY 1`` and ``GROUP BY revenue_day`` both name a projection, so a reader walking the
-    ``Group`` node's arguments finds an ``exp.Literal`` or a table-less ``exp.Column`` where the
-    semantics are the projected expression. Every structural check over grouping keys wants that
-    expression, so the resolution belongs here rather than in each caller. We resolve by lookup
-    rather than by rewriting the tree, and pair each resolved expression with the node the query
-    writes, so a caller reasons over the semantics while still reporting at the source position
-    the analyst reads.
+    ``Group`` node's arguments finds a literal or a table-less column where the semantics are the
+    projected expression. Every structural check over grouping keys wants that expression, so the
+    resolution belongs here rather than in each caller. Resolution is by lookup rather than by
+    rewriting the tree, so the nodes keep their source positions.
 
-    Every adapter dblect targets reads a bare integer in GROUP BY as a position, so this needs
-    no dialect gate.
-
-    A target we cannot resolve carries itself as its own ``expression``, leaving callers to treat
-    it as the opaque target it is. :func:`_resolve_ordinal` and :func:`_resolve_name` each
-    document when they decline.
+    Every adapter dblect targets reads a bare integer in GROUP BY as a position, so no dialect
+    gate is needed. A target we cannot resolve carries itself as its own ``expression``.
     """
     group = group_of(sel)
     if group is None:
@@ -107,56 +96,51 @@ def group_targets(sel: exp.Select) -> tuple[GroupTarget, ...]:
     projections = cast("list[Expr]", sel.expressions)
     projected = _projection_expressions_by_output_name(sel)
     return tuple(
-        GroupTarget(_resolve_group_target(target, sel, projections, projected), target)
+        GroupTarget(_resolve_group_target(target, projections, projected), target)
         for target in group.expressions
     )
 
 
 def _resolve_group_target(
-    target: Expr, sel: exp.Select, projections: Sequence[Expr], projected: Mapping[str, Expr]
+    target: Expr, projections: Sequence[Expr], projected: Mapping[str, Expr]
 ) -> Expr:
     resolved = _resolve_ordinal(target, projections)
-    return resolved if resolved is not None else _resolve_name(target, sel, projected)
+    return resolved if resolved is not None else _resolve_name(target, projected)
 
 
 def _names_an_output_column(e: Expr) -> TypeGuard[exp.Column]:
     """Whether ``e`` is the spelling that can bind to a projection's output name.
 
-    Only an unqualified column reference can. A qualified ``t.k`` binds to that relation's
-    column and never picks up an output name that happens to match, which holds for a GROUP BY
-    and a statement-level ORDER BY alike (duckdb: ``select id as x, other as id ... order by
-    orders.id`` sorts by ``id``, ``order by id`` sorts by ``other``).
+    Only an unqualified column reference can. A qualified ``t.k`` binds to that relation's column
+    and never picks up a matching output name, in a GROUP BY and a statement-level ORDER BY alike
+    (duckdb: ``select id as x, other as id ... order by orders.id`` sorts by ``id``, while
+    ``order by id`` sorts by ``other``).
     """
     return isinstance(e, exp.Column) and isinstance(e.this, exp.Identifier) and e.table == ""
 
 
-def _resolve_name(target: Expr, sel: exp.Select, projected: Mapping[str, Expr]) -> Expr:
+def _resolve_name(target: Expr, projected: Mapping[str, Expr]) -> Expr:
     """``target`` resolved to the projection it names, if it is an output-name reference.
 
-    A name matching a projection that is *itself* the bare column of that name resolves
-    unconditionally: SQL would bind the name to that input column, and the projection is that
-    same column, so the two readings agree and the shadowing question does not arise. This is
-    the ``select orders.customer_id ... group by customer_id`` idiom. Any other projection is
-    a renaming, where an input column of the same name would win over the output name, so it
-    resolves only when :func:`_shadows_an_input_column` finds no such column.
+    **Known-permissive edge**: SQL binds a GROUP BY name to an input column before an output
+    alias, so ``select b.amt * 2 as amt ... group by amt`` really groups by ``b.amt`` while this
+    resolves it to ``b.amt * 2``. Ruling that out needs a schema the AST layer does not have. A
+    reader reasoning structurally lands on the same join side either way, which is why the
+    detectors accept it: their error direction is to over-report. A consumer that *grounds* a
+    fact from the group key needs more, and takes it from the target it was written as.
     """
     if not _names_an_output_column(target):
         return target
-    name = column_name(target)
-    projection = projected.get(name)
-    if projection is None:
-        return target
-    if isinstance(projection, exp.Column) and column_name(projection) == name:
-        return projection
-    return target if _shadows_an_input_column(name, sel) else projection
+    projection = projected.get(column_name(target))
+    return target if projection is None else projection
 
 
 def _projection_expressions_by_output_name(sel: exp.Select) -> dict[str, Expr]:
     """Each output name in ``sel``'s projection mapped to the expression behind it.
 
-    An output name carried by two projections names neither unambiguously, so it is dropped
-    rather than resolved to whichever came last. Such a query does not run anyway: an engine
-    binds the first and then rejects the second as ungrouped.
+    A name carried by two projections names neither unambiguously, so it is dropped rather than
+    resolved to whichever came last. Such a query does not run anyway: an engine binds the first
+    and rejects the second as ungrouped.
     """
     out: dict[str, Expr] = {}
     duplicated: set[str] = set()
@@ -174,199 +158,18 @@ def _projection_expressions_by_output_name(sel: exp.Select) -> dict[str, Expr]:
 
 
 @dataclass(frozen=True)
-class _ColumnNames:
-    """Column names the AST states outright, and whether a star leaves further ones unnamed.
-
-    Both readings this rule needs have the same shape: the names a SELECT projects, and the
-    input columns a scope's sources contribute (the union of the first over those sources).
-    ``has_unknown_width`` records a star standing where columns beyond ``names`` are present but
-    unnameable, which is the signal to decline rather than to conclude a name is free.
-    """
-
-    names: frozenset[str]
-    has_unknown_width: bool
-
-
-def _shadows_an_input_column(name: str, sel: exp.Select) -> bool:
-    """Whether ``name`` may bind to an input column of ``sel`` rather than to its output alias.
-
-    SQL resolves a GROUP BY name against the input columns first and only then against the
-    output aliases, so ``select b.amt * 2 as amt ... group by amt`` groups by ``b.amt``.
-
-    The name shadows when it is one of the enumerated input columns, and either way one thing
-    short-circuits to "declines": a star of unknown width, whether the scope's own projection
-    (``select a.*``) or one it reads from (``(select * from raw) p``), carries columns any of
-    which may be the queried name. A source that aliases the name into existence
-    (``(select v as amt from raw) p``) is caught by the first test, since that name is among the
-    enumerated columns.
-
-    Where every source names its own columns and this one is not among them, the name is
-    decidably free: no valid reference to it can exist, so it does not shadow.
-
-    A base table is what forces the third answer, its columns being unknowable without a schema.
-    There we fall back to evidence: a column of that name referenced somewhere that could bind to
-    one of this scope's own sources. That leaves the **known-permissive edge** of this rule, an
-    input column of a base table the query never mentions, which still slips through.
-
-    Not evidence: a reference from a scope that cannot bind to this one. An unused CTE's body
-    and an uncorrelated subquery both describe other scopes' columns, so they say nothing about
-    what this scope's sources carry. A correlated reference does reach back out, so a column
-    qualified with one of this scope's source aliases counts wherever it is written. ``GROUP BY``
-    and ``ORDER BY`` are skipped because both resolve names against output aliases themselves,
-    so a reference there is not evidence of an input column.
-    """
-    ctes = _visible_ctes(sel)
-    bodies = [_relation_body(source, ctes) for source in _sources_of(sel)]
-    inputs = _input_columns(sel, bodies)
-    if name in inputs.names or inputs.has_unknown_width:
-        return True
-    if all(body is not None for body in bodies):
-        return False
-    return _name_bound_against_scope(name, sel)
-
-
-def _input_columns(sel: exp.Select, bodies: Sequence[exp.Select | None]) -> _ColumnNames:
-    """What ``sel``'s sources contribute to its input columns, as far as the AST names them.
-
-    ``bodies`` holds one entry per source, ``None`` where that source is a base table whose
-    columns only a schema could enumerate.
-    """
-    names: set[str] = set()
-    has_unknown_width = any(_expands_to_unknown_width(p) for p in sel.expressions)
-    for body in bodies:
-        if body is None:
-            continue
-        outputs = _output_names(body)
-        names |= outputs.names
-        has_unknown_width = has_unknown_width or outputs.has_unknown_width
-    return _ColumnNames(frozenset(names), has_unknown_width)
-
-
-def _relation_body(source: Expr, ctes: Mapping[str, exp.Select]) -> exp.Select | None:
-    """The SELECT behind ``source`` when it is one we can read: a derived table, or an
-    unqualified table reference naming a CTE in scope.
-
-    A base table has no body here and its columns stay unknown, as does anything else in FROM
-    position such as a table function or an UNNEST. So does a schema- or catalog-qualified name:
-    ``db.c`` is the real table even where a CTE ``c`` is in scope, so reading that CTE's body
-    would answer about a different relation.
-    """
-    if isinstance(source, exp.Subquery) and isinstance(source.this, exp.Select):
-        return source.this
-    if isinstance(source, exp.Table) and not source.db and not source.catalog:
-        return ctes.get(source.name.lower())
-    return None
-
-
-def _output_names(sel: exp.Select) -> _ColumnNames:
-    """Every name ``sel`` projects. A star sets ``has_unknown_width``, since it stands for
-    columns we cannot name. A bare expression contributes no name (the engine picks one that no
-    clean identifier a GROUP BY writes will match), but it does not widen the output the way a
-    star does, so it is simply skipped."""
-    names: set[str] = set()
-    has_unknown_width = False
-    for proj in sel.expressions:
-        if _expands_to_unknown_width(proj):
-            has_unknown_width = True
-        elif isinstance(proj, exp.Alias):
-            names.add(proj.alias_or_name)
-        elif isinstance(proj, exp.Column) and isinstance(proj.this, exp.Identifier):
-            names.add(column_name(proj))
-    return _ColumnNames(frozenset(names), has_unknown_width)
-
-
-def _visible_ctes(sel: exp.Select) -> dict[str, exp.Select]:
-    """Every CTE ``sel`` can reference, by lower-cased name, walking out through the enclosing
-    statements. An inner definition shadows an outer one of the same name, so the first binding
-    found walking outward wins."""
-    out: dict[str, exp.Select] = {}
-    node: Expr | None = sel
-    while node is not None:
-        if isinstance(node, exp.Select):
-            for cte in node.ctes:
-                if isinstance(cte.this, exp.Select):
-                    out.setdefault(cte.alias_or_name.lower(), cte.this)
-        node = node.parent
-    return out
-
-
-def _sources_of(sel: exp.Select) -> list[Expr]:
-    """The relations ``sel`` reads from: its FROM, its JOINs, and its laterals."""
-    from_ = from_of(sel)
-    sources: list[Expr] = [] if from_ is None else [cast("Expr", from_.this)]
-    sources.extend(cast("Expr", j.this) for j in joins_of(sel))
-    sources.extend(laterals_of(sel))
-    return sources
-
-
-# Clauses whose column references are not evidence that a name binds to an input column.
-# GROUP BY and ORDER BY resolve names against output aliases themselves, so a reference there
-# is the very thing being resolved. A CTE list describes other scopes; where a CTE is actually
-# read, :func:`_input_columns` takes its output names instead. Both spellings of the WITH key
-# are listed for the same reason :func:`from_of` accepts two: sqlglot's compiled build suffixes
-# keys that collide with Python keywords.
-#
-# HAVING and QUALIFY stay in the sweep even though several adapters resolve output aliases
-# there too, so a reference from one is weak evidence. Counting it can only decline to resolve,
-# which is the permissive direction this rule already takes for a base table.
-_NOT_INPUT_EVIDENCE = frozenset({"group", "order", "with", "with_"})
-
-
-def _name_bound_against_scope(name: str, sel: exp.Select) -> bool:
-    """Whether a column named ``name`` is referenced anywhere that could bind to ``sel``'s own
-    sources: written directly in ``sel``'s scope, or qualified with one of its source aliases
-    from inside a correlated subquery."""
-    aliases = {a.lower() for a in (name_of(s) for s in _sources_of(sel)) if a}
-    for key, arg in sel.args.items():
-        if key in _NOT_INPUT_EVIDENCE:
-            continue
-        nodes = cast("list[object]", arg) if isinstance(arg, list) else [cast("object", arg)]
-        for node in nodes:
-            if not isinstance(node, Expr):
-                continue
-            for c in find_columns(node):
-                if column_name(c) != name:
-                    continue
-                table = column_table(c)
-                if node_in_scope(c, sel) or (table is not None and table.lower() in aliases):
-                    return True
-    return False
-
-
-def node_in_scope(node: Expr, sel: exp.Select) -> bool:
-    """True when ``node``'s nearest enclosing SELECT is ``sel`` (not a nested sub-SELECT).
-
-    A node's scope decides which relations' columns it can refer to, so any check that reads a
-    node against ``sel``'s sources, keys, or grouping has to exclude nodes that actually belong
-    to a nested SELECT, where those are a different scope's.
-    """
-    cur: Expr | None = node.parent
-    while cur is not None:
-        if isinstance(cur, exp.Select):
-            return cur is sel
-        cur = cur.parent
-    return False
-
-
-@dataclass(frozen=True)
 class OrderTarget:
     """One statement-level ``ORDER BY`` target, and which namespace its expression is in.
 
-    A positional target resolves to the named projection's own expression, so it arrives in the
-    query's *source* namespace, already past the ``AS`` binding. So does a qualified ``t.k``,
-    which binds to that relation's column outright (see :func:`_names_an_output_column`). Only a
-    bare name is in the *output* namespace, where a caller matching against source columns still
-    has to translate it through the projection's aliases.
+    A resolved ordinal and a qualified ``t.k`` both name a source column outright, already past
+    the ``AS`` binding. Only a bare name is in the *output* namespace, where a caller matching
+    against source columns has to translate it through the projection's aliases first.
 
     Conflating the two re-translates a source column whenever some *other* projection is aliased
-    to that name: in ``select id as x, other as id ... order by 1`` (and in the ``order by
-    orders.id`` spelling of the same thing) the target is ``id``, which a second pass through the
-    alias map would turn into ``other``.
-
-    A target that names no single column, an ``order by lower(k)``, carries the source-namespace
-    reading by default. Nothing acts on that: the one consumer,
-    ``detect_limit_without_deterministic_order``, declines a target that is not a bare column
-    before the namespace can matter.
+    to that name: in ``select id as x, other as id ... order by 1`` the target is ``id``, which a
+    second pass through the alias map would turn into ``other``. A target naming no single column
+    (``order by lower(k)``) carries the source reading by default, which nothing acts on: the one
+    consumer declines a non-bare-column target first.
     """
 
     expression: Expr
@@ -401,13 +204,12 @@ def imposes_row_order(order: exp.Order | None) -> bool:
 
     An ORDER BY inside a window or an aggregate takes expressions, never the positional
     references a statement-level ORDER BY accepts, so a literal there is a constant: every row
-    sorts equal and the ranking falls back to whatever physical order the engine happened to
-    have. An ordering whose targets reference no column therefore pins nothing, and the caller's
-    "no ORDER BY" hazard applies to it unchanged.
+    sorts equal and the ranking follows whatever physical order the engine had. An ordering whose
+    targets reference no column therefore pins nothing.
 
-    A target referencing a column counts even when the column sits inside a subquery, where the
-    value is constant per row and so orders nothing either. That keeps the answer conservative:
-    the caller stays silent rather than reporting a hazard this rule cannot yet prove.
+    A column inside a subquery counts even though it is constant per row and orders nothing
+    either, which keeps the answer conservative: the caller stays silent rather than report a
+    hazard this rule cannot prove.
     """
     if order is None or not order.expressions:
         return False
@@ -844,11 +646,10 @@ def line_range(e: Expr) -> tuple[int, int] | None:
     """The 1-indexed (start, end) source-line span covered by `e`.
 
     sqlglot stamps ``meta["line"]`` at the token a node opens on, and not only on identifiers:
-    literals, function calls, and stars carry one too. So we walk every descendant and take
-    min/max over the positions we find. Every stamp lies within its own node's span, so the
-    extra sources only tighten the answer toward the true start. Reading identifiers alone left
-    literal-only expressions with no span at all, which is how ``GROUP BY 1`` reported a finding
-    against line 0. Returns ``None`` when no descendant carries a usable line number.
+    literals, function calls, and stars carry one too. Every stamp lies inside its own node's
+    span, so walking all descendants and taking min/max only tightens the answer. Reading
+    identifiers alone left literal-only expressions with no span, which is how ``GROUP BY 1``
+    reported against line 0. Returns ``None`` when no descendant carries a line number.
 
     Line numbers refer to the SQL the parser saw (the model's ``compiled_code``).
     """

--- a/src/dblect/sql/_sqlglot.py
+++ b/src/dblect/sql/_sqlglot.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import cast
+from typing import TypeGuard, cast
 
 import sqlglot.expressions as exp
 from sqlglot import Expr
@@ -63,23 +63,43 @@ def group_of(sel: exp.Select) -> exp.Group | None:
     return cast("exp.Group | None", sel.args.get("group"))
 
 
-def group_targets(sel: exp.Select) -> tuple[Expr, ...]:
-    """The expressions ``sel`` groups by, with positional ordinals and output-alias references
+@dataclass(frozen=True)
+class GroupTarget:
+    """One ``GROUP BY`` target: the expression it denotes, and the node the query writes.
+
+    ``expression`` is the projection an ordinal or an output name resolves to, which is what a
+    structural check reasons over. ``written_at`` is the node inside the ``Group`` clause, and it
+    is where a finding about the *grouping decision* belongs: ``GROUP BY 1`` is diagnosed at the
+    ``GROUP BY``, which is the line an analyst goes looking at. A finding about something written
+    *inside* the target instead (a ``now()`` call, say) belongs at ``expression``, since that is
+    where the offending call is spelled out.
+
+    The two are the same node for a target written out in full, and for one we decline to
+    resolve.
+    """
+
+    expression: Expr
+    written_at: Expr
+
+
+def group_targets(sel: exp.Select) -> tuple[GroupTarget, ...]:
+    """The targets ``sel`` groups by, with positional ordinals and output-name references
     resolved to the projections they name.
 
     ``GROUP BY 1`` and ``GROUP BY revenue_day`` both name a projection, so a reader walking the
     ``Group`` node's arguments finds an ``exp.Literal`` or a table-less ``exp.Column`` where the
     semantics are the projected expression. Every structural check over grouping keys wants that
     expression, so the resolution belongs here rather than in each caller. We resolve by lookup
-    instead of rewriting the tree, so the caller's nodes keep the source positions that findings
-    report line numbers from.
+    rather than by rewriting the tree, and pair each resolved expression with the node the query
+    writes, so a caller reasons over the semantics while still reporting at the source position
+    the analyst reads.
 
     Every adapter dblect targets reads a bare integer in GROUP BY as a position, so this needs
     no dialect gate.
 
-    A target we cannot resolve is returned unchanged, leaving callers to treat it as the opaque
-    target it is. :func:`_resolve_ordinal` and :func:`_resolve_name` each document when they
-    decline.
+    A target we cannot resolve carries itself as its own ``expression``, leaving callers to treat
+    it as the opaque target it is. :func:`_resolve_ordinal` and :func:`_resolve_name` each
+    document when they decline.
     """
     group = group_of(sel)
     if group is None:
@@ -87,7 +107,8 @@ def group_targets(sel: exp.Select) -> tuple[Expr, ...]:
     projections = cast("list[Expr]", sel.expressions)
     projected = _projection_expressions_by_output_name(sel)
     return tuple(
-        _resolve_group_target(target, sel, projections, projected) for target in group.expressions
+        GroupTarget(_resolve_group_target(target, sel, projections, projected), target)
+        for target in group.expressions
     )
 
 
@@ -98,10 +119,19 @@ def _resolve_group_target(
     return resolved if resolved is not None else _resolve_name(target, sel, projected)
 
 
+def _names_an_output_column(e: Expr) -> TypeGuard[exp.Column]:
+    """Whether ``e`` is the spelling that can bind to a projection's output name.
+
+    Only an unqualified column reference can. A qualified ``t.k`` binds to that relation's
+    column and never picks up an output name that happens to match, which holds for a GROUP BY
+    and a statement-level ORDER BY alike (duckdb: ``select id as x, other as id ... order by
+    orders.id`` sorts by ``id``, ``order by id`` sorts by ``other``).
+    """
+    return isinstance(e, exp.Column) and isinstance(e.this, exp.Identifier) and e.table == ""
+
+
 def _resolve_name(target: Expr, sel: exp.Select, projected: Mapping[str, Expr]) -> Expr:
     """``target`` resolved to the projection it names, if it is an output-name reference.
-
-    Only an unqualified column name can name a projection; ``t.k`` binds to the table.
 
     A name matching a projection that is *itself* the bare column of that name resolves
     unconditionally: SQL would bind the name to that input column, and the projection is that
@@ -110,9 +140,7 @@ def _resolve_name(target: Expr, sel: exp.Select, projected: Mapping[str, Expr]) 
     a renaming, where an input column of the same name would win over the output name, so it
     resolves only when :func:`_shadows_an_input_column` finds no such column.
     """
-    if not isinstance(target, exp.Column) or target.args.get("table") is not None:
-        return target
-    if not isinstance(target.this, exp.Identifier):
+    if not _names_an_output_column(target):
         return target
     name = column_name(target)
     projection = projected.get(name)
@@ -146,12 +174,13 @@ def _projection_expressions_by_output_name(sel: exp.Select) -> dict[str, Expr]:
 
 
 @dataclass(frozen=True)
-class _InputColumns:
-    """What a scope's sources contribute to its input columns.
+class _ColumnNames:
+    """Column names the AST states outright, and whether a star leaves further ones unnamed.
 
-    ``names`` are the input columns the AST names outright. ``has_unknown_width`` records that
-    some source (or the scope's own projection) carries a star, so columns beyond ``names`` are
-    present but unnamed.
+    Both readings this rule needs have the same shape: the names a SELECT projects, and the
+    input columns a scope's sources contribute (the union of the first over those sources).
+    ``has_unknown_width`` records a star standing where columns beyond ``names`` are present but
+    unnameable, which is the signal to decline rather than to conclude a name is free.
     """
 
     names: frozenset[str]
@@ -171,12 +200,13 @@ def _shadows_an_input_column(name: str, sel: exp.Select) -> bool:
     (``(select v as amt from raw) p``) is caught by the first test, since that name is among the
     enumerated columns.
 
-    Otherwise we fall back to evidence: a column of that name referenced somewhere that could
-    bind to one of this scope's own sources. This is the case a base table forces, its columns
-    being unknowable without a schema, and it leaves the **known-permissive edge** of this rule,
-    an input column of a base table the query never mentions, which still slips through. Where
-    every source enumerates its columns and the name is not among them, no valid reference to it
-    can exist, so this path resolves the alias just the same.
+    Where every source names its own columns and this one is not among them, the name is
+    decidably free: no valid reference to it can exist, so it does not shadow.
+
+    A base table is what forces the third answer, its columns being unknowable without a schema.
+    There we fall back to evidence: a column of that name referenced somewhere that could bind to
+    one of this scope's own sources. That leaves the **known-permissive edge** of this rule, an
+    input column of a base table the query never mentions, which still slips through.
 
     Not evidence: a reference from a scope that cannot bind to this one. An unused CTE's body
     and an uncorrelated subquery both describe other scopes' columns, so they say nothing about
@@ -185,47 +215,50 @@ def _shadows_an_input_column(name: str, sel: exp.Select) -> bool:
     and ``ORDER BY`` are skipped because both resolve names against output aliases themselves,
     so a reference there is not evidence of an input column.
     """
-    inputs = _input_columns(sel)
+    ctes = _visible_ctes(sel)
+    bodies = [_relation_body(source, ctes) for source in _sources_of(sel)]
+    inputs = _input_columns(sel, bodies)
     if name in inputs.names or inputs.has_unknown_width:
         return True
+    if all(body is not None for body in bodies):
+        return False
     return _name_bound_against_scope(name, sel)
 
 
-def _input_columns(sel: exp.Select) -> _InputColumns:
-    """What ``sel``'s sources contribute to its input columns, as far as the AST names them."""
+def _input_columns(sel: exp.Select, bodies: Sequence[exp.Select | None]) -> _ColumnNames:
+    """What ``sel``'s sources contribute to its input columns, as far as the AST names them.
+
+    ``bodies`` holds one entry per source, ``None`` where that source is a base table whose
+    columns only a schema could enumerate.
+    """
     names: set[str] = set()
     has_unknown_width = any(_expands_to_unknown_width(p) for p in sel.expressions)
-    ctes = _visible_ctes(sel)
-    for source in _sources_of(sel):
-        body = _relation_body(source, ctes)
-        if body is None:  # a base table: unknowable, evidence fallback
+    for body in bodies:
+        if body is None:
             continue
         outputs = _output_names(body)
         names |= outputs.names
         has_unknown_width = has_unknown_width or outputs.has_unknown_width
-    return _InputColumns(frozenset(names), has_unknown_width)
+    return _ColumnNames(frozenset(names), has_unknown_width)
 
 
 def _relation_body(source: Expr, ctes: Mapping[str, exp.Select]) -> exp.Select | None:
-    """The SELECT behind ``source`` when it is one we can read: a derived table, or a table
-    reference naming a CTE in scope. A base table (or anything else in FROM position, such as a
-    table function or an UNNEST) has no body here and its columns stay unknown."""
+    """The SELECT behind ``source`` when it is one we can read: a derived table, or an
+    unqualified table reference naming a CTE in scope.
+
+    A base table has no body here and its columns stay unknown, as does anything else in FROM
+    position such as a table function or an UNNEST. So does a schema- or catalog-qualified name:
+    ``db.c`` is the real table even where a CTE ``c`` is in scope, so reading that CTE's body
+    would answer about a different relation.
+    """
     if isinstance(source, exp.Subquery) and isinstance(source.this, exp.Select):
         return source.this
-    if isinstance(source, exp.Table):
+    if isinstance(source, exp.Table) and not source.db and not source.catalog:
         return ctes.get(source.name.lower())
     return None
 
 
-@dataclass(frozen=True)
-class _OutputNames:
-    """The names a SELECT projects, and whether a star leaves some of them unnamed."""
-
-    names: frozenset[str]
-    has_unknown_width: bool
-
-
-def _output_names(sel: exp.Select) -> _OutputNames:
+def _output_names(sel: exp.Select) -> _ColumnNames:
     """Every name ``sel`` projects. A star sets ``has_unknown_width``, since it stands for
     columns we cannot name. A bare expression contributes no name (the engine picks one that no
     clean identifier a GROUP BY writes will match), but it does not widen the output the way a
@@ -239,7 +272,7 @@ def _output_names(sel: exp.Select) -> _OutputNames:
             names.add(proj.alias_or_name)
         elif isinstance(proj, exp.Column) and isinstance(proj.this, exp.Identifier):
             names.add(column_name(proj))
-    return _OutputNames(frozenset(names), has_unknown_width)
+    return _ColumnNames(frozenset(names), has_unknown_width)
 
 
 def _visible_ctes(sel: exp.Select) -> dict[str, exp.Select]:
@@ -272,6 +305,10 @@ def _sources_of(sel: exp.Select) -> list[Expr]:
 # read, :func:`_input_columns` takes its output names instead. Both spellings of the WITH key
 # are listed for the same reason :func:`from_of` accepts two: sqlglot's compiled build suffixes
 # keys that collide with Python keywords.
+#
+# HAVING and QUALIFY stay in the sweep even though several adapters resolve output aliases
+# there too, so a reference from one is weak evidence. Counting it can only decline to resolve,
+# which is the permissive direction this rule already takes for a base table.
 _NOT_INPUT_EVIDENCE = frozenset({"group", "order", "with", "with_"})
 
 
@@ -316,13 +353,20 @@ class OrderTarget:
     """One statement-level ``ORDER BY`` target, and which namespace its expression is in.
 
     A positional target resolves to the named projection's own expression, so it arrives in the
-    query's *source* namespace, already past the ``AS`` binding. A target spelled as a name is
-    in the *output* namespace, where a caller matching against source columns still has to
-    translate it through the projection's aliases.
+    query's *source* namespace, already past the ``AS`` binding. So does a qualified ``t.k``,
+    which binds to that relation's column outright (see :func:`_names_an_output_column`). Only a
+    bare name is in the *output* namespace, where a caller matching against source columns still
+    has to translate it through the projection's aliases.
 
-    Conflating the two re-translates a resolved source column whenever some *other* projection
-    is aliased to that name: in ``select id as x, other as id ... order by 1`` the ordinal
-    resolves to ``id``, which a second pass through the alias map would turn into ``other``.
+    Conflating the two re-translates a source column whenever some *other* projection is aliased
+    to that name: in ``select id as x, other as id ... order by 1`` (and in the ``order by
+    orders.id`` spelling of the same thing) the target is ``id``, which a second pass through the
+    alias map would turn into ``other``.
+
+    A target that names no single column, an ``order by lower(k)``, carries the source-namespace
+    reading by default. Nothing acts on that: the one consumer,
+    ``detect_limit_without_deterministic_order``, declines a target that is not a bare column
+    before the namespace can matter.
     """
 
     expression: Expr
@@ -347,9 +391,9 @@ def statement_order_targets(sel: exp.Select) -> tuple[OrderTarget, ...]:
 
 def _order_target(target: Expr, projections: Sequence[Expr]) -> OrderTarget:
     resolved = _resolve_ordinal(target, projections)
-    if resolved is None:
-        return OrderTarget(target, in_source_namespace=False)
-    return OrderTarget(resolved, in_source_namespace=True)
+    if resolved is not None:
+        return OrderTarget(resolved, in_source_namespace=True)
+    return OrderTarget(target, in_source_namespace=not _names_an_output_column(target))
 
 
 def imposes_row_order(order: exp.Order | None) -> bool:
@@ -799,17 +843,18 @@ def conjunctive_leaves(predicate: Expr) -> list[Expr]:
 def line_range(e: Expr) -> tuple[int, int] | None:
     """The 1-indexed (start, end) source-line span covered by `e`.
 
-    sqlglot stamps token-position metadata onto the leaves it builds from a single token,
-    which is mostly ``Identifier`` but also ``Literal``, so we walk every descendant and take
-    min/max over the ``meta["line"]`` values we find. Reading identifiers alone left the
-    literal-only expressions with no span at all, which is how ``GROUP BY 1`` reported a
-    finding against line 0. Returns ``None`` when no descendant carries a usable line number.
+    sqlglot stamps ``meta["line"]`` at the token a node opens on, and not only on identifiers:
+    literals, function calls, and stars carry one too. So we walk every descendant and take
+    min/max over the positions we find. Every stamp lies within its own node's span, so the
+    extra sources only tighten the answer toward the true start. Reading identifiers alone left
+    literal-only expressions with no span at all, which is how ``GROUP BY 1`` reported a finding
+    against line 0. Returns ``None`` when no descendant carries a usable line number.
 
     Line numbers refer to the SQL the parser saw (the model's ``compiled_code``).
     """
     lines: list[int] = []
     for node in e.walk():
-        line = node.meta.get("line") if node.meta else None
+        line = node.meta.get("line")
         if isinstance(line, int):
             lines.append(line)
     if not lines:

--- a/src/dblect/sql/patterns.py
+++ b/src/dblect/sql/patterns.py
@@ -414,6 +414,10 @@ def detect_unordered_window(tree: Expr) -> tuple[Finding, ...]:
     runs unless an ORDER BY pins the order. ``LAG``/``LEAD``/``FIRST_VALUE``/
     ``LAST_VALUE`` are similarly meaningless without an ordering.
 
+    An ORDER BY whose targets reference no column is no ordering at all: inside a window a
+    literal is a constant rather than the positional reference the same literal denotes at
+    statement level, so every row sorts equal and the ranking stays arbitrary.
+
     The exception is the dedup where a ``row_number() = 1`` keeps one row per partition and
     the partition key covers every column the ranked scope carries forward: the surviving
     rows are then identical on all surfaced columns, so the missing ORDER BY does not change
@@ -424,8 +428,7 @@ def detect_unordered_window(tree: Expr) -> tuple[Finding, ...]:
         fn = sg.fn_of(w)
         if fn is None or type(fn) not in _RANKING_FUNCTIONS:
             continue
-        order = sg.order_of(w)
-        if order is not None and order.expressions:
+        if sg.imposes_row_order(sg.order_of(w)):
             continue
         if _row_number_dedup_is_order_insensitive(w):
             continue
@@ -443,12 +446,16 @@ def detect_unordered_window(tree: Expr) -> tuple[Finding, ...]:
 
 
 def detect_unordered_aggregate(tree: Expr) -> tuple[Finding, ...]:
-    """Flag order-sensitive aggregates (ARRAY_AGG, STRING_AGG) with no ORDER BY."""
+    """Flag order-sensitive aggregates (ARRAY_AGG, STRING_AGG) with no ORDER BY.
+
+    An aggregate's ORDER BY takes expressions, so ``array_agg(x order by 1)`` orders by a
+    constant and leaves the element order as undefined as no ORDER BY would.
+    """
     out: list[Finding] = []
     for node in sg.find_all_ordered_aggregates(tree):
         if isinstance(node.parent, exp.WithinGroup):
             continue
-        if sg.aggregate_order_of(node) is not None:
+        if sg.imposes_row_order(sg.aggregate_order_of(node)):
             continue
         out.append(
             finding_at(

--- a/src/dblect/sql/patterns.py
+++ b/src/dblect/sql/patterns.py
@@ -182,12 +182,12 @@ def list_group_bys(tree: Expr) -> tuple[GroupBySummary, ...]:
     """Return every GROUP BY clause's targets, one summary per containing SELECT."""
     out: list[GroupBySummary] = []
     for sel in sg.find_all_selects(tree):
-        g = sg.group_of(sel)
-        if g is None:
+        if sg.group_of(sel) is None:
             continue
-        targets = tuple(sg.render_sql(e) for e in g.expressions)
+        grouped = sg.group_targets(sel)
+        targets = tuple(sg.render_sql(e) for e in grouped)
         cols: list[tuple[str | None, str]] = []
-        for e in g.expressions:
+        for e in grouped:
             cols.extend(sg.column_key(c) for c in sg.find_columns(e))
         out.append(GroupBySummary(targets=targets, target_columns=tuple(cols)))
     return tuple(out)
@@ -239,7 +239,7 @@ def detect_null_group_after_outer_join(tree: Expr) -> tuple[Finding, ...]:
         nullable_fs = frozenset(nullable)
         risky_tables: set[str] = set()
         risky_targets: list[str] = []
-        for grp_expr in g.expressions:
+        for grp_expr in sg.group_targets(sel):
             hit: set[str] = set()
             for c in sg.find_columns(grp_expr):
                 table = sg.column_table(c)
@@ -863,9 +863,7 @@ def _load_bearing_scopes(sel: exp.Select) -> list[tuple[str, Expr]]:
         on = sg.on_of(j)
         if on is not None:
             scopes.append(("a JOIN ON clause", on))
-    group = sg.group_of(sel)
-    if group is not None:
-        scopes.extend(("a GROUP BY target", g) for g in group.expressions)
+    scopes.extend(("a GROUP BY target", g) for g in sg.group_targets(sel))
     for w in sg.find_all_windows(sel):
         scopes.extend(("a window PARTITION BY", part) for part in sg.partition_of(w))
         order = sg.order_of(w)

--- a/src/dblect/sql/patterns.py
+++ b/src/dblect/sql/patterns.py
@@ -184,7 +184,7 @@ def list_group_bys(tree: Expr) -> tuple[GroupBySummary, ...]:
     for sel in sg.find_all_selects(tree):
         if sg.group_of(sel) is None:
             continue
-        grouped = sg.group_targets(sel)
+        grouped = [t.expression for t in sg.group_targets(sel)]
         targets = tuple(sg.render_sql(e) for e in grouped)
         cols: list[tuple[str | None, str]] = []
         for e in grouped:
@@ -239,7 +239,7 @@ def detect_null_group_after_outer_join(tree: Expr) -> tuple[Finding, ...]:
         nullable_fs = frozenset(nullable)
         risky_tables: set[str] = set()
         risky_targets: list[str] = []
-        for grp_expr in sg.group_targets(sel):
+        for grp_expr in (t.expression for t in sg.group_targets(sel)):
             hit: set[str] = set()
             for c in sg.find_columns(grp_expr):
                 table = sg.column_table(c)
@@ -857,7 +857,8 @@ def _load_bearing_scopes(sel: exp.Select) -> list[tuple[str, Expr]]:
     Returns ``(label, scope)`` pairs:
 
     * Each JOIN's ON clause.
-    * Each GROUP BY target expression.
+    * Each GROUP BY target expression. A target named positionally or by output name
+      contributes the projection it resolves to, which is where the call would be written.
     * Each window function's PARTITION BY expression list (rolled up as the
       window node itself for snippet purposes) and ORDER BY expression list.
 
@@ -870,7 +871,7 @@ def _load_bearing_scopes(sel: exp.Select) -> list[tuple[str, Expr]]:
         on = sg.on_of(j)
         if on is not None:
             scopes.append(("a JOIN ON clause", on))
-    scopes.extend(("a GROUP BY target", g) for g in sg.group_targets(sel))
+    scopes.extend(("a GROUP BY target", t.expression) for t in sg.group_targets(sel))
     for w in sg.find_all_windows(sel):
         scopes.extend(("a window PARTITION BY", part) for part in sg.partition_of(w))
         order = sg.order_of(w)

--- a/src/dblect/uniqueness/detector.py
+++ b/src/dblect/uniqueness/detector.py
@@ -354,7 +354,7 @@ def detect_limit_without_deterministic_order(
     )
     if source_keys is None:
         return ()
-    order_cols = _bare_column_names(order.expressions)
+    order_cols = _bare_column_names(list(sg.statement_order_targets(tree)))
     if order_cols is None:
         return ()
     projection = _projection_aliases(tree)

--- a/src/dblect/uniqueness/detector.py
+++ b/src/dblect/uniqueness/detector.py
@@ -333,9 +333,10 @@ def detect_limit_without_deterministic_order(
     equivalence check we do not model). When an ``ORDER BY`` is present but no source key is
     known, it stays silent rather than guess the ordering is non-unique. A top scope that
     yields a single row (an ungrouped aggregate) is exempt: SQL's implicit grouping collapses
-    it to one row, so a ``LIMIT`` cannot drop a row. Order keys are resolved through the
-    projection's aliases before being matched, so an ``order by <alias>`` of a key counts as
-    covering (and a renamed non-key column does not pass as the key).
+    it to one row, so a ``LIMIT`` cannot drop a row. Order keys named as output names are
+    resolved through the projection's aliases before being matched, so an ``order by <alias>``
+    of a key counts as covering (and a renamed non-key column does not pass as the key); a
+    positional key arrives already in the source namespace and is matched as-is.
     """
     if not is_materialized or not isinstance(tree, exp.Select):
         return ()
@@ -354,11 +355,15 @@ def detect_limit_without_deterministic_order(
     )
     if source_keys is None:
         return ()
-    order_cols = _bare_column_names(list(sg.statement_order_targets(tree)))
+    targets = sg.statement_order_targets(tree)
+    order_cols = _bare_column_names([t.expression for t in targets])
     if order_cols is None:
         return ()
     projection = _projection_aliases(tree)
-    covered = frozenset(projection.get(c, c) for c in order_cols)
+    covered = frozenset(
+        name if t.in_source_namespace else projection.get(name, name)
+        for t, name in zip(targets, order_cols, strict=True)
+    )
     if any(k <= covered for k in source_keys):
         return ()
     return (_limit_finding(limit, ordered=True, order_cols=order_cols),)

--- a/src/dblect/uniqueness/detector.py
+++ b/src/dblect/uniqueness/detector.py
@@ -105,7 +105,7 @@ def detect_non_unique_window_order_keys(
         if source_keys is None:
             continue
         for w in sg.find_all_windows(sel):
-            if not _node_in_scope(w, sel):
+            if not sg.node_in_scope(w, sel):
                 continue
             order = sg.order_of(w)
             if order is None:
@@ -177,7 +177,7 @@ def detect_non_unique_aggregate_order_keys(
         group = sg.group_of(sel)
         grouping = group.expressions if group is not None else []
         for agg in sg.find_all_ordered_aggregates(sel):
-            if not _node_in_scope(agg, sel):
+            if not sg.node_in_scope(agg, sel):
                 continue
             order = sg.aggregate_order_of(agg)
             agg_limit = sg.aggregate_limit_of(agg)
@@ -1021,20 +1021,6 @@ def _reads_outside_grouping(node: Expr, group_keys: frozenset[tuple[str | None, 
     return any(
         (sg.column_table(c), sg.column_name(c)) not in group_keys for c in sg.find_columns(node)
     )
-
-
-def _node_in_scope(node: Expr, sel: exp.Select) -> bool:
-    """True when ``node``'s nearest enclosing SELECT is ``sel`` (not a nested sub-SELECT).
-
-    Both the window and top-n-aggregate order-key checks read a node against ``sel``'s source
-    keys and grouping, so a window or aggregate that actually belongs to a nested SELECT must be
-    excluded: its keys and grouping are a different scope's."""
-    cur: Expr | None = node.parent
-    while cur is not None:
-        if isinstance(cur, exp.Select):
-            return cur is sel
-        cur = cur.parent
-    return False
 
 
 def _uncovered_order_keys(

--- a/src/dblect/uniqueness/detector.py
+++ b/src/dblect/uniqueness/detector.py
@@ -105,7 +105,7 @@ def detect_non_unique_window_order_keys(
         if source_keys is None:
             continue
         for w in sg.find_all_windows(sel):
-            if not sg.node_in_scope(w, sel):
+            if not _node_in_scope(w, sel):
                 continue
             order = sg.order_of(w)
             if order is None:
@@ -177,7 +177,7 @@ def detect_non_unique_aggregate_order_keys(
         group = sg.group_of(sel)
         grouping = group.expressions if group is not None else []
         for agg in sg.find_all_ordered_aggregates(sel):
-            if not sg.node_in_scope(agg, sel):
+            if not _node_in_scope(agg, sel):
                 continue
             order = sg.aggregate_order_of(agg)
             agg_limit = sg.aggregate_limit_of(agg)
@@ -1022,6 +1022,20 @@ def _reads_outside_grouping(node: Expr, group_keys: frozenset[tuple[str | None, 
     return any(
         (sg.column_table(c), sg.column_name(c)) not in group_keys for c in sg.find_columns(node)
     )
+
+
+def _node_in_scope(node: Expr, sel: exp.Select) -> bool:
+    """True when ``node``'s nearest enclosing SELECT is ``sel`` (not a nested sub-SELECT).
+
+    Both the window and top-n-aggregate order-key checks read a node against ``sel``'s source
+    keys and grouping, so a window or aggregate that actually belongs to a nested SELECT must be
+    excluded: its keys and grouping are a different scope's."""
+    cur: Expr | None = node.parent
+    while cur is not None:
+        if isinstance(cur, exp.Select):
+            return cur is sel
+        cur = cur.parent
+    return False
 
 
 def _uncovered_order_keys(

--- a/src/dblect/uniqueness/detector.py
+++ b/src/dblect/uniqueness/detector.py
@@ -333,10 +333,11 @@ def detect_limit_without_deterministic_order(
     equivalence check we do not model). When an ``ORDER BY`` is present but no source key is
     known, it stays silent rather than guess the ordering is non-unique. A top scope that
     yields a single row (an ungrouped aggregate) is exempt: SQL's implicit grouping collapses
-    it to one row, so a ``LIMIT`` cannot drop a row. Order keys named as output names are
+    it to one row, so a ``LIMIT`` cannot drop a row. An order key spelled as a bare name is
     resolved through the projection's aliases before being matched, so an ``order by <alias>``
-    of a key counts as covering (and a renamed non-key column does not pass as the key); a
-    positional key arrives already in the source namespace and is matched as-is.
+    of a key counts as covering (and a renamed non-key column does not pass as the key). A
+    positional or qualified key already names a source column (``sg.OrderTarget``) and is
+    matched as-is, so all three spellings of one key agree.
     """
     if not is_materialized or not isinstance(tree, exp.Select):
         return ()

--- a/tests/nullability/test_detector.py
+++ b/tests/nullability/test_detector.py
@@ -147,6 +147,9 @@ def _kinds(mart_sql: str) -> list[FindingKind]:
 # this layer reasons only about single-source, join-free scopes.
 _CASES: list[tuple[str, str, bool]] = [
     ("group-by/nullable", "SELECT tag, count(*) AS n FROM stg GROUP BY tag", True),
+    # An ordinal names the projection, so the inherited-nullable key is grouped on just the
+    # same and the detector has to read through the position rather than past it.
+    ("group-by/nullable-ordinal", "SELECT tag, count(*) AS n FROM stg GROUP BY 1", True),
     ("group-by/non-null", "SELECT id, count(*) AS n FROM stg GROUP BY id", False),
     (
         "group-by/local-join",

--- a/tests/nullability/test_detector.py
+++ b/tests/nullability/test_detector.py
@@ -134,11 +134,15 @@ def _join_finding(mart_sql: str) -> Finding:
     return findings[0]
 
 
-def _kinds(mart_sql: str) -> list[FindingKind]:
+def _findings(mart_sql: str) -> list[Finding]:
     """Every nullability finding the detectors raise on ``mart``."""
     detectors = make_nullability_detectors(_manifest(mart_sql), _DUCKDB)
     tree = parse_sql(mart_sql, dialect="duckdb")
-    return [f.kind for detector in detectors for f in detector(tree)]
+    return [f for detector in detectors for f in detector(tree)]
+
+
+def _kinds(mart_sql: str) -> list[FindingKind]:
+    return [f.kind for f in _findings(mart_sql)]
 
 
 # ``stg.tag`` is nullable upstream (the optional side of stg's LEFT JOIN); ``stg.id`` and
@@ -177,6 +181,19 @@ def test_detector_fires_only_on_an_inherited_nullable_key(
     sql: str, kind: FindingKind, fires: bool
 ) -> None:
     assert (kind in _kinds(sql)) is fires
+
+
+@pytest.mark.parametrize("target", ["tag", "1"])
+def test_group_finding_lands_on_the_group_by_the_analyst_wrote(target: str) -> None:
+    # Grouping is the decision this finding is about, so its line points at the GROUP BY
+    # rather than at the projection a bare name or an ordinal resolves through. The message
+    # still names the resolved column, which is what makes a positional key readable.
+    mart_sql = f"SELECT\n  tag,\n  count(*) AS n\nFROM stg\nGROUP BY\n  {target}"
+    (finding,) = [
+        f for f in _findings(mart_sql) if f.kind is FindingKind.NULL_GROUP_ON_NULLABLE_KEY
+    ]
+    assert (finding.line_start, finding.line_end) == (6, 6)
+    assert "GROUP BY tag " in finding.message
 
 
 def test_flagged_group_key_really_carries_a_null_bucket() -> None:

--- a/tests/sql/test_patterns.py
+++ b/tests/sql/test_patterns.py
@@ -73,23 +73,12 @@ def test_list_group_bys_one_per_select() -> None:
     assert {g.targets for g in groups} == {("x",), ("y",)}
 
 
-def test_list_group_bys_resolves_positional_targets() -> None:
-    # The ordinal names a projection, so the inventory reports what is grouped rather than the
-    # literal standing in for it.
-    groups = list_group_bys(_parse("select b.k, count(*) from t group by 1"))
-    assert groups[0].targets == ("b.k",)
-    assert groups[0].target_columns == (("b", "k"),)
-
-
 def test_list_group_bys_resolves_positional_target_through_alias() -> None:
+    # The ordinal names a projection, so the inventory reports what is grouped rather than the
+    # literal standing in for it, seeing through the AS binding to the expression underneath.
     groups = list_group_bys(_parse("select b.k as key, count(*) from t group by 1"))
     assert groups[0].targets == ("b.k",)
     assert groups[0].target_columns == (("b", "k"),)
-
-
-def test_list_group_bys_resolves_mixed_positional_and_named_targets() -> None:
-    groups = list_group_bys(_parse("select b.k, b.status, count(*) from t group by 1, b.status"))
-    assert groups[0].targets == ("b.k", "b.status")
 
 
 def test_list_group_bys_leaves_out_of_range_ordinal_unresolved() -> None:
@@ -121,12 +110,52 @@ def test_list_group_bys_leaves_non_ordinal_literals_unresolved(target: str) -> N
     assert groups[0].target_columns == ()
 
 
+def test_list_group_bys_leaves_duplicated_alias_unresolved() -> None:
+    # Two projections carrying one alias name it ambiguously, and the query is not valid SQL
+    # anyway (duckdb binds the first and then rejects the ungrouped second), so there is nothing
+    # to resolve to and the target stays as written rather than picking an arm.
+    groups = list_group_bys(_parse("select b.k as x, b.status as x, count(*) from t group by x"))
+    assert groups[0].targets == ("x",)
+    assert groups[0].target_columns == ((None, "x"),)
+
+
 def test_list_aggregations_excludes_windowed_functions() -> None:
     p = _parse("select sum(x), sum(y) over () from t")
     aggs = list_aggregations(p)
     assert len(aggs) == 1
     assert aggs[0].function == "Sum"
     assert aggs[0].argument_sql == "x"
+
+
+def test_unordered_window_constant_order_by_detected() -> None:
+    # `over (order by 1)` is not a positional reference: inside a window the literal is a
+    # constant, so every row sorts equal and the ranking is as arbitrary as with no ORDER BY.
+    findings = detect_unordered_window(_parse("select row_number() over (order by 1) from t"))
+    assert len(findings) == 1
+    assert findings[0].kind is FindingKind.UNORDERED_RANKING_WINDOW
+
+
+@pytest.mark.parametrize("order", ["1", "'x'", "null", "1 + 2"])
+def test_unordered_window_column_free_order_by_detected(order: str) -> None:
+    # Nothing that fails to reference a column can order rows.
+    sql = f"select row_number() over (order by {order}) from t"
+    assert len(detect_unordered_window(_parse(sql))) == 1
+
+
+def test_unordered_window_partly_constant_order_by_not_detected() -> None:
+    # One real key is an ordering; the constant alongside it is merely inert.
+    sql = "select row_number() over (order by 1, n) from t"
+    assert detect_unordered_window(_parse(sql)) == ()
+
+
+def test_unordered_aggregate_constant_order_by_detected() -> None:
+    findings = detect_unordered_aggregate(_parse("select array_agg(s order by 1) from t"))
+    assert len(findings) == 1
+    assert findings[0].kind is FindingKind.UNORDERED_AGGREGATE
+
+
+def test_unordered_aggregate_real_order_by_not_detected() -> None:
+    assert detect_unordered_aggregate(_parse("select array_agg(s order by n) from t")) == ()
 
 
 def test_null_group_after_left_join_detected() -> None:
@@ -151,35 +180,59 @@ def test_null_group_after_left_join_positional_target_detected() -> None:
     assert findings[0].kind is FindingKind.NULL_GROUP_AFTER_OUTER_JOIN
 
 
-def test_null_group_positional_target_to_preserved_side_not_detected() -> None:
+def test_null_group_alias_target_detected() -> None:
+    # `group by grp` names the projection aliased grp, which is the nullable side.
     sql = """
-    select a.k, sum(amount) as total
+    select b.k as grp, sum(amount) as total
     from a left join b on a.k = b.k
-    group by 1
-    """
-    assert detect_null_group_after_outer_join(_parse(sql)) == ()
-
-
-def test_null_group_positional_coalesce_to_preserved_side_not_detected() -> None:
-    # The guard that clears a recovered key has to see the COALESCE the ordinal names.
-    sql = """
-    select coalesce(b.k, a.k) as k, sum(amount) as total
-    from a left join b on a.k = b.k
-    group by 1
-    """
-    assert detect_null_group_after_outer_join(_parse(sql)) == ()
-
-
-def test_null_group_positional_target_selects_the_named_projection() -> None:
-    # Ordinal 2 must land on the nullable projection, not the preserved one at ordinal 1.
-    sql = """
-    select a.k, b.status, sum(amount) as total
-    from a left join b on a.k = b.k
-    group by 1, 2
+    group by grp
     """
     findings = detect_null_group_after_outer_join(_parse(sql))
     assert len(findings) == 1
-    assert "b.status" in findings[0].message
+    assert findings[0].kind is FindingKind.NULL_GROUP_AFTER_OUTER_JOIN
+
+
+def test_null_group_unqualified_reference_to_projected_column_detected() -> None:
+    # The dbt idiom: project a qualified column, group by its bare name. SQL binds the name to
+    # the input column, and the projection *is* that column, so both readings land on the same
+    # expression and resolving is sound even though the name shadows an input column.
+    sql = """
+    select orders.customer_id, sum(amount) as total
+    from payments left join orders on payments.order_id = orders.order_id
+    group by customer_id
+    """
+    findings = detect_null_group_after_outer_join(_parse(sql))
+    assert len(findings) == 1
+    assert findings[0].kind is FindingKind.NULL_GROUP_AFTER_OUTER_JOIN
+
+
+def test_null_group_unqualified_reference_to_preserved_column_not_detected() -> None:
+    sql = """
+    select payments.order_id, sum(amount) as total
+    from payments left join orders on payments.order_id = orders.order_id
+    group by order_id
+    """
+    assert detect_null_group_after_outer_join(_parse(sql)) == ()
+
+
+def test_null_group_alias_shadowing_an_input_column_not_resolved() -> None:
+    # SQL resolves a GROUP BY name to an input column before an output alias, so `group by amt`
+    # here groups by b.amt, not by the projection aliased amt. We cannot tell which table an
+    # unqualified name binds to without a schema, so we decline to resolve and stay silent.
+    # This is the known-permissive edge of the alias rule: the b.amt grouping is a real hazard
+    # we do not report, matching the behaviour before aliases resolved at all.
+    sql = """
+    select b.amt * 2 as amt, sum(amount) as total
+    from a left join b on a.k = b.k
+    group by amt
+    """
+    assert detect_null_group_after_outer_join(_parse(sql)) == ()
+
+
+def test_list_group_bys_resolves_alias_target() -> None:
+    groups = list_group_bys(_parse("select b.k as grp, count(*) from t group by grp"))
+    assert groups[0].targets == ("b.k",)
+    assert groups[0].target_columns == (("b", "k"),)
 
 
 def test_null_group_positional_target_reports_the_group_by_line() -> None:

--- a/tests/sql/test_patterns.py
+++ b/tests/sql/test_patterns.py
@@ -220,6 +220,90 @@ def test_null_group_alias_under_a_star_projection_not_resolved() -> None:
     assert detect_null_group_after_outer_join(_parse(sql)) == ()
 
 
+# Which scope a column belongs to decides whether it is evidence that a GROUP BY name is
+# taken. The guard asks two questions in order: can this scope's input columns be enumerated
+# (a derived table or a CTE names its own output, a base table does not), and failing that,
+# is a column of the name referenced somewhere that could bind to one of this scope's sources.
+# Each case below is a distinct answer to that pair, and `amt` is always the projected alias.
+_SHADOW_CASES: list[tuple[str, str, bool]] = [
+    (
+        # `c` is never a source here, so its body says nothing about what `a` and `b` carry.
+        "unused-cte/not-evidence",
+        """with c as (select amt from raw)
+        select b.k * 2 as amt, sum(amount) as total
+        from a left join b on a.k = b.k group by amt""",
+        True,
+    ),
+    (
+        # Nor does a subquery that only correlates to itself; `z.amt` is a column of `z`.
+        "unrelated-subquery/not-evidence",
+        """select b.k * 2 as amt, sum(amount) as total
+        from a left join b on a.k = b.k
+        where exists (select 1 from z where z.amt > 0) group by amt""",
+        True,
+    ),
+    (
+        # A correlated reference reaches back out to this scope, so `a.amt` is a real input
+        # column even though it is written inside the subquery.
+        "correlated-outer-reference/evidence",
+        """select b.k * 2 as amt, sum(amount) as total
+        from a left join b on a.k = b.k
+        where exists (select 1 from z where z.q = a.amt) group by amt""",
+        False,
+    ),
+    (
+        # A CTE that IS a source names its own output columns, so `amt` is taken. The name
+        # appears nowhere as a column, only as an output alias, which is why sweeping for
+        # referenced columns cannot see it.
+        "cte-source-aliases-the-name/evidence",
+        """with c as (select v as amt, k from raw)
+        select b.k * 2 as amt, sum(amount) as total
+        from c left join b on c.k = b.k group by amt""",
+        False,
+    ),
+    (
+        # Same for a derived table, and here every source is enumerable, so this is decided
+        # rather than guessed.
+        "derived-table-aliases-the-name/evidence",
+        """select q.k * 2 as amt, sum(q.amount) as total
+        from (select v as amt, k from raw) p left join (select k, amount from other) q
+        on p.k = q.k group by amt""",
+        False,
+    ),
+    (
+        # Every source enumerable and no `amt` among them: the name is decidably free, so the
+        # alias resolves without falling back to the reference sweep at all.
+        "derived-tables-without-the-name/not-evidence",
+        """select q.k * 2 as amt, sum(q.amount) as total
+        from (select v, k from raw) p left join (select k, amount from other) q
+        on p.k = q.k group by amt""",
+        True,
+    ),
+    (
+        # A star inside a derived-table source carries unknown columns just as an outer `*`
+        # does, so `amt` may be among them: the same decline, whether the star is the scope's
+        # own projection or one it reads from.
+        "derived-source-star/unknown-columns",
+        """select q.k * 2 as amt, sum(q.amount) as total
+        from (select * from raw) p left join (select k, amount from other) q
+        on p.k = q.k group by amt""",
+        False,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("sql", "resolves"),
+    [(sql, resolves) for _name, sql, resolves in _SHADOW_CASES],
+    ids=[name for name, _sql, _resolves in _SHADOW_CASES],
+)
+def test_null_group_alias_resolves_only_when_the_name_is_free(sql: str, resolves: bool) -> None:
+    # Resolving the alias reaches `b.k * 2` / `q.k * 2` on the nullable side, so the finding
+    # firing is the observable signal that resolution happened.
+    fired = detect_null_group_after_outer_join(_parse(sql)) != ()
+    assert fired is resolves
+
+
 def test_list_group_bys_resolves_alias_target() -> None:
     groups = list_group_bys(_parse("select b.k as grp, count(*) from t group by grp"))
     assert groups[0].targets == ("b.k",)

--- a/tests/sql/test_patterns.py
+++ b/tests/sql/test_patterns.py
@@ -127,25 +127,19 @@ def test_list_aggregations_excludes_windowed_functions() -> None:
     assert aggs[0].argument_sql == "x"
 
 
-def test_unordered_window_constant_order_by_detected() -> None:
-    # `over (order by 1)` is not a positional reference: inside a window the literal is a
-    # constant, so every row sorts equal and the ranking is as arbitrary as with no ORDER BY.
-    findings = detect_unordered_window(_parse("select row_number() over (order by 1) from t"))
-    assert len(findings) == 1
-    assert findings[0].kind is FindingKind.UNORDERED_RANKING_WINDOW
-
-
+# The clear direction and the full clause enumeration belong to the duckdb permutation oracle
+# in ``test_pbt_structural_hazards.py``, which decides "really orders" from the data rather
+# than from a re-derivation of the rule. These keep a parse-only guard on the detect direction,
+# which is where reading a window's ORDER BY structurally went wrong.
 @pytest.mark.parametrize("order", ["1", "'x'", "null", "1 + 2"])
 def test_unordered_window_column_free_order_by_detected(order: str) -> None:
-    # Nothing that fails to reference a column can order rows.
+    # Nothing that fails to reference a column can order rows. `over (order by 1)` in
+    # particular is not a positional reference: inside a window the literal is a constant, so
+    # every row sorts equal and the ranking is as arbitrary as with no ORDER BY.
     sql = f"select row_number() over (order by {order}) from t"
-    assert len(detect_unordered_window(_parse(sql))) == 1
-
-
-def test_unordered_window_partly_constant_order_by_not_detected() -> None:
-    # One real key is an ordering; the constant alongside it is merely inert.
-    sql = "select row_number() over (order by 1, n) from t"
-    assert detect_unordered_window(_parse(sql)) == ()
+    findings = detect_unordered_window(_parse(sql))
+    assert len(findings) == 1
+    assert findings[0].kind is FindingKind.UNORDERED_RANKING_WINDOW
 
 
 def test_unordered_aggregate_constant_order_by_detected() -> None:
@@ -154,26 +148,11 @@ def test_unordered_aggregate_constant_order_by_detected() -> None:
     assert findings[0].kind is FindingKind.UNORDERED_AGGREGATE
 
 
-def test_unordered_aggregate_real_order_by_not_detected() -> None:
-    assert detect_unordered_aggregate(_parse("select array_agg(s order by n) from t")) == ()
-
-
 def test_null_group_after_left_join_detected() -> None:
     sql = """
     select b.k, sum(amount) as total
     from a left join b on a.k = b.k
     group by b.k
-    """
-    findings = detect_null_group_after_outer_join(_parse(sql))
-    assert len(findings) == 1
-    assert findings[0].kind is FindingKind.NULL_GROUP_AFTER_OUTER_JOIN
-
-
-def test_null_group_after_left_join_positional_target_detected() -> None:
-    sql = """
-    select b.k, sum(amount) as total
-    from a left join b on a.k = b.k
-    group by 1
     """
     findings = detect_null_group_after_outer_join(_parse(sql))
     assert len(findings) == 1
@@ -229,18 +208,33 @@ def test_null_group_alias_shadowing_an_input_column_not_resolved() -> None:
     assert detect_null_group_after_outer_join(_parse(sql)) == ()
 
 
+def test_null_group_alias_under_a_star_projection_not_resolved() -> None:
+    # `select a.*` carries input columns the query never names, so `amt` may bind to an `a.amt`
+    # the shadow guard cannot see. A star makes every name potentially taken, so resolution
+    # declines rather than resolving to `b.k * 2` and reporting a hazard the query may not have.
+    sql = """
+    select a.*, b.k * 2 as amt, sum(amount) as total
+    from a left join b on a.k = b.k
+    group by a.id, amt
+    """
+    assert detect_null_group_after_outer_join(_parse(sql)) == ()
+
+
 def test_list_group_bys_resolves_alias_target() -> None:
     groups = list_group_bys(_parse("select b.k as grp, count(*) from t group by grp"))
     assert groups[0].targets == ("b.k",)
     assert groups[0].target_columns == (("b", "k"),)
 
 
-def test_null_group_positional_target_reports_the_group_by_line() -> None:
-    # The finding has to land on the GROUP BY the analyst wrote, not at line 0. A positional
-    # target holds no identifier, so the line has to come off the ordinal literal itself.
+def test_null_group_positional_target_detected_and_located() -> None:
+    # `group by 1` names the nullable-side projection, so the hazard is the same one the
+    # spelled-out `group by b.k` carries. The finding also has to land on the GROUP BY the
+    # analyst wrote, not at line 0: a positional target holds no identifier, so the line has to
+    # come off the ordinal literal itself.
     sql = "select b.k, sum(amount) as total\nfrom a left join b on a.k = b.k\ngroup by 1"
     findings = detect_null_group_after_outer_join(_parse(sql))
     assert len(findings) == 1
+    assert findings[0].kind is FindingKind.NULL_GROUP_AFTER_OUTER_JOIN
     assert findings[0].line_start == 3
     assert findings[0].line_end == 3
 

--- a/tests/sql/test_patterns.py
+++ b/tests/sql/test_patterns.py
@@ -73,6 +73,54 @@ def test_list_group_bys_one_per_select() -> None:
     assert {g.targets for g in groups} == {("x",), ("y",)}
 
 
+def test_list_group_bys_resolves_positional_targets() -> None:
+    # The ordinal names a projection, so the inventory reports what is grouped rather than the
+    # literal standing in for it.
+    groups = list_group_bys(_parse("select b.k, count(*) from t group by 1"))
+    assert groups[0].targets == ("b.k",)
+    assert groups[0].target_columns == (("b", "k"),)
+
+
+def test_list_group_bys_resolves_positional_target_through_alias() -> None:
+    groups = list_group_bys(_parse("select b.k as key, count(*) from t group by 1"))
+    assert groups[0].targets == ("b.k",)
+    assert groups[0].target_columns == (("b", "k"),)
+
+
+def test_list_group_bys_resolves_mixed_positional_and_named_targets() -> None:
+    groups = list_group_bys(_parse("select b.k, b.status, count(*) from t group by 1, b.status"))
+    assert groups[0].targets == ("b.k", "b.status")
+
+
+def test_list_group_bys_leaves_out_of_range_ordinal_unresolved() -> None:
+    # Nothing to resolve against; the target stays the opaque literal it is rather than
+    # indexing off the end of the projection list.
+    groups = list_group_bys(_parse("select b.k, count(*) from t group by 7"))
+    assert groups[0].targets == ("7",)
+    assert groups[0].target_columns == ()
+
+
+def test_list_group_bys_leaves_ordinal_unresolved_under_unexpanded_star() -> None:
+    # A star expands to an unknown number of columns, so position 2 is not the second listed
+    # projection and the ordinal cannot be resolved soundly.
+    groups = list_group_bys(_parse("select *, b.k from t group by 2"))
+    assert groups[0].targets == ("2",)
+
+
+def test_list_group_bys_resolves_ordinal_when_star_follows_it() -> None:
+    # A star *after* the ordinal's position does not shift the prefix it indexes into.
+    groups = list_group_bys(_parse("select b.k, * from t group by 1"))
+    assert groups[0].targets == ("b.k",)
+
+
+@pytest.mark.parametrize("target", ["'1'", "1.5", "-1", "0"])
+def test_list_group_bys_leaves_non_ordinal_literals_unresolved(target: str) -> None:
+    # Only a bare positive integer literal is a positional reference. A string, a float, a
+    # negation, and the out-of-range 0 are grouped values, not positions.
+    groups = list_group_bys(_parse(f"select b.k, count(*) from t group by {target}"))
+    assert groups[0].target_columns == ()
+
+
 def test_list_aggregations_excludes_windowed_functions() -> None:
     p = _parse("select sum(x), sum(y) over () from t")
     aggs = list_aggregations(p)
@@ -90,6 +138,58 @@ def test_null_group_after_left_join_detected() -> None:
     findings = detect_null_group_after_outer_join(_parse(sql))
     assert len(findings) == 1
     assert findings[0].kind is FindingKind.NULL_GROUP_AFTER_OUTER_JOIN
+
+
+def test_null_group_after_left_join_positional_target_detected() -> None:
+    sql = """
+    select b.k, sum(amount) as total
+    from a left join b on a.k = b.k
+    group by 1
+    """
+    findings = detect_null_group_after_outer_join(_parse(sql))
+    assert len(findings) == 1
+    assert findings[0].kind is FindingKind.NULL_GROUP_AFTER_OUTER_JOIN
+
+
+def test_null_group_positional_target_to_preserved_side_not_detected() -> None:
+    sql = """
+    select a.k, sum(amount) as total
+    from a left join b on a.k = b.k
+    group by 1
+    """
+    assert detect_null_group_after_outer_join(_parse(sql)) == ()
+
+
+def test_null_group_positional_coalesce_to_preserved_side_not_detected() -> None:
+    # The guard that clears a recovered key has to see the COALESCE the ordinal names.
+    sql = """
+    select coalesce(b.k, a.k) as k, sum(amount) as total
+    from a left join b on a.k = b.k
+    group by 1
+    """
+    assert detect_null_group_after_outer_join(_parse(sql)) == ()
+
+
+def test_null_group_positional_target_selects_the_named_projection() -> None:
+    # Ordinal 2 must land on the nullable projection, not the preserved one at ordinal 1.
+    sql = """
+    select a.k, b.status, sum(amount) as total
+    from a left join b on a.k = b.k
+    group by 1, 2
+    """
+    findings = detect_null_group_after_outer_join(_parse(sql))
+    assert len(findings) == 1
+    assert "b.status" in findings[0].message
+
+
+def test_null_group_positional_target_reports_the_group_by_line() -> None:
+    # The finding has to land on the GROUP BY the analyst wrote, not at line 0. A positional
+    # target holds no identifier, so the line has to come off the ordinal literal itself.
+    sql = "select b.k, sum(amount) as total\nfrom a left join b on a.k = b.k\ngroup by 1"
+    findings = detect_null_group_after_outer_join(_parse(sql))
+    assert len(findings) == 1
+    assert findings[0].line_start == 3
+    assert findings[0].line_end == 3
 
 
 def test_null_group_after_inner_join_not_detected() -> None:
@@ -884,13 +984,13 @@ def test_now_in_join_on_detected() -> None:
     assert findings[0].kind is FindingKind.NON_DETERMINISTIC_FUNCTION
 
 
-def test_now_in_group_by_detected() -> None:
+def test_now_in_positional_group_by_detected() -> None:
+    # `group by 1` names the first projection, so the grouped expression is the one holding
+    # now() even though the GROUP BY target in the AST is the literal 1.
     sql = "select date_diff('day', ts, now()) as days_ago, count(*) from t group by 1"
-    # `group by 1` is a positional reference; the GROUP BY *target* in the AST
-    # is the literal 1, not the expression. So this won't fire. The pattern
-    # we care about is `group by <expression containing now()>` directly.
-    # (Documented because someone will inevitably wonder why it didn't trigger.)
-    assert _non_determinism(sql) == ()
+    findings = _non_determinism(sql)
+    assert len(findings) == 1
+    assert findings[0].kind is FindingKind.NON_DETERMINISTIC_FUNCTION
 
 
 def test_now_in_explicit_group_by_expression_detected() -> None:

--- a/tests/sql/test_patterns.py
+++ b/tests/sql/test_patterns.py
@@ -73,50 +73,33 @@ def test_list_group_bys_one_per_select() -> None:
     assert {g.targets for g in groups} == {("x",), ("y",)}
 
 
-def test_list_group_bys_resolves_positional_target_through_alias() -> None:
-    # The ordinal names a projection, so the inventory reports what is grouped rather than the
-    # literal standing in for it, seeing through the AS binding to the expression underneath.
-    groups = list_group_bys(_parse("select b.k as key, count(*) from t group by 1"))
-    assert groups[0].targets == ("b.k",)
-    assert groups[0].target_columns == (("b", "k"),)
+# What a GROUP BY target resolves to, and the conditions under which it cannot. An
+# unresolvable target reads back as written, so the rendered target is the whole contract.
+# Only a bare positive integer is positional: a string, a float, a negation (which parses as
+# Neg over the literal), and 0 are grouped values. A star expands to an unknown number of
+# columns, so an ordinal reaching over one indexes nothing knowable, while one before it is
+# unaffected. A name carried by two projections names neither.
+_GROUP_TARGET_RESOLUTION: list[tuple[str, str, str]] = [
+    ("ordinal-through-alias", "select b.k as key, count(*) from t group by 1", "b.k"),
+    ("name-through-alias", "select b.k as grp, count(*) from t group by grp", "b.k"),
+    ("ordinal-past-the-end", "select b.k, count(*) from t group by 7", "7"),
+    ("ordinal-over-a-star", "select *, b.k from t group by 2", "2"),
+    ("ordinal-before-a-star", "select b.k, * from t group by 1", "b.k"),
+    ("string-literal", "select b.k, count(*) from t group by '1'", "'1'"),
+    ("float-literal", "select b.k, count(*) from t group by 1.5", "1.5"),
+    ("negated-literal", "select b.k, count(*) from t group by -1", "-1"),
+    ("zero", "select b.k, count(*) from t group by 0", "0"),
+    ("duplicated-output-name", "select b.k as x, b.status as x from t group by x", "x"),
+]
 
 
-def test_list_group_bys_leaves_out_of_range_ordinal_unresolved() -> None:
-    # Nothing to resolve against; the target stays the opaque literal it is rather than
-    # indexing off the end of the projection list.
-    groups = list_group_bys(_parse("select b.k, count(*) from t group by 7"))
-    assert groups[0].targets == ("7",)
-    assert groups[0].target_columns == ()
-
-
-def test_list_group_bys_leaves_ordinal_unresolved_under_unexpanded_star() -> None:
-    # A star expands to an unknown number of columns, so position 2 is not the second listed
-    # projection and the ordinal cannot be resolved soundly.
-    groups = list_group_bys(_parse("select *, b.k from t group by 2"))
-    assert groups[0].targets == ("2",)
-
-
-def test_list_group_bys_resolves_ordinal_when_star_follows_it() -> None:
-    # A star *after* the ordinal's position does not shift the prefix it indexes into.
-    groups = list_group_bys(_parse("select b.k, * from t group by 1"))
-    assert groups[0].targets == ("b.k",)
-
-
-@pytest.mark.parametrize("target", ["'1'", "1.5", "-1", "0"])
-def test_list_group_bys_leaves_non_ordinal_literals_unresolved(target: str) -> None:
-    # Only a bare positive integer literal is a positional reference. A string, a float, a
-    # negation, and the out-of-range 0 are grouped values, not positions.
-    groups = list_group_bys(_parse(f"select b.k, count(*) from t group by {target}"))
-    assert groups[0].target_columns == ()
-
-
-def test_list_group_bys_leaves_duplicated_alias_unresolved() -> None:
-    # Two projections carrying one alias name it ambiguously, and the query is not valid SQL
-    # anyway (duckdb binds the first and then rejects the ungrouped second), so there is nothing
-    # to resolve to and the target stays as written rather than picking an arm.
-    groups = list_group_bys(_parse("select b.k as x, b.status as x, count(*) from t group by x"))
-    assert groups[0].targets == ("x",)
-    assert groups[0].target_columns == ((None, "x"),)
+@pytest.mark.parametrize(
+    ("sql", "target"),
+    [(sql, target) for _name, sql, target in _GROUP_TARGET_RESOLUTION],
+    ids=[name for name, _sql, _target in _GROUP_TARGET_RESOLUTION],
+)
+def test_list_group_bys_reports_the_resolved_target(sql: str, target: str) -> None:
+    assert list_group_bys(_parse(sql))[0].targets == (target,)
 
 
 def test_list_aggregations_excludes_windowed_functions() -> None:
@@ -160,7 +143,9 @@ def test_null_group_after_left_join_detected() -> None:
 
 
 def test_null_group_alias_target_detected() -> None:
-    # `group by grp` names the projection aliased grp, which is the nullable side.
+    # `group by grp` names the projection aliased grp, which is the nullable side. The
+    # unqualified `group by customer_id` spelling of the jaffle idiom is the same lookup, and
+    # the metamorphic property in test_pbt_structural_hazards.py holds every detector to it.
     sql = """
     select b.k as grp, sum(amount) as total
     from a left join b on a.k = b.k
@@ -171,152 +156,27 @@ def test_null_group_alias_target_detected() -> None:
     assert findings[0].kind is FindingKind.NULL_GROUP_AFTER_OUTER_JOIN
 
 
-def test_null_group_unqualified_reference_to_projected_column_detected() -> None:
-    # The dbt idiom: project a qualified column, group by its bare name. SQL binds the name to
-    # the input column, and the projection *is* that column, so both readings land on the same
-    # expression and resolving is sound even though the name shadows an input column.
+def test_null_group_alias_of_a_preserved_column_not_detected() -> None:
     sql = """
-    select orders.customer_id, sum(amount) as total
+    select payments.order_id as grp, sum(amount) as total
     from payments left join orders on payments.order_id = orders.order_id
-    group by customer_id
-    """
-    findings = detect_null_group_after_outer_join(_parse(sql))
-    assert len(findings) == 1
-    assert findings[0].kind is FindingKind.NULL_GROUP_AFTER_OUTER_JOIN
-
-
-def test_null_group_unqualified_reference_to_preserved_column_not_detected() -> None:
-    sql = """
-    select payments.order_id, sum(amount) as total
-    from payments left join orders on payments.order_id = orders.order_id
-    group by order_id
+    group by grp
     """
     assert detect_null_group_after_outer_join(_parse(sql)) == ()
 
 
-def test_null_group_alias_shadowing_an_input_column_not_resolved() -> None:
-    # SQL resolves a GROUP BY name to an input column before an output alias, so `group by amt`
-    # here groups by b.amt, not by the projection aliased amt. We cannot tell which table an
-    # unqualified name binds to without a schema, so we decline to resolve and stay silent.
-    # This is the known-permissive edge of the alias rule: the b.amt grouping is a real hazard
-    # we do not report, matching the behaviour before aliases resolved at all.
+def test_null_group_alias_shadowed_by_an_input_column_still_reports() -> None:
+    # The known-permissive edge: SQL binds `amt` to the input column `b.amt`, so the grouping
+    # is really by b.amt while we resolve to the projection `b.k * 2`. Ruling that out needs a
+    # schema the AST layer does not have. Both readings sit on the nullable side here, so the
+    # verdict stands, and over-reporting is this detector's safe direction either way.
     sql = """
-    select b.amt * 2 as amt, sum(amount) as total
+    select b.k * 2 as amt, sum(amount) as total
     from a left join b on a.k = b.k
     group by amt
     """
-    assert detect_null_group_after_outer_join(_parse(sql)) == ()
-
-
-def test_null_group_alias_under_a_star_projection_not_resolved() -> None:
-    # `select a.*` carries input columns the query never names, so `amt` may bind to an `a.amt`
-    # the shadow guard cannot see. A star makes every name potentially taken, so resolution
-    # declines rather than resolving to `b.k * 2` and reporting a hazard the query may not have.
-    sql = """
-    select a.*, b.k * 2 as amt, sum(amount) as total
-    from a left join b on a.k = b.k
-    group by a.id, amt
-    """
-    assert detect_null_group_after_outer_join(_parse(sql)) == ()
-
-
-# Which scope a column belongs to decides whether it is evidence that a GROUP BY name is
-# taken. The guard asks two questions in order: can this scope's input columns be enumerated
-# (a derived table or a CTE names its own output, a base table does not), and failing that,
-# is a column of the name referenced somewhere that could bind to one of this scope's sources.
-# Each case below is a distinct answer to that pair, and `amt` is always the projected alias.
-_SHADOW_CASES: list[tuple[str, str, bool]] = [
-    (
-        # `c` is never a source here, so its body says nothing about what `a` and `b` carry.
-        "unused-cte/not-evidence",
-        """with c as (select amt from raw)
-        select b.k * 2 as amt, sum(amount) as total
-        from a left join b on a.k = b.k group by amt""",
-        True,
-    ),
-    (
-        # Nor does a subquery that only correlates to itself; `z.amt` is a column of `z`.
-        "unrelated-subquery/not-evidence",
-        """select b.k * 2 as amt, sum(amount) as total
-        from a left join b on a.k = b.k
-        where exists (select 1 from z where z.amt > 0) group by amt""",
-        True,
-    ),
-    (
-        # A correlated reference reaches back out to this scope, so `a.amt` is a real input
-        # column even though it is written inside the subquery.
-        "correlated-outer-reference/evidence",
-        """select b.k * 2 as amt, sum(amount) as total
-        from a left join b on a.k = b.k
-        where exists (select 1 from z where z.q = a.amt) group by amt""",
-        False,
-    ),
-    (
-        # A CTE that IS a source names its own output columns, so `amt` is taken. The name
-        # appears nowhere as a column, only as an output alias, which is why sweeping for
-        # referenced columns cannot see it.
-        "cte-source-aliases-the-name/evidence",
-        """with c as (select v as amt, k from raw)
-        select b.k * 2 as amt, sum(amount) as total
-        from c left join b on c.k = b.k group by amt""",
-        False,
-    ),
-    (
-        # Same for a derived table, and here every source is enumerable, so this is decided
-        # rather than guessed.
-        "derived-table-aliases-the-name/evidence",
-        """select q.k * 2 as amt, sum(q.amount) as total
-        from (select v as amt, k from raw) p left join (select k, amount from other) q
-        on p.k = q.k group by amt""",
-        False,
-    ),
-    (
-        # Every source enumerable and no `amt` among them: the name is decidably free, so the
-        # alias resolves without falling back to the reference sweep at all.
-        "derived-tables-without-the-name/not-evidence",
-        """select q.k * 2 as amt, sum(q.amount) as total
-        from (select v, k from raw) p left join (select k, amount from other) q
-        on p.k = q.k group by amt""",
-        True,
-    ),
-    (
-        # A schema-qualified name binds to the real table, so a CTE that happens to share its
-        # bare name describes a different relation and its `amt` is not this source's column.
-        "schema-qualified-source-is-not-the-cte/not-evidence",
-        """with c as (select v as amt, k from raw)
-        select b.k * 2 as amt, sum(amount) as total
-        from db.c as t left join b on t.k = b.k group by amt""",
-        True,
-    ),
-    (
-        # A star inside a derived-table source carries unknown columns just as an outer `*`
-        # does, so `amt` may be among them: the same decline, whether the star is the scope's
-        # own projection or one it reads from.
-        "derived-source-star/unknown-columns",
-        """select q.k * 2 as amt, sum(q.amount) as total
-        from (select * from raw) p left join (select k, amount from other) q
-        on p.k = q.k group by amt""",
-        False,
-    ),
-]
-
-
-@pytest.mark.parametrize(
-    ("sql", "resolves"),
-    [(sql, resolves) for _name, sql, resolves in _SHADOW_CASES],
-    ids=[name for name, _sql, _resolves in _SHADOW_CASES],
-)
-def test_null_group_alias_resolves_only_when_the_name_is_free(sql: str, resolves: bool) -> None:
-    # Resolving the alias reaches `b.k * 2` / `q.k * 2` on the nullable side, so the finding
-    # firing is the observable signal that resolution happened.
-    fired = detect_null_group_after_outer_join(_parse(sql)) != ()
-    assert fired is resolves
-
-
-def test_list_group_bys_resolves_alias_target() -> None:
-    groups = list_group_bys(_parse("select b.k as grp, count(*) from t group by grp"))
-    assert groups[0].targets == ("b.k",)
-    assert groups[0].target_columns == (("b", "k"),)
+    findings = detect_null_group_after_outer_join(_parse(sql))
+    assert len(findings) == 1
 
 
 def test_null_group_positional_target_detected_and_located() -> None:

--- a/tests/sql/test_patterns.py
+++ b/tests/sql/test_patterns.py
@@ -280,6 +280,15 @@ _SHADOW_CASES: list[tuple[str, str, bool]] = [
         True,
     ),
     (
+        # A schema-qualified name binds to the real table, so a CTE that happens to share its
+        # bare name describes a different relation and its `amt` is not this source's column.
+        "schema-qualified-source-is-not-the-cte/not-evidence",
+        """with c as (select v as amt, k from raw)
+        select b.k * 2 as amt, sum(amount) as total
+        from db.c as t left join b on t.k = b.k group by amt""",
+        True,
+    ),
+    (
         # A star inside a derived-table source carries unknown columns just as an outer `*`
         # does, so `amt` may be among them: the same decline, whether the star is the scope's
         # own projection or one it reads from.

--- a/tests/sql/test_pbt_structural_hazards.py
+++ b/tests/sql/test_pbt_structural_hazards.py
@@ -46,6 +46,7 @@ from hypothesis import strategies as st
 from dblect.sql.patterns import (
     detect_inner_flatten_row_drop,
     detect_where_on_outer_joined_nullable,
+    scan_all,
 )
 from tests.lineage._duckdb_oracle import materialized, scalar
 
@@ -245,3 +246,74 @@ def test_where_clear_implies_unmatched_rows_survive(
             f"detector cleared but {dropped_unmatched} unmatched rows were dropped by "
             f"where {predicate!r} (a={d.a_rows}, b={d.b_rows})"
         )
+
+
+# --- spelling invariance of GROUP BY targets ---------------------------------------------
+
+
+@dataclass(frozen=True)
+class _GroupTarget:
+    """One projection that a GROUP BY can name, either by expression or by ordinal."""
+
+    sql: str
+    alias: str | None
+
+    def projection(self) -> str:
+        return self.sql if self.alias is None else f"{self.sql} as {self.alias}"
+
+
+# Projections chosen so the grouped set reaches every clause the GROUP BY readers branch on:
+# the nullable side of the join (the null-group hazard), the preserved side and a
+# preserved-side COALESCE fallback (its guards), a two-nullable-side COALESCE (which the
+# guards must *not* clear), an IS NOT NULL test (the boolean-bucket clear), and a
+# non-deterministic call (the load-bearing-position hazard).
+_GROUP_TARGET_SQL = (
+    "a.k",
+    "b.k",
+    "b.status",
+    "coalesce(b.k, a.k)",
+    "coalesce(b.k, b.status)",
+    "b.k is not null",
+    "date_diff('day', a.ts, now())",
+)
+
+
+@st.composite
+def _group_by_query(draw: st.DrawFn) -> tuple[str, str]:
+    """One logical query rendered twice: grouping by expression, and by ordinal.
+
+    Both spellings denote the same grouping, so every detector must return the same verdict
+    for them. Aliases are drawn independently of the grouping so the ordinal has to resolve
+    through an ``AS`` binding as often as not.
+    """
+    chosen = draw(st.lists(st.sampled_from(_GROUP_TARGET_SQL), min_size=1, max_size=4, unique=True))
+    targets = [
+        _GroupTarget(sql, f"p{i}" if draw(st.booleans()) else None) for i, sql in enumerate(chosen)
+    ]
+    grouped = draw(
+        st.lists(st.integers(min_value=0, max_value=len(targets) - 1), min_size=1, unique=True)
+    )
+    # The aggregate trails the grouped projections so ordinals index a stable prefix.
+    projections = ", ".join([t.projection() for t in targets] + ["sum(a.amt) as total"])
+    body = f"select {projections} from a left join b on a.k = b.k group by "
+    return (
+        body + ", ".join(targets[i].sql for i in grouped),
+        body + ", ".join(str(i + 1) for i in grouped),
+    )
+
+
+@given(q=_group_by_query())
+@settings(max_examples=200, deadline=None)
+def test_group_by_ordinal_matches_named_spelling(q: tuple[str, str]) -> None:
+    """``GROUP BY 1`` is the same query as ``GROUP BY <first projection>``, so it must draw the
+    same findings. A detector that reads the ``Group`` node structurally sees an ``exp.Literal``
+    where the semantics are the projected expression, which silently disarms it; this property
+    is what pins the two spellings together across every detector at once."""
+    named, positional = q
+    assert _scan_kinds(named) == _scan_kinds(positional), (
+        f"named {named!r} and positional {positional!r} disagree"
+    )
+
+
+def _scan_kinds(sql: str) -> list[str]:
+    return sorted(f.kind.value for f in scan_all(sqlglot.parse_one(sql, read="duckdb")))

--- a/tests/sql/test_pbt_structural_hazards.py
+++ b/tests/sql/test_pbt_structural_hazards.py
@@ -1,7 +1,7 @@
 """Property-based tests for two structural detectors, complementing the example tests
 in ``test_patterns.py``.
 
-Three properties with teeth for the precision fixes these detectors carry:
+Properties with teeth for the precision fixes these detectors carry:
 
 * **Dialect invariance of the inner-flatten detector** (parse-only, metamorphic): the same
   logical array flatten written under ``UNNEST`` (duckdb/bigquery), ``LATERAL VIEW EXPLODE``
@@ -30,12 +30,24 @@ Three properties with teeth for the precision fixes these detectors carry:
   include the column-level ``COALESCE(b.col, 0) = x`` idiom, whose permissive clear is a
   deliberate "the analyst handled the null" call rather than a preservation claim (see
   ``guards.is_coalesced``); that idiom's contract is not "the join is preserved".
+
+* **Spelling invariance of GROUP BY targets** (parse-only, metamorphic): a query grouped by
+  expression and the same query grouped by ordinal or by output alias must draw the same
+  findings. The detectors read grouping keys off the ``Group`` node, where both indirect
+  spellings arrive as something other than the projected expression, so this pins every
+  GROUP BY reader to the semantics rather than to the surface form.
+
+* **The unordered-window verdict against permutation stability** (duckdb execution oracle): the
+  detector clears a ranking window exactly when its ORDER BY survives feeding the same rows in a
+  different insertion order. A literal inside a window is a constant rather than a positional
+  reference, so ``over (order by 1)`` pins nothing, and the engine is the judge of that.
 """
 
 from __future__ import annotations
 
 from collections.abc import Iterator
 from dataclasses import dataclass
+from typing import cast
 
 import duckdb
 import pytest
@@ -45,6 +57,7 @@ from hypothesis import strategies as st
 
 from dblect.sql.patterns import (
     detect_inner_flatten_row_drop,
+    detect_unordered_window,
     detect_where_on_outer_joined_nullable,
     scan_all,
 )
@@ -280,11 +293,15 @@ _GROUP_TARGET_SQL = (
 
 @st.composite
 def _group_by_query(draw: st.DrawFn) -> tuple[str, str]:
-    """One logical query rendered twice: grouping by expression, and by ordinal.
+    """One logical query rendered twice: grouping wholly by expression, and grouping with at
+    least one target named indirectly, by its ordinal or by its output alias.
 
-    Both spellings denote the same grouping, so every detector must return the same verdict
-    for them. Aliases are drawn independently of the grouping so the ordinal has to resolve
-    through an ``AS`` binding as often as not.
+    All three spellings denote the same grouping, so every detector must return the same verdict
+    for them. Aliases are drawn independently of the grouping, so an ordinal has to resolve
+    through an ``AS`` binding as often as not, and the spelling is drawn per target rather than
+    all-or-nothing, so a clause mixing spellings is an ordinary example rather than a special
+    case. The alias pool (``p0``..``p3``) deliberately avoids the source column names, since a
+    name that could bind to an input column is one this resolution declines to touch.
     """
     chosen = draw(st.lists(st.sampled_from(_GROUP_TARGET_SQL), min_size=1, max_size=4, unique=True))
     targets = [
@@ -293,13 +310,34 @@ def _group_by_query(draw: st.DrawFn) -> tuple[str, str]:
     grouped = draw(
         st.lists(st.integers(min_value=0, max_value=len(targets) - 1), min_size=1, unique=True)
     )
+    spellings = [draw(st.sampled_from(_spellings_for(targets[i]))) for i in grouped]
+    # At least one target has to be written indirectly, or the two renderings are the same query.
+    forced = draw(st.integers(min_value=0, max_value=len(grouped) - 1))
+    indirect = [s for s in _spellings_for(targets[grouped[forced]]) if s != "expression"]
+    spellings[forced] = draw(st.sampled_from(indirect))
     # The aggregate trails the grouped projections so ordinals index a stable prefix.
     projections = ", ".join([t.projection() for t in targets] + ["sum(a.amt) as total"])
     body = f"select {projections} from a left join b on a.k = b.k group by "
     return (
         body + ", ".join(targets[i].sql for i in grouped),
-        body + ", ".join(str(i + 1) for i in grouped),
+        body
+        + ", ".join(_render(targets[i], i, s) for i, s in zip(grouped, spellings, strict=True)),
     )
+
+
+def _spellings_for(target: _GroupTarget) -> list[str]:
+    """How this target can be named in a GROUP BY: always by its expression or its ordinal, and
+    by its output alias when it carries one."""
+    return ["expression", "ordinal"] + (["alias"] if target.alias is not None else [])
+
+
+def _render(target: _GroupTarget, index: int, spelling: str) -> str:
+    if spelling == "ordinal":
+        return str(index + 1)
+    if spelling == "alias":
+        assert target.alias is not None
+        return target.alias
+    return target.sql
 
 
 @given(q=_group_by_query())
@@ -308,7 +346,8 @@ def test_group_by_ordinal_matches_named_spelling(q: tuple[str, str]) -> None:
     """``GROUP BY 1`` is the same query as ``GROUP BY <first projection>``, so it must draw the
     same findings. A detector that reads the ``Group`` node structurally sees an ``exp.Literal``
     where the semantics are the projected expression, which silently disarms it; this property
-    is what pins the two spellings together across every detector at once."""
+    is what pins the two spellings together across every detector at once, including the
+    off-by-one an ordinal resolved against the wrong projection would introduce."""
     named, positional = q
     assert _scan_kinds(named) == _scan_kinds(positional), (
         f"named {named!r} and positional {positional!r} disagree"
@@ -317,3 +356,50 @@ def test_group_by_ordinal_matches_named_spelling(q: tuple[str, str]) -> None:
 
 def _scan_kinds(sql: str) -> list[str]:
     return sorted(f.kind.value for f in scan_all(sqlglot.parse_one(sql, read="duckdb")))
+
+
+# --- a constant ORDER BY is not an ordering (duckdb execution oracle) ---------------------
+
+
+_WINDOW_ORDERINGS = [
+    "order by n",
+    "order by 1",
+    "order by 'x'",
+    "order by null",
+    "order by 1 + 2",
+    "order by 1, n",
+    "order by n + 1",
+    "order by -n",
+]
+
+
+@pytest.mark.parametrize("clause", _WINDOW_ORDERINGS)
+def test_unordered_window_verdict_matches_permutation_stability(
+    con: duckdb.DuckDBPyConnection, clause: str
+) -> None:
+    """The detector clears a ranking window exactly when its ORDER BY really orders the rows.
+
+    A literal in a *window* ORDER BY is a constant, not the positional reference the same
+    literal denotes in a statement-level ORDER BY, so every row sorts equal and the ranking
+    falls back to whatever physical order the engine had. The oracle for "really orders" is
+    therefore permutation stability: feed the same rows in two different insertion orders and
+    see whether the row-number assignment survives. The data is the judge, so a clause we clear
+    that does not actually pin an order fails here rather than against a re-derivation.
+    """
+    ranked: list[list[tuple[int, int]]] = []
+    for rows in ("(3), (1), (2)", "(2), (1), (3)"):
+        con.execute("create or replace table w(n integer)")
+        con.execute(f"insert into w values {rows}")
+        assigned = cast(
+            "list[tuple[int, int]]",
+            con.execute(f"select n, row_number() over ({clause}) rn from w").fetchall(),
+        )
+        ranked.append(sorted(assigned))
+    stable = ranked[0] == ranked[1]
+    cleared = not detect_unordered_window(
+        sqlglot.parse_one(f"select row_number() over ({clause}) from w", read="duckdb")
+    )
+    assert cleared == stable, (
+        f"detector {'cleared' if cleared else 'flagged'} `{clause}` but the ranking is "
+        f"{'stable' if stable else 'unstable'} under input permutation: {ranked}"
+    )

--- a/tests/sql/test_pbt_structural_hazards.py
+++ b/tests/sql/test_pbt_structural_hazards.py
@@ -264,17 +264,6 @@ def test_where_clear_implies_unmatched_rows_survive(
 # --- spelling invariance of GROUP BY targets ---------------------------------------------
 
 
-@dataclass(frozen=True)
-class _GroupTarget:
-    """One projection that a GROUP BY can name, either by expression or by ordinal."""
-
-    sql: str
-    alias: str | None
-
-    def projection(self) -> str:
-        return self.sql if self.alias is None else f"{self.sql} as {self.alias}"
-
-
 # Projections chosen so the grouped set reaches every clause the GROUP BY readers branch on:
 # the nullable side of the join (the null-group hazard), the preserved side and a
 # preserved-side COALESCE fallback (its guards), a two-nullable-side COALESCE (which the
@@ -296,48 +285,42 @@ def _group_by_query(draw: st.DrawFn) -> tuple[str, str]:
     """One logical query rendered twice: grouping wholly by expression, and grouping with at
     least one target named indirectly, by its ordinal or by its output alias.
 
-    All three spellings denote the same grouping, so every detector must return the same verdict
-    for them. Aliases are drawn independently of the grouping, so an ordinal has to resolve
-    through an ``AS`` binding as often as not, and the spelling is drawn per target rather than
-    all-or-nothing, so a clause mixing spellings is an ordinary example rather than a special
-    case. The alias pool (``p0``..``p3``) deliberately avoids the source column names, since a
-    name that could bind to an input column is one this resolution declines to touch.
+    Aliases are drawn independently of the grouping, so an ordinal has to resolve through an
+    ``AS`` binding as often as not, and the spelling is drawn per target, so a clause mixing
+    spellings is an ordinary example rather than a special case.
     """
     chosen = draw(st.lists(st.sampled_from(_GROUP_TARGET_SQL), min_size=1, max_size=4, unique=True))
-    targets = [
-        _GroupTarget(sql, f"p{i}" if draw(st.booleans()) else None) for i, sql in enumerate(chosen)
-    ]
+    # An alias, where drawn, is also how the target can be named. `p0`..`p3` avoid the source
+    # column names so the spelling stays an alias reference rather than an input column.
+    aliases = [f"p{i}" if draw(st.booleans()) else None for i in range(len(chosen))]
     grouped = draw(
-        st.lists(st.integers(min_value=0, max_value=len(targets) - 1), min_size=1, unique=True)
+        st.lists(st.integers(min_value=0, max_value=len(chosen) - 1), min_size=1, unique=True)
     )
-    spellings = [draw(st.sampled_from(_spellings_for(targets[i]))) for i in grouped]
-    # At least one target has to be written indirectly, or the two renderings are the same query.
-    forced = draw(st.integers(min_value=0, max_value=len(grouped) - 1))
-    indirect = [s for s in _spellings_for(targets[grouped[forced]]) if s != "expression"]
-    spellings[forced] = draw(st.sampled_from(indirect))
+
+    def spellings(i: int) -> list[str]:
+        alias = aliases[i]
+        return [str(i + 1)] + ([alias] if alias is not None else [])
+
+    indirect = [draw(st.sampled_from(spellings(i))) for i in grouped]
+    # At least one target is written indirectly, or the two renderings are the same query.
+    direct = [draw(st.booleans()) for _ in grouped]
+    direct[draw(st.integers(min_value=0, max_value=len(grouped) - 1))] = False
+
     # The aggregate trails the grouped projections so ordinals index a stable prefix.
-    projections = ", ".join([t.projection() for t in targets] + ["sum(a.amt) as total"])
-    body = f"select {projections} from a left join b on a.k = b.k group by "
+    projections = [
+        sql if alias is None else f"{sql} as {alias}"
+        for sql, alias in zip(chosen, aliases, strict=True)
+    ]
+    selected = ", ".join([*projections, "sum(a.amt) as total"])
+    body = f"select {selected} from a left join b on a.k = b.k group by "
     return (
-        body + ", ".join(targets[i].sql for i in grouped),
+        body + ", ".join(chosen[i] for i in grouped),
         body
-        + ", ".join(_render(targets[i], i, s) for i, s in zip(grouped, spellings, strict=True)),
+        + ", ".join(
+            chosen[i] if d else spelled
+            for i, d, spelled in zip(grouped, direct, indirect, strict=True)
+        ),
     )
-
-
-def _spellings_for(target: _GroupTarget) -> list[str]:
-    """How this target can be named in a GROUP BY: always by its expression or its ordinal, and
-    by its output alias when it carries one."""
-    return ["expression", "ordinal"] + (["alias"] if target.alias is not None else [])
-
-
-def _render(target: _GroupTarget, index: int, spelling: str) -> str:
-    if spelling == "ordinal":
-        return str(index + 1)
-    if spelling == "alias":
-        assert target.alias is not None
-        return target.alias
-    return target.sql
 
 
 @given(q=_group_by_query())

--- a/tests/uniqueness/test_detector.py
+++ b/tests/uniqueness/test_detector.py
@@ -227,6 +227,22 @@ _LIMIT_CASES = [
         True,
         True,
     ),
+    (
+        # A statement-level ORDER BY *is* positional, unlike the same literal inside a window,
+        # so ordinal 1 names the key column and the slice is deterministic.
+        "order_ordinal_of_key",
+        "select id from orders order by 1 limit 10",
+        _ORDERS_ON_ID,
+        True,
+        False,
+    ),
+    (
+        "order_ordinal_of_non_key",
+        "select other from orders order by 1 limit 10",
+        _ORDERS_ON_ID,
+        True,
+        True,
+    ),
 ]
 
 

--- a/tests/uniqueness/test_detector.py
+++ b/tests/uniqueness/test_detector.py
@@ -243,6 +243,17 @@ _LIMIT_CASES = [
         True,
         True,
     ),
+    (
+        # An ordinal resolves to the named projection's own source column, which is already a
+        # source name. Translating it through the projection's aliases a second time would
+        # re-map it whenever another projection is aliased to that name: here `other as id`
+        # would turn the resolved `id` into `other` and lose the key that covers the order.
+        "order_ordinal_of_key_aliased_over_by_a_later_projection",
+        "select id as x, other as id from orders order by 1 limit 10",
+        _ORDERS_ON_ID,
+        True,
+        False,
+    ),
 ]
 
 

--- a/tests/uniqueness/test_detector.py
+++ b/tests/uniqueness/test_detector.py
@@ -254,6 +254,26 @@ _LIMIT_CASES = [
         True,
         False,
     ),
+    (
+        # A qualified name binds to the relation's column, never to the output alias that
+        # shares its name, so it is in the source namespace for the same reason an ordinal is.
+        # duckdb agrees: `order by orders.id` sorts by the key while `order by id` sorts by
+        # `other`, so the three spellings of the key here must all clear.
+        "order_qualified_key_aliased_over_by_a_later_projection",
+        "select id as x, other as id from orders order by orders.id limit 10",
+        _ORDERS_ON_ID,
+        True,
+        False,
+    ),
+    (
+        # The other direction of the same rule: a bare name does bind to the output alias, so
+        # `order by id` here orders by `other` and the key no longer covers the slice.
+        "order_bare_name_captured_by_a_later_projection_alias",
+        "select id as x, other as id from orders order by id limit 10",
+        _ORDERS_ON_ID,
+        True,
+        True,
+    ),
 ]
 
 


### PR DESCRIPTION
`GROUP BY 1` silently disabled the structural detectors. Verified end to end on the jaffle fixture: the null-group hazard at `customers.sql:44` reported under `group by orders.customer_id` and vanished under `group by 1`. The detectors match `exp.Column` inside `exp.Group`, and a positional reference is `exp.Literal(1)`, so there was nothing to match. `tests/sql/test_patterns.py` documented this for the non-determinism detector and pinned the miss as expected behaviour.

Chasing it turned up two more gaps of the same family, where a detector reads a clause structurally and the surface form is not the semantics.

## GROUP BY targets

`sg.group_targets` resolves ordinals and output-name references to the projections they name, by lookup rather than by rewriting the tree, so the nodes keep the source positions findings report line numbers from. Wired into `detect_null_group_after_outer_join`, `detect_null_group_on_nullable_key`, the non-determinism detector's load-bearing scopes, and `list_group_bys`.

Each target comes back as a `GroupTarget` carrying both the resolved `expression` and the `written_at` node, because the two answer different questions. A finding about the *grouping decision* belongs at the clause the analyst wrote, so `group by 1` and `group by customer_id` both land on the GROUP BY. A finding about something written *inside* the target, a `now()` call say, belongs at the projection holding it. Handing back the resolved node alone moved the ordinary `group by customer_id` finding off the GROUP BY and onto the SELECT line, which is the locate-ability the line-number fix below exists to protect.

An ordinal declines on the shapes where position is not the Nth projection: an index past the end of the projection list, one reaching over a `SELECT *` of unknown width, and anything that is not a bare positive integer (a string, a float, a negation, which parses as `Neg` over the literal). A name declines when two projections carry it, since it then names neither, and such a query does not run anyway: an engine binds the first and rejects the second as ungrouped.

**Known-permissive edge**, documented at the resolution and pinned by a test: SQL binds a GROUP BY name to an input column before an output alias, so `select b.amt * 2 as amt ... group by amt` really groups by `b.amt` while this resolves it to `b.amt * 2`. Ruling that out needs a schema the AST layer does not have. A reader reasoning structurally lands on the same join side either way, which is why the detectors accept it: their error direction is to over-report, and the previous behaviour of staying silent was a miss on a real hazard.

## A constant ORDER BY is not an ordering

A literal in an ORDER BY means different things by position, checked against duckdb before writing any code:

| Position | `ORDER BY 1` means |
|---|---|
| statement-level | first projection (positional) |
| window `OVER (...)` | the constant `1` |
| aggregate `array_agg(x ORDER BY 1)` | the constant `1` |
| `DISTINCT ON (1)` | first projection (positional) |

So resolving ordinals inside a window would have been wrong. The bug there is the reverse: `over (order by 1)` sorts every row equal and the ranking follows insertion order, but both ordering detectors cleared on any non-empty ORDER BY, so a column-free one silently disarmed them. They now ask `sg.imposes_row_order`.

## Statement-level ORDER BY ordinals

There a literal *is* positional. The LIMIT-without-deterministic-order check bailed on one because its targets were not bare columns, losing the key-coverage test. It resolves them first now, and `statement_order_targets` returns an `OrderTarget` carrying which namespace the expression is in, so the caller translates only what needs translating.

A resolved ordinal and a qualified `t.k` both name a source column outright, already past the `AS` binding. Only a bare name is in the output namespace. Conflating them re-translates a source column whenever some *other* projection is aliased to that name, so `select id as x, other as id from orders order by 1 limit 10` fired while its `order by x` spelling cleared. duckdb settles the qualified case: `order by orders.id` sorts by `id` while `order by id` sorts by `other`. All three spellings of one key now agree.

## Line numbers

`line_range` read positions off `Identifier` nodes only, so a positional GROUP BY, which holds no identifier, reported against line 0. sqlglot stamps `meta["line"]` at the token a node opens on, and literals, function calls, and stars carry one too, so it walks every descendant. Every stamp lies inside its own node's span, so the wider walk only tightens the answer. Without this the fix traded a silent miss for a finding nobody could locate.

## Tests

The GROUP BY contract is a metamorphic property: a query grouped by expression and the same query grouped by ordinal or alias must draw the same findings from every detector. Each target's spelling is drawn independently, so the three mix within one clause, which is also what catches an off-by-one resolution. This is the load-bearing test for the whole change.

The ordering rule is pinned against duckdb: the detector must clear a ranking window exactly when its ORDER BY survives feeding the same rows in a different insertion order. An earlier version of this test asserted a specific winning row and was pinning an arbitrary engine choice. `order by null` caught it by returning a stable result for a clause that orders nothing. The division that came out of it: the oracle owns the clause enumeration and the clear direction, and the parse-only cases guard the detect direction, which is where reading a window's ORDER BY structurally went wrong.

Everything a resolution can do to a target is one parametrized table of `(sql, rendered target)`, since an unresolvable target reads back as written and the rendered target is therefore the whole contract.

Per the repo's "prove the tests bite" rule, each guard was broken in turn and confirmed to fail a distinct test: output-name resolution, ordinal resolution, the star-in-the-prefix guard, the duplicate-output-name drop, `imposes_row_order`, the ORDER BY namespaces, `line_range`, and the finding's location.

## Verification

```
named:                L44 null_group_after_outer_join (source)
group by 1:           L44 null_group_after_outer_join (source)
group by customer_id: L44 null_group_after_outer_join (source)
```

Full gate: 1583 passed, `ruff check`, `ruff format --check`, `pyright` 0 errors.

## Left alone

The lattice properties (`_group_key`, `_group_columns`) also go blind on ordinals, but they return `None`, which drops tracked keys, the safe direction. Resolving there newly *grounds* facts, and a key is read downstream to clear hazards, so a wrong resolution silences findings rather than adding one. That needs its own soundness argument, which #225 makes on top of this branch.

## History

This branch first carried a 153-line shadow guard that enumerated a scope's input columns to decide when resolving a renaming alias was safe. It came out in `bf37282`, along with the tests describing it: the question it answered is not one a detector needs answered, and its own pinned case documented a real hazard it suppressed. See the comment below for the full accounting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVtkAmkgzf5PDg4YAs4aZA
