### PR TITLE
feat(lineage): ground a candidate key and an FD from an ordinal GROUP BY

### DIFF
--- a/src/dblect/lineage/properties/functional_dependency.py
+++ b/src/dblect/lineage/properties/functional_dependency.py
@@ -259,7 +259,7 @@ class _FdWalk:
         group = sg.group_of(sel)
         group_names: frozenset[str] | None = None
         if group is not None and group.expressions:
-            group_names = _group_columns(group)
+            group_names = _group_columns(sel)
             if group_names is None:
                 return frozenset()  # unmodellable group shape: prove nothing
             # Grouping aggregates everything outside the group key away, so only a
@@ -377,11 +377,18 @@ class _FdWalk:
         return _project_qualified(qfds, qrename)
 
 
-def _group_columns(group: exp.Group) -> frozenset[str] | None:
-    """The group key as case-folded input column names, or ``None`` for a shape we
-    cannot name (positional or expression group keys)."""
+def _group_columns(sel: exp.Select) -> frozenset[str] | None:
+    """The group key as case-folded input column names, or ``None`` for a shape we cannot name
+    (an expression group key).
+
+    Targets are read through :attr:`sg.GroupTarget.grounded_expression`, so ``GROUP BY 1`` names
+    the same columns its spelled-out form would. The dependencies minted below say the group key
+    determines every output, which is a key claim in FD clothing, so the same fallback applies:
+    a binding the AST cannot decide stays at the column name the query wrote.
+    """
     out: set[str] = set()
-    for g in group.expressions:
+    for target in sg.group_targets(sel):
+        g = target.grounded_expression
         if not isinstance(g, exp.Column) or isinstance(g.this, exp.Star):
             return None
         out.add(sg.column_name(g).lower())

--- a/src/dblect/lineage/properties/uniqueness.py
+++ b/src/dblect/lineage/properties/uniqueness.py
@@ -855,7 +855,7 @@ class _RelationWalk:
         group = sg.group_of(sel)
         grouped = group is not None and bool(group.expressions)
         if group is not None and grouped:
-            gk = _group_key(group, from_alias=from_alias)
+            gk = _group_key(sel, from_alias=from_alias)
             combined = gk if gk is not None else frozenset[_QKey]()
 
         combined |= rn_postjoin
@@ -1005,10 +1005,18 @@ def _bare_column_key(exprs: Collection[Expr], *, from_alias: str) -> _QKey | Non
     return frozenset(cols)
 
 
-def _group_key(group: exp.Group, *, from_alias: str) -> frozenset[_QKey] | None:
-    """The key a GROUP BY introduces, or ``None`` for a shape we cannot size
-    (positional or expression group keys), which drops tracked keys."""
-    key = _bare_column_key(group.expressions, from_alias=from_alias)
+def _group_key(sel: exp.Select, *, from_alias: str) -> frozenset[_QKey] | None:
+    """The key ``sel``'s GROUP BY introduces, or ``None`` for a shape we cannot size
+    (an expression group key), which drops tracked keys.
+
+    Targets are read through :attr:`sg.GroupTarget.grounded_expression`, so ``GROUP BY 1``
+    grounds the key its spelled-out form would. That fallback matters here rather than in a
+    detector: this key is read downstream to clear hazards, so resolving a target the AST
+    cannot decide would silence findings rather than add one.
+    """
+    key = _bare_column_key(
+        [t.grounded_expression for t in sg.group_targets(sel)], from_alias=from_alias
+    )
     return None if key is None else frozenset({key})
 
 

--- a/src/dblect/sql/_sqlglot.py
+++ b/src/dblect/sql/_sqlglot.py
@@ -63,18 +63,53 @@ def group_of(sel: exp.Select) -> exp.Group | None:
     return cast("exp.Group | None", sel.args.get("group"))
 
 
+class GroupBinding(StrEnum):
+    """How firmly a ``GROUP BY`` target is bound to the expression it denotes.
+
+    ``WRITTEN`` is a target spelled out in full, or one we declined to resolve, so the node is
+    its own meaning. ``DECIDED`` is fixed by SQL's own rules: an ordinal, or a name whose
+    projection is that very column. ``PRESUMED`` is a renaming alias, where SQL
+    would bind an input column of that name first and the AST cannot rule one out.
+
+    A detector may read all three, since over-reporting is its safe direction. A consumer that
+    *grounds* a fact from the group key stops at ``DECIDED`` (see
+    :attr:`GroupTarget.grounded_expression`): keys and dependencies are read downstream to
+    clear hazards, so a wrong resolution there silences real findings instead of adding a
+    spurious one.
+    """
+
+    WRITTEN = "written"
+    DECIDED = "decided"
+    PRESUMED = "presumed"
+
+
 @dataclass(frozen=True)
 class GroupTarget:
-    """One ``GROUP BY`` target: the expression it denotes, and the node the query writes.
+    """One ``GROUP BY`` target: the expression it denotes, the node the query writes, and how
+    firmly the two are tied together.
 
     A finding about the *grouping decision* belongs at ``written_at``, so ``GROUP BY 1`` is
     diagnosed at the clause an analyst reads. One about something written inside the target (a
     ``now()`` call) belongs at ``expression``, where that call is spelled out. The two nodes
-    coincide for a target written in full.
+    coincide for a target written in full. ``binding`` decides whether a consumer may ground a
+    fact from ``expression``: see :attr:`grounded_expression`.
     """
 
     expression: Expr
     written_at: Expr
+    binding: GroupBinding
+
+    @property
+    def grounded_expression(self) -> Expr:
+        """The reading a consumer may ground a fact from: the resolved expression where SQL's
+        own rules decide the binding, and the written node where they do not.
+
+        Falling back to ``written_at`` on a ``PRESUMED`` binding is the conservative reading, and
+        it is the one SQL takes whenever the name really is an input column. Two targets can also
+        resolve onto one node (``SELECT x AS a ... GROUP BY a, x`` where ``a`` is an input
+        column), which would shrink the group key, and a shorter key is the stronger claim.
+        """
+        return self.written_at if self.binding is GroupBinding.PRESUMED else self.expression
 
 
 def group_targets(sel: exp.Select) -> tuple[GroupTarget, ...]:
@@ -96,16 +131,18 @@ def group_targets(sel: exp.Select) -> tuple[GroupTarget, ...]:
     projections = cast("list[Expr]", sel.expressions)
     projected = _projection_expressions_by_output_name(sel)
     return tuple(
-        GroupTarget(_resolve_group_target(target, projections, projected), target)
-        for target in group.expressions
+        _resolve_group_target(target, projections, projected) for target in group.expressions
     )
 
 
 def _resolve_group_target(
     target: Expr, projections: Sequence[Expr], projected: Mapping[str, Expr]
-) -> Expr:
+) -> GroupTarget:
     resolved = _resolve_ordinal(target, projections)
-    return resolved if resolved is not None else _resolve_name(target, projected)
+    if resolved is not None:
+        return GroupTarget(resolved, target, GroupBinding.DECIDED)
+    expression, binding = _resolve_name(target, projected)
+    return GroupTarget(expression, target, binding)
 
 
 def _names_an_output_column(e: Expr) -> TypeGuard[exp.Column]:
@@ -119,20 +156,29 @@ def _names_an_output_column(e: Expr) -> TypeGuard[exp.Column]:
     return isinstance(e, exp.Column) and isinstance(e.this, exp.Identifier) and e.table == ""
 
 
-def _resolve_name(target: Expr, projected: Mapping[str, Expr]) -> Expr:
-    """``target`` resolved to the projection it names, if it is an output-name reference.
+def _resolve_name(target: Expr, projected: Mapping[str, Expr]) -> tuple[Expr, GroupBinding]:
+    """``target`` resolved to the projection it names, if it is an output-name reference, with
+    how firmly the two are tied together.
 
-    **Known-permissive edge**: SQL binds a GROUP BY name to an input column before an output
-    alias, so ``select b.amt * 2 as amt ... group by amt`` really groups by ``b.amt`` while this
-    resolves it to ``b.amt * 2``. Ruling that out needs a schema the AST layer does not have. A
-    reader reasoning structurally lands on the same join side either way, which is why the
-    detectors accept it: their error direction is to over-report. A consumer that *grounds* a
-    fact from the group key needs more, and takes it from the target it was written as.
+    A name whose projection is *itself* the bare column of that name is ``DECIDED``: SQL binds
+    the name to that input column, the projection is that same column, so the two readings agree.
+    This is the ``select orders.customer_id ... group by customer_id`` idiom.
+
+    Any other projection is a renaming, and SQL binds a GROUP BY name to an input column before
+    an output alias, so ``select b.amt * 2 as amt ... group by amt`` really groups by ``b.amt``
+    while this resolves it to ``b.amt * 2``. Ruling that out needs a schema the AST layer does not
+    have, hence ``PRESUMED``. A reader reasoning structurally lands on the same join side either
+    way, which is why the detectors accept it: their error direction is to over-report.
     """
     if not _names_an_output_column(target):
-        return target
-    projection = projected.get(column_name(target))
-    return target if projection is None else projection
+        return target, GroupBinding.WRITTEN
+    name = column_name(target)
+    projection = projected.get(name)
+    if projection is None:
+        return target, GroupBinding.WRITTEN
+    if isinstance(projection, exp.Column) and column_name(projection) == name:
+        return projection, GroupBinding.DECIDED
+    return projection, GroupBinding.PRESUMED
 
 
 def _projection_expressions_by_output_name(sel: exp.Select) -> dict[str, Expr]:

--- a/tests/lineage/_group_spelling.py
+++ b/tests/lineage/_group_spelling.py
@@ -1,0 +1,25 @@
+"""How a GROUP BY names its targets, shared by the generators that vary that axis.
+
+Both lattice soundness PBTs (uniqueness and functional dependency) ground a fact from the
+group key, so both want the same spellings drawn against the same oracle.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class GroupSpelling(StrEnum):
+    """How a GROUP BY names its targets.
+
+    ``EXPRESSION`` and ``ORDINAL`` denote the same grouping, so a lattice must ground the
+    same fact for either. ``SHADOWING_ALIAS`` does not: there the name is a real input
+    column that the projection also aliases over, so SQL's input-before-alias binding keeps
+    the two targets distinct, while reading the name as its projection collapses them onto
+    one column. A collapsed two-column group key becomes a one-column key, the stronger
+    claim, which an execution oracle sees as a duplicate in the output.
+    """
+
+    EXPRESSION = "expression"
+    ORDINAL = "ordinal"
+    SHADOWING_ALIAS = "shadowing_alias"

--- a/tests/lineage/test_functional_dependency_propagation.py
+++ b/tests/lineage/test_functional_dependency_propagation.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 
+import pytest
+
 from dblect.adapters import profile_for_adapter
 from dblect.lineage.builder import build_relation_graph
 from dblect.lineage.facts.model import Annotation, Declared, DeclaredSource, Fact
@@ -205,16 +207,42 @@ def test_constancy_flows_through_a_cte_and_a_downstream_model() -> None:
 # --- GROUP BY --------------------------------------------------------------------
 
 
-def test_group_by_determines_the_aggregates() -> None:
+# The group key determines the aggregates however the GROUP BY spells its targets.
+# ``GROUP BY 1`` is the dbt house style, so the ordinal carries most real aggregate models.
+_GROUP_SPELLINGS: list[tuple[str, str]] = [
+    ("expression", "SELECT country, SUM(amount) AS total FROM payments GROUP BY country"),
+    ("ordinal", "SELECT country, SUM(amount) AS total FROM payments GROUP BY 1"),
+    (
+        "ordinal-through-alias",
+        "SELECT payments.country AS country, SUM(amount) AS total FROM payments GROUP BY 1",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "sql", [sql for _name, sql in _GROUP_SPELLINGS], ids=[name for name, _sql in _GROUP_SPELLINGS]
+)
+def test_group_by_determines_the_aggregates(sql: str) -> None:
+    out = _fds(_declared(), _source(_PAYMENTS.unique_id), _model("model.shop.by_country", sql))
+    assert out["model.shop.by_country"] == FDSet.of(_fd("total", "country"))
+
+
+def test_group_by_name_shadowed_by_an_input_column_determines_nothing() -> None:
+    # `GROUP BY country` binds to the input column, which the projection aliases over, so
+    # the grouping is by (country, currency) while the output carries only the renamed
+    # currency. Two groups sharing a currency then disagree on the total, so `country` in
+    # the output determines nothing. Reading the name as its projection would collapse the
+    # two targets onto `currency` and mint the dependency anyway.
     out = _fds(
         _declared(),
         _source(_PAYMENTS.unique_id),
         _model(
             "model.shop.by_country",
-            "SELECT country, SUM(amount) AS total FROM payments GROUP BY country",
+            "SELECT p.currency AS country, SUM(amount) AS total FROM payments p "
+            "GROUP BY country, p.currency",
         ),
     )
-    assert out["model.shop.by_country"] == FDSet.of(_fd("total", "country"))
+    assert out["model.shop.by_country"] == FDSet.of()
 
 
 def test_group_by_keeps_fds_among_the_group_columns() -> None:

--- a/tests/lineage/test_pbt_functional_dependency_soundness.py
+++ b/tests/lineage/test_pbt_functional_dependency_soundness.py
@@ -36,6 +36,7 @@ from dblect.lineage.properties.functional_dependency import (
 )
 from dblect.lineage.property import propagate
 from dblect.manifest import Manifest, Node, ResourceType
+from tests.lineage._group_spelling import GroupSpelling
 
 _SRC = SourceRef(SourceKind.SOURCE, "source.test.raw.t")
 _MODEL = SourceRef(SourceKind.MODEL, "model.test.m")
@@ -48,6 +49,7 @@ class Scenario:
     declared: bool  # ``g -> x`` declared, and the data honours it
     where: tuple[str, int] | None  # equality filter ``col = literal``
     group_cols: tuple[str, ...]  # non-empty means GROUP BY these input columns
+    group_spelling: GroupSpelling  # how that GROUP BY names them
     renames: Mapping[str, str]  # projected input column -> output name
 
 
@@ -78,8 +80,16 @@ def _scenario(draw: st.DrawFn) -> Scenario:
         projected = tuple(sorted(draw(st.sets(st.sampled_from(_COLS), min_size=1, max_size=3))))
     names = draw(st.permutations(("a", "b", "c")))
     renames = {col: names[i] for i, col in enumerate(projected)}
+    # Every projection here renames, so an ordinal has to see through the AS binding to the
+    # input column and then let the projection rename it back.
+    spelling = draw(st.sampled_from((GroupSpelling.EXPRESSION, GroupSpelling.ORDINAL)))
     return Scenario(
-        rows=tuple(rows), declared=declared, where=where, group_cols=group_cols, renames=renames
+        rows=tuple(rows),
+        declared=declared,
+        where=where,
+        group_cols=group_cols,
+        group_spelling=spelling,
+        renames=renames,
     )
 
 
@@ -91,7 +101,13 @@ def _model_sql(s: Scenario) -> str:
     if s.where is not None:
         sql += f" WHERE {s.where[0]} = {s.where[1]}"
     if s.group_cols:
-        sql += f" GROUP BY {', '.join(s.group_cols)}"
+        # The group columns lead the projection list, so ordinal i names group column i.
+        targets = (
+            ", ".join(str(i + 1) for i in range(len(s.group_cols)))
+            if s.group_spelling is GroupSpelling.ORDINAL
+            else ", ".join(s.group_cols)
+        )
+        sql += f" GROUP BY {targets}"
     return sql
 
 

--- a/tests/lineage/test_pbt_uniqueness_soundness.py
+++ b/tests/lineage/test_pbt_uniqueness_soundness.py
@@ -17,7 +17,9 @@ Two generators feed one soundness checker:
 
 * **Unconditional shapes** (``_scenario``): one model over one or two sources with
   ``unique`` declarations, in the filter / inner-join / left-join / group-by /
-  distinct forms.
+  distinct forms. The group-by form draws how it names its targets (see
+  ``GroupSpelling``), so the ordinals a dbt project actually writes are judged by the
+  same oracle as the spelled-out form.
 * **Conditional activation** (``_cond_scenario``): a ``where``-filtered ``unique``
   on a source whose downstream model applies a filter that may or may not imply the
   predicate. Source data honors the conditional declaration (``id`` is distinct only
@@ -55,6 +57,7 @@ from dblect.lineage.properties.uniqueness import (
 from dblect.lineage.property import propagate
 from dblect.manifest import DbtTestMetadata, Manifest, Node, ResourceType
 from tests.lineage._duckdb_oracle import Table, materialized, scalar
+from tests.lineage._group_spelling import GroupSpelling
 
 _DUCKDB = profile_for_adapter("duckdb")
 
@@ -166,6 +169,7 @@ class ModelSpec:
     filter_col: str | None = None
     filter_threshold: int | None = None
     group_cols: tuple[str, ...] | None = None
+    group_spelling: GroupSpelling | None = None
     partition_cols: tuple[str, ...] | None = None
 
 
@@ -199,6 +203,13 @@ def _rows(draw: st.DrawFn, source: SourceSpec) -> tuple[tuple[int, ...], ...]:
         )
         rows.append((key, *plain))
     return tuple(rows)
+
+
+def _column_subset(draw: st.DrawFn) -> tuple[str, ...]:
+    """A sorted distinct subset of ``s0``'s columns, the shape GROUP BY and DISTINCT share."""
+    return tuple(
+        sorted(draw(st.lists(st.sampled_from(_S0.columns), min_size=1, max_size=3, unique=True)))
+    )
 
 
 @st.composite
@@ -253,14 +264,29 @@ def _scenario(draw: st.DrawFn) -> Scenario:
             filter_col=draw(st.sampled_from(_S0.columns)),
             filter_threshold=draw(st.integers(min_value=0, max_value=_PLAIN_DOMAIN)),
         )
-    else:  # group_by | distinct
-        cols = tuple(
-            sorted(
-                draw(st.lists(st.sampled_from(_S0.columns), min_size=1, max_size=3, unique=True))
+    elif shape == "group_by":
+        spelling = draw(st.sampled_from(tuple(GroupSpelling)))
+        if spelling is GroupSpelling.SHADOWING_ALIAS:
+            # ``SELECT source AS name ... GROUP BY name, source``: the group key is
+            # (input ``name``, ``source``) while the output carries only ``source`` under
+            # ``name``'s spelling, so two groups can share an output value.
+            name_col, source_col = draw(
+                st.lists(st.sampled_from(_S0.columns), min_size=2, max_size=2, unique=True)
             )
-        )
-        select = (*cols, "n") if shape == "group_by" else cols
-        model = ModelSpec(shape=shape, select_cols=select, group_cols=cols)
+            model = ModelSpec(
+                shape=shape,
+                select_cols=(name_col, "n"),
+                group_cols=(name_col, source_col),
+                group_spelling=spelling,
+            )
+        else:
+            cols = _column_subset(draw)
+            model = ModelSpec(
+                shape=shape, select_cols=(*cols, "n"), group_cols=cols, group_spelling=spelling
+            )
+    else:  # distinct
+        cols = _column_subset(draw)
+        model = ModelSpec(shape=shape, select_cols=cols, group_cols=cols)
 
     data = tuple((s.name, draw(_rows(s))) for s in sources)
     return Scenario(sources=sources, model=model, data=data)
@@ -293,9 +319,20 @@ def _scenario_sql(m: ModelSpec) -> str:
         )
     assert m.group_cols is not None
     cols = ", ".join(m.group_cols)
-    if m.shape == "group_by":
-        return f"SELECT {cols}, COUNT(*) AS n FROM s0 GROUP BY {cols}"
-    return f"SELECT DISTINCT {cols} FROM s0"
+    if m.shape != "group_by":
+        return f"SELECT DISTINCT {cols} FROM s0"
+    if m.group_spelling is GroupSpelling.SHADOWING_ALIAS:
+        name_col, source_col = m.group_cols
+        return (
+            f"SELECT {source_col} AS {name_col}, COUNT(*) AS n "
+            f"FROM s0 GROUP BY {name_col}, {source_col}"
+        )
+    targets = (
+        ", ".join(str(i + 1) for i in range(len(m.group_cols)))
+        if m.group_spelling is GroupSpelling.ORDINAL
+        else cols
+    )
+    return f"SELECT {cols}, COUNT(*) AS n FROM s0 GROUP BY {targets}"
 
 
 def _scenario_manifest(s: Scenario) -> Manifest:

--- a/tests/lineage/test_uniqueness_propagation.py
+++ b/tests/lineage/test_uniqueness_propagation.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 
+import pytest
 import sqlglot.expressions as exp
 
 # The relation-graph builder lives next to the column builder.
@@ -169,16 +170,53 @@ def test_projection_rename_remaps_the_key() -> None:
     assert keys["model.shop.stg"] == CandidateKeySet.of(_key("order_id"))
 
 
-def test_group_by_introduces_a_key_on_the_group_columns() -> None:
+# A GROUP BY names its targets in several ways, and the key it introduces is the same for
+# all of them. `GROUP BY 1` is the dbt house style, so the ordinal spellings carry most of
+# the aggregate models a project has.
+_SAME_KEY_SPELLINGS: list[tuple[str, str]] = [
+    ("expression", "SELECT customer_id, SUM(amount) AS total FROM orders GROUP BY customer_id"),
+    ("ordinal", "SELECT customer_id, SUM(amount) AS total FROM orders GROUP BY 1"),
+    # The ordinal names the projection, so resolving it has to see through the AS binding to
+    # the source column and then let the projection rename it back.
+    (
+        "ordinal-through-alias",
+        "SELECT orders.customer_id AS customer_id, SUM(amount) AS total FROM orders GROUP BY 1",
+    ),
+    (
+        "name-of-the-projected-column",
+        "SELECT orders.customer_id, SUM(amount) AS total FROM orders GROUP BY customer_id",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [sql for _name, sql in _SAME_KEY_SPELLINGS],
+    ids=[name for name, _sql in _SAME_KEY_SPELLINGS],
+)
+def test_group_by_introduces_a_key_on_the_group_columns(sql: str) -> None:
+    src = _source("source.shop.raw.orders")
+    keys = _keys(src, _model("model.shop.by_customer", sql))
+    assert keys["model.shop.by_customer"] == CandidateKeySet.of(_key("customer_id"))
+
+
+def test_group_by_name_shadowed_by_an_input_column_introduces_no_key() -> None:
+    # `GROUP BY customer_id` binds to the input column, which the projection aliases over,
+    # so the grouping is by (customer_id, region) while the output carries only the renamed
+    # region. Two groups sharing a region then produce the same output value, so no key
+    # holds. Reading the name as the projection instead would collapse the two targets onto
+    # `region` and claim one, which is the edge the resolution declines to cross: an input
+    # column of a base table is not something the AST can rule out.
     src = _source("source.shop.raw.orders")
     keys = _keys(
         src,
         _model(
             "model.shop.by_customer",
-            "SELECT customer_id, SUM(amount) AS total FROM orders GROUP BY customer_id",
+            "SELECT o.region AS customer_id, COUNT(*) AS n "
+            "FROM orders o GROUP BY customer_id, o.region",
         ),
     )
-    assert keys["model.shop.by_customer"] == CandidateKeySet.of(_key("customer_id"))
+    assert keys["model.shop.by_customer"] == CandidateKeySet.of()
 
 
 def test_distinct_introduces_a_full_tuple_key() -> None:

--- a/tests/lineage/test_uniqueness_propagation.py
+++ b/tests/lineage/test_uniqueness_propagation.py
@@ -200,6 +200,25 @@ def test_group_by_introduces_a_key_on_the_group_columns(sql: str) -> None:
     assert keys["model.shop.by_customer"] == CandidateKeySet.of(_key("customer_id"))
 
 
+def test_group_by_bare_name_binds_to_the_joined_in_side_it_projects() -> None:
+    # The dbt idiom `select orders.customer_id ... group by customer_id`, in a scope where
+    # the name belongs to the joined-in side rather than the FROM. Reading the written node
+    # would qualify it with the FROM's alias and lose the key; the projection is that same
+    # column, so SQL's own binding decides it and the key survives.
+    orders = _source("source.shop.raw.orders")
+    customers = _source("source.shop.raw.customers")
+    keys = _keys(
+        orders,
+        customers,
+        _model(
+            "model.shop.by_customer",
+            "SELECT c.region, SUM(o.amount) AS total "
+            "FROM orders o JOIN customers c ON o.customer_id = c.id GROUP BY region",
+        ),
+    )
+    assert keys["model.shop.by_customer"] == CandidateKeySet.of(_key("region"))
+
+
 def test_group_by_name_shadowed_by_an_input_column_introduces_no_key() -> None:
     # `GROUP BY customer_id` binds to the input column, which the projection aliases over,
     # so the grouping is by (customer_id, region) while the output carries only the renamed


### PR DESCRIPTION
Stacked on #224, which introduces `GroupTarget`. Base is `worktree-group-by-ordinal`, so review that one first.

`GROUP BY 1` is the dbt house style, and both lattices read the `Group` node structurally, so the key of a large share of real aggregate models is invisible today. Every fact-grounded detector downstream of one goes quiet. On a four-model project where `daily` groups by `1, 2`:

```
before:  0 findings
after:   join_fanout
         limit_without_deterministic_order
         non_unique_window_order_keys
```

All three are real, confirmed on rows: `facts JOIN daily ON customer_id` takes 2 fact rows to 3 because `daily`'s grain is `(customer_id, order_date)`; the window and the LIMIT both tie within a customer.

## Why a lattice cannot just reuse the detectors' resolution

A detector that resolves a group target wrongly over-reports, which is visible and bounded. A lattice grounds a key or a dependency, and those are read downstream to *clear* hazards, so the same mistake silences real findings. The direction of the error inverts, so the two consumers need different confidence thresholds.

`GroupTarget` now carries a `GroupBinding`, and `grounded_expression` takes the resolved node only where SQL's own rules decide the binding:

| Binding | Source | Grounded? |
|---|---|---|
| `DECIDED` | an ordinal, or a name whose projection is that very column | yes |
| `WRITTEN` | spelled out, or a resolution we declined | yes, it is its own meaning |
| `PRESUMED` | a renaming alias resolved through the shadow guard | no, falls back to the written node |

An ordinal is positional by definition and `_resolve_ordinal` already declines the shapes where position is not the Nth projection. A name whose projection is that same column agrees with the engine, since the two cases where it would not (an ambiguous unqualified name, a `USING` merged column) are queries no adapter accepts. Both were checked against duckdb.

Detectors are untouched and keep reading every binding.

## The counterexample

```sql
SELECT x AS a, COUNT(*) AS n FROM t GROUP BY a, x   -- `a` is a real input column
```

`a` binds to the input column, so the group key is `(a, x)`. Reading the name as its projection collapses both targets onto `x`, and a two-column group key becomes one column, which is the stronger claim. Over three rows duckdb returns two output rows sharing an `a` value, so both the key and the minted dependency are refuted by data. This is why `PRESUMED` falls back rather than declining outright: the written node is what SQL binds whenever the name really is an input column.

## Tests

Test-first. The four ordinal cases and the FD soundness PBT failed before the change; the two shadowing cases passed beforehand, which is the right baseline since the conservative reading was already correct there.

The two execution oracles do the load-bearing work. `test_pbt_uniqueness_soundness.py` draws a `GroupSpelling` alongside the spelled-out form, including the shadowing collapse, so duckdb judges it rather than a re-derivation. `test_pbt_functional_dependency_soundness.py` draws the ordinal against its own oracle. The spelling enum is shared, since both generators vary the same axis.

Each guard was reverted in turn:

| Reverted | Failing test |
|---|---|
| gate removed (always trust resolution) | both shadowing tests |
| gate maximal (never trust resolution) | four ordinal cases + FD PBT |
| ordinals classified `PRESUMED` | four ordinal cases + FD PBT |
| self-named branch classified `PRESUMED` | the joined-in-side test |

That last row found a gap. The self-named branch's two readings coincide in a single-source scope, so nothing bit at first. In a join scope they diverge, because qualifying the written name with the FROM's alias loses the key the projected column carries. That is the `select orders.customer_id ... group by customer_id` idiom, so it earned its own case.

Full gate: 1601 passed, `ruff check`, `ruff format --check`, `pyright` 0 errors.

## Left alone

The FD soundness PBT does not draw the shadowing spelling. Its anti-vacuity assertion (`if s.group_cols: assert claimed.fds`) assumes the group key always survives the projection, which that shape breaks by design, and relaxing it would weaken an existing guard. The focused FD test covers the collapse instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
