### PR TITLE
feat(check): declared-grain not-established emitter on the pre-reconcile record

### DIFF
--- a/src/dblect/check/findings.py
+++ b/src/dblect/check/findings.py
@@ -41,11 +41,12 @@ class CheckFindingKind(StrEnum):
     ISO-3), so the equated values cannot mean the same thing."""
 
     GRAIN_NOT_ESTABLISHED = auto()
-    """A declared grain or key the model's construction does not re-derive, with the
-    defeater witnessed: a strictly finer key survives to the output with no collapse
-    to the declared grain. The data may still satisfy the declaration (every order
-    may have exactly one line), so this reports "declared but not established",
-    never a violation; see ``docs/design/refutation-and-verdicts.md``."""
+    """A model's SQL does not produce the grain the user declared for it, and we can
+    name the finer key it produces instead (one row per order was declared; the SQL
+    keeps one row per order line). The data may still hold the declaration, since
+    every order might happen to have exactly one line, so this says the grain is not
+    established rather than that it is violated. See
+    ``docs/design/refutation-and-verdicts.md``."""
 
     RESOLUTION_BELOW_FLOOR = auto()
     """Lineage resolution across the project sits below the configured floor, so

--- a/src/dblect/check/findings.py
+++ b/src/dblect/check/findings.py
@@ -40,6 +40,13 @@ class CheckFindingKind(StrEnum):
     conflict (a ``MoneyUSD`` key against a ``MoneyEUR`` one, an ISO-2 country against an
     ISO-3), so the equated values cannot mean the same thing."""
 
+    GRAIN_NOT_ESTABLISHED = auto()
+    """A declared grain or key the model's construction does not re-derive, with the
+    defeater witnessed: a strictly finer key survives to the output with no collapse
+    to the declared grain. The data may still satisfy the declaration (every order
+    may have exactly one line), so this reports "declared but not established",
+    never a violation; see ``docs/design/refutation-and-verdicts.md``."""
+
     RESOLUTION_BELOW_FLOOR = auto()
     """Lineage resolution across the project sits below the configured floor, so
     the analysis covers only a fraction of columns and a clean report would

--- a/src/dblect/check/findings.py
+++ b/src/dblect/check/findings.py
@@ -41,11 +41,9 @@ class CheckFindingKind(StrEnum):
     ISO-3), so the equated values cannot mean the same thing."""
 
     GRAIN_NOT_ESTABLISHED = auto()
-    """A model's SQL does not produce the grain the user declared for it, and we can
-    name the finer key it produces instead (one row per order was declared; the SQL
-    keeps one row per order line). The data may still hold the declaration, since
-    every order might happen to have exactly one line, so this says the grain is not
-    established rather than that it is violated. See
+    """A model's SQL carries a strictly finer key than its declared grain (one row
+    per order declared; one row per order line produced). The data may still satisfy
+    the grain, so this is "not established", not "violated"; see
     ``docs/design/refutation-and-verdicts.md``."""
 
     RESOLUTION_BELOW_FLOOR = auto()

--- a/src/dblect/check/grain.py
+++ b/src/dblect/check/grain.py
@@ -31,9 +31,10 @@ from dblect.lineage.facts.model import (
     Declared,
     Fact,
     NativeConstraint,
+    Provenance,
 )
 from dblect.lineage.graph import SourceRef
-from dblect.lineage.properties.functional_dependency import FDSet, NO_FDS, determines
+from dblect.lineage.properties.functional_dependency import NO_FDS, FDSet, determines
 from dblect.lineage.properties.uniqueness import CandidateKeySet, Key
 from dblect.manifest import Manifest
 
@@ -88,21 +89,8 @@ def declared_grain_findings(
         fd_ann = fd.get(scope)
         fds = fd_ann.value if fd_ann is not None else NO_FDS
         for fact in bucket:
-            # Every provenance of the closed union is decided here. A Declared key is
-            # a claim about this SELECT's output, so it is judged. A NativeConstraint
-            # is discharged (or not) by the warehouse's write path, and the
-            # advisory-unenforced case is the unenforced-constraint finding's (#48). A
-            # CompileValue key is an incremental ``unique_key`` under a deduplicating
-            # strategy: the merge collapses on write, so the SELECT is expected to
-            # carry finer rows (the incremental-grain stream, #7, owns that write
-            # path).
-            match fact.provenance:
-                case Declared():
-                    pass
-                case NativeConstraint() | CompileValue():
-                    continue
-                case other:
-                    assert_never(other)
+            if not _judged_provenance(fact.provenance):
+                continue
             if fact.condition is not None:
                 continue  # a conditional key holds only over a row filter; activation owns it
             for authored in fact.value.keys:
@@ -117,6 +105,22 @@ def declared_grain_findings(
                     continue
                 out.append(_finding(manifest, scope, fact, authored, witness))
     return out
+
+
+def _judged_provenance(provenance: Provenance) -> bool:
+    """Whether a key of this provenance is a claim about the SELECT's own output,
+    every case of the closed union decided. A Declared key is judged. A
+    NativeConstraint is discharged (or not) by the warehouse's write path, and the
+    advisory-unenforced case belongs to the unenforced-constraint finding (#48). A
+    CompileValue key is an incremental ``unique_key`` under a deduplicating
+    strategy: the merge collapses on write, so the SELECT is expected to carry
+    finer rows (the incremental-grain stream, #7, owns that write path)."""
+    match provenance:
+        case Declared():
+            return True
+        case NativeConstraint() | CompileValue():
+            return False
+    assert_never(provenance)
 
 
 def _finding(

--- a/src/dblect/check/grain.py
+++ b/src/dblect/check/grain.py
@@ -1,22 +1,35 @@
-"""The declared-grain not-established emitter.
+"""Checking a declared grain against the SQL that is supposed to produce it.
 
-A declared grain is trusted downstream (assume-guarantee) and judged once, at the
-declaring model: do the upstream contracts plus this model's SQL re-derive
-uniqueness on the declared columns? The verdict vocabulary is
-``docs/design/refutation-and-verdicts.md``. Uniqueness reconciles declared and
-inferred keys by meet, so the flow value always contains the declaration and can
-never answer that question; the emitter reads the pre-reconcile record instead,
-the inferred keys as the SQL derived them.
+A user who writes ``grain(per=order_id)`` is telling us the model has one row per
+order. Everything downstream takes that at its word. This module asks the one
+question nobody else asks: does this model's own SQL actually produce it?
 
-The finding requires a witnessed defeater. The key walk is conservative and drops
-keys at shapes it does not model, so a declared key's absence from the inferred set
-is routinely the walk's own silence; firing on absence would flag every model with
-an unmodeled construct. The witness is a strictly finer key surviving to the output
-with no collapse to the declared grain, and coverage runs through the functional
-dependency closure so a non-minimal grain does not false-fire (the same hardening
-``detect_join_fanout`` uses). The severity is a hazard, never an error: every
-extensional claim holds vacuously on the empty relation, so the honest wording is
-"declared but not established", not "violated".
+Comparing against the keys we store for the model would answer yes every time,
+because a declared key is merged into what we know about a model as soon as it is
+read, so the declaration ends up checking itself. What we compare against instead
+is the set of keys the SQL alone implies, which the propagator records separately
+before the merge.
+
+Two rules keep the answer honest.
+
+*We report only when we can point at a specific finer key.* Failing to find the
+declared key among the derived ones is weak evidence, because key derivation gives
+up on SQL it cannot model and returns nothing rather than guessing. Treating "we
+found nothing" as "the grain is wrong" would flag a large share of real models. So
+we speak up only when the SQL demonstrably carries a *finer* key all the way to the
+output, one that keeps the rows the declared grain says are collapsed.
+
+*The SQL is allowed to be stricter than the declaration.* Unique per order is also
+unique per (order, region), and a declared dependency can close a gap the columns
+alone leave open, so we ask whether the declared columns cover a derived key through
+the functional-dependency closure rather than looking for an exact match. This is the
+same reasoning ``detect_join_fanout`` uses to decide a join key covers a key.
+
+Even when we do report, the SQL failing to guarantee the grain is not proof that the
+data breaks it: every order may happen to have exactly one line. So the finding says
+the grain is not established rather than violated, and it warns rather than errors.
+``docs/design/refutation-and-verdicts.md`` works through why that distinction holds
+for claims about rows.
 """
 
 from __future__ import annotations
@@ -40,21 +53,26 @@ from dblect.manifest import Manifest
 
 
 def grain_established(declared: Key, inferred: frozenset[Key], fds: FDSet) -> bool:
-    """Whether the construction re-derives uniqueness on ``declared``: some inferred
-    key lies within the declared columns' closure under ``fds``. A relation unique
-    on ``K`` is unique on any superset, and closure extends that through the
-    dependencies (unique on ``(order_id, region)`` plus ``order_id -> region`` is
-    unique on ``(order_id)``). With no dependencies this reduces to ``K`` within the
-    declared columns."""
+    """Whether the SQL already gives us the declared grain.
+
+    It does when one of the keys it derives sits inside the declared columns, since
+    a table unique on some columns is also unique on any larger set of them: unique
+    per order means unique per (order, region). Declared dependencies widen what the
+    declared columns reach, so unique on (order_id, region) plus ``order_id ->
+    region`` counts as unique on (order_id) too. With no dependencies in play this
+    is plain containment."""
     return any(all(determines(fds, declared, col) for col in key) for key in inferred)
 
 
 def grain_witness(declared: Key, inferred: frozenset[Key]) -> Key | None:
-    """The witnessed defeater: a strictly finer surviving key (a strict superset of
-    the declared columns), or ``None`` when nothing witnesses. A key that does not
-    contain the declared grain says nothing about rows per declared tuple (every
-    order may have exactly one line), so it never witnesses. The smallest finer key
-    is returned so the finding is deterministic."""
+    """The finer key we can point at as evidence the grain is not met, if there is one.
+
+    A key counts as evidence only when it contains every declared column and at
+    least one more: the SQL is keeping rows apart that the declared grain says are
+    one row. A key that is merely different, say a key on ``line_id`` against a grain
+    of ``order_id``, tells us nothing about how many rows an order gets, so it is not
+    evidence. Returns the smallest such key, so the finding reads the same on every
+    run."""
     finer = [key for key in inferred if declared < key]
     if not finer:
         return None
@@ -67,15 +85,18 @@ def declared_grain_findings(
     inferred: Mapping[SourceRef, Annotation[CandidateKeySet]],
     fd: Mapping[SourceRef, Annotation[FDSet]],
 ) -> list[CheckFinding]:
-    """One finding per declared key the construction fails to establish, with the
-    defeater witnessed.
+    """One finding per declared grain this model's SQL does not deliver.
 
-    ``key_facts`` is the same bucket the uniqueness property grounds from, so the
-    emitter and the propagation can never disagree on what was declared.
-    ``inferred`` is the pre-reconcile record. A scope absent from it is a leaf or an
-    unbuilt model: no derivation, no entailment to judge (coverage reports the
-    unbuilt case). A provisional inferred value rests on an upstream contradiction
-    the propagator recovered from, so it is not treated as a witness.
+    ``key_facts`` holds every key a user declared, read from the same place the
+    propagation reads them so the two cannot disagree about what was claimed.
+    ``inferred`` holds the keys each model's SQL implies on its own, recorded before
+    declared keys were merged in.
+
+    A model missing from ``inferred`` has no SQL of its own to judge, a source or a
+    model that failed to build, and is passed over; the coverage report is what
+    surfaces the ones that failed to build. We also stay quiet when the keys we
+    derived rest on contradictory upstream declarations, since evidence drawn from a
+    known contradiction is not worth reporting.
     """
     out: list[CheckFinding] = []
     judged: set[tuple[SourceRef, Key]] = set()
@@ -108,13 +129,15 @@ def declared_grain_findings(
 
 
 def _judged_provenance(provenance: Provenance) -> bool:
-    """Whether a key of this provenance is a claim about the SELECT's own output,
-    every case of the closed union decided. A Declared key is judged. A
-    NativeConstraint is discharged (or not) by the warehouse's write path, and the
-    advisory-unenforced case belongs to the unenforced-constraint finding (#48). A
-    CompileValue key is an incremental ``unique_key`` under a deduplicating
-    strategy: the merge collapses on write, so the SELECT is expected to carry
-    finer rows (the incremental-grain stream, #7, owns that write path)."""
+    """Whether a key from this source is a claim about what the SELECT itself
+    produces, deciding every kind we can receive.
+
+    A key someone wrote down, in a contract or a dbt test, is such a claim, so we
+    check it. A native warehouse constraint is enforced when the table is written
+    rather than by the query, and whether the warehouse really enforces it is #48's
+    question. An incremental model's ``unique_key`` under a merge strategy is the
+    same story: the merge collapses duplicates on write, so its SELECT is expected to
+    produce finer rows and flagging that would be wrong (#7 covers the write path)."""
     match provenance:
         case Declared():
             return True

--- a/src/dblect/check/grain.py
+++ b/src/dblect/check/grain.py
@@ -1,0 +1,146 @@
+"""The declared-grain not-established emitter.
+
+A declared grain is trusted downstream (assume-guarantee) and judged once, at the
+declaring model: do the upstream contracts plus this model's SQL re-derive
+uniqueness on the declared columns? The verdict vocabulary is
+``docs/design/refutation-and-verdicts.md``. Uniqueness reconciles declared and
+inferred keys by meet, so the flow value always contains the declaration and can
+never answer that question; the emitter reads the pre-reconcile record instead,
+the inferred keys as the SQL derived them.
+
+The finding requires a witnessed defeater. The key walk is conservative and drops
+keys at shapes it does not model, so a declared key's absence from the inferred set
+is routinely the walk's own silence; firing on absence would flag every model with
+an unmodeled construct. The witness is a strictly finer key surviving to the output
+with no collapse to the declared grain, and coverage runs through the functional
+dependency closure so a non-minimal grain does not false-fire (the same hardening
+``detect_join_fanout`` uses). The severity is a hazard, never an error: every
+extensional claim holds vacuously on the empty relation, so the honest wording is
+"declared but not established", not "violated".
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import assert_never
+
+from dblect.check.findings import CheckFinding, CheckFindingKind
+from dblect.lineage.facts.model import (
+    Annotation,
+    CompileValue,
+    Declared,
+    Fact,
+    NativeConstraint,
+)
+from dblect.lineage.graph import SourceRef
+from dblect.lineage.properties.functional_dependency import FDSet, NO_FDS, determines
+from dblect.lineage.properties.uniqueness import CandidateKeySet, Key
+from dblect.manifest import Manifest
+
+
+def grain_established(declared: Key, inferred: frozenset[Key], fds: FDSet) -> bool:
+    """Whether the construction re-derives uniqueness on ``declared``: some inferred
+    key lies within the declared columns' closure under ``fds``. A relation unique
+    on ``K`` is unique on any superset, and closure extends that through the
+    dependencies (unique on ``(order_id, region)`` plus ``order_id -> region`` is
+    unique on ``(order_id)``). With no dependencies this reduces to ``K`` within the
+    declared columns."""
+    return any(all(determines(fds, declared, col) for col in key) for key in inferred)
+
+
+def grain_witness(declared: Key, inferred: frozenset[Key]) -> Key | None:
+    """The witnessed defeater: a strictly finer surviving key (a strict superset of
+    the declared columns), or ``None`` when nothing witnesses. A key that does not
+    contain the declared grain says nothing about rows per declared tuple (every
+    order may have exactly one line), so it never witnesses. The smallest finer key
+    is returned so the finding is deterministic."""
+    finer = [key for key in inferred if declared < key]
+    if not finer:
+        return None
+    return min(finer, key=lambda key: (len(key), tuple(sorted(key))))
+
+
+def declared_grain_findings(
+    manifest: Manifest,
+    key_facts: Mapping[SourceRef, tuple[Fact[CandidateKeySet, SourceRef], ...]],
+    inferred: Mapping[SourceRef, Annotation[CandidateKeySet]],
+    fd: Mapping[SourceRef, Annotation[FDSet]],
+) -> list[CheckFinding]:
+    """One finding per declared key the construction fails to establish, with the
+    defeater witnessed.
+
+    ``key_facts`` is the same bucket the uniqueness property grounds from, so the
+    emitter and the propagation can never disagree on what was declared.
+    ``inferred`` is the pre-reconcile record. A scope absent from it is a leaf or an
+    unbuilt model: no derivation, no entailment to judge (coverage reports the
+    unbuilt case). A provisional inferred value rests on an upstream contradiction
+    the propagator recovered from, so it is not treated as a witness.
+    """
+    out: list[CheckFinding] = []
+    judged: set[tuple[SourceRef, Key]] = set()
+    for scope, bucket in sorted(key_facts.items(), key=lambda kv: kv[0].unique_id):
+        inferred_ann = inferred.get(scope)
+        if inferred_ann is None or inferred_ann.provisional:
+            continue
+        derived = inferred_ann.value
+        if derived.is_bottom:
+            continue  # the formal universal element already carries every key
+        fd_ann = fd.get(scope)
+        fds = fd_ann.value if fd_ann is not None else NO_FDS
+        for fact in bucket:
+            # Every provenance of the closed union is decided here. A Declared key is
+            # a claim about this SELECT's output, so it is judged. A NativeConstraint
+            # is discharged (or not) by the warehouse's write path, and the
+            # advisory-unenforced case is the unenforced-constraint finding's (#48). A
+            # CompileValue key is an incremental ``unique_key`` under a deduplicating
+            # strategy: the merge collapses on write, so the SELECT is expected to
+            # carry finer rows (the incremental-grain stream, #7, owns that write
+            # path).
+            match fact.provenance:
+                case Declared():
+                    pass
+                case NativeConstraint() | CompileValue():
+                    continue
+                case other:
+                    assert_never(other)
+            if fact.condition is not None:
+                continue  # a conditional key holds only over a row filter; activation owns it
+            for authored in fact.value.keys:
+                declared = frozenset(col.lower() for col in authored)
+                if (scope, declared) in judged:
+                    continue
+                judged.add((scope, declared))
+                if grain_established(declared, derived.keys, fds):
+                    continue
+                witness = grain_witness(declared, derived.keys)
+                if witness is None:
+                    continue
+                out.append(_finding(manifest, scope, fact, authored, witness))
+    return out
+
+
+def _finding(
+    manifest: Manifest,
+    scope: SourceRef,
+    fact: Fact[CandidateKeySet, SourceRef],
+    declared: Key,
+    witness: Key,
+) -> CheckFinding:
+    declared_cols = ", ".join(sorted(declared))
+    witness_cols = ", ".join(sorted(witness))
+    attribution = f" (declared by {fact.detail})" if fact.detail else ""
+    node = manifest.nodes.get(scope.unique_id)
+    single = next(iter(declared)) if len(declared) == 1 else None
+    return CheckFinding(
+        kind=CheckFindingKind.GRAIN_NOT_ESTABLISHED,
+        message=(
+            f"declared grain ({declared_cols}){attribution} is not established: the "
+            f"construction carries the strictly finer key ({witness_cols}) to the "
+            "output with no collapse to the declared grain. Aggregate to the "
+            "declared grain, or correct the declaration to the grain the SQL "
+            "produces."
+        ),
+        model_unique_id=scope.unique_id,
+        file_path=node.original_file_path if node is not None else None,
+        column=single,
+    )

--- a/src/dblect/check/grain.py
+++ b/src/dblect/check/grain.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import assert_never
 
+from dblect.adapters import AdapterProfile
 from dblect.check.findings import CheckFinding, CheckFindingKind
 from dblect.lineage.facts.model import (
     Annotation,
@@ -48,7 +49,7 @@ from dblect.lineage.facts.model import (
 )
 from dblect.lineage.graph import SourceRef
 from dblect.lineage.properties.functional_dependency import NO_FDS, FDSet, determines
-from dblect.lineage.properties.uniqueness import CandidateKeySet, Key
+from dblect.lineage.properties.uniqueness import CandidateKeySet, Key, model_dedups_on_write
 from dblect.manifest import Manifest
 
 
@@ -81,6 +82,7 @@ def grain_witness(declared: Key, inferred: frozenset[Key]) -> Key | None:
 
 def declared_grain_findings(
     manifest: Manifest,
+    profile: AdapterProfile,
     key_facts: Mapping[SourceRef, tuple[Fact[CandidateKeySet, SourceRef], ...]],
     inferred: Mapping[SourceRef, Annotation[CandidateKeySet]],
     fd: Mapping[SourceRef, Annotation[FDSet]],
@@ -96,11 +98,16 @@ def declared_grain_findings(
     model that failed to build, and is passed over; the coverage report is what
     surfaces the ones that failed to build. We also stay quiet when the keys we
     derived rest on contradictory upstream declarations, since evidence drawn from a
-    known contradiction is not worth reporting.
+    known contradiction is not worth reporting. A model whose write path dedups on
+    its own (:func:`model_dedups_on_write`) is passed over entirely: its SELECT is
+    expected to carry finer rows than any key claimed on it, whoever claimed it.
     """
     out: list[CheckFinding] = []
     judged: set[tuple[SourceRef, Key]] = set()
     for scope, bucket in sorted(key_facts.items(), key=lambda kv: kv[0].unique_id):
+        node = manifest.nodes.get(scope.unique_id)
+        if node is not None and model_dedups_on_write(node.config, profile):
+            continue
         inferred_ann = inferred.get(scope)
         if inferred_ann is None or inferred_ann.provisional:
             continue
@@ -135,9 +142,9 @@ def _judged_provenance(provenance: Provenance) -> bool:
     A key someone wrote down, in a contract or a dbt test, is such a claim, so we
     check it. A native warehouse constraint is enforced when the table is written
     rather than by the query, and whether the warehouse really enforces it is #48's
-    question. An incremental model's ``unique_key`` under a merge strategy is the
-    same story: the merge collapses duplicates on write, so its SELECT is expected to
-    produce finer rows and flagging that would be wrong (#7 covers the write path)."""
+    question. A compile-time value is not an assertion about the query either; the
+    incremental-write exemption is decided per model, not by this provenance switch
+    (see ``model_dedups_on_write``)."""
     match provenance:
         case Declared():
             return True

--- a/src/dblect/check/grain.py
+++ b/src/dblect/check/grain.py
@@ -1,35 +1,16 @@
-"""Checking a declared grain against the SQL that is supposed to produce it.
+"""Check a declared grain against the SQL that is supposed to produce it.
 
-A user who writes ``grain(per=order_id)`` is telling us the model has one row per
-order. Everything downstream takes that at its word. This module asks the one
-question nobody else asks: does this model's own SQL actually produce it?
+Downstream checks trust a declared grain. This one asks whether the model's own
+SQL establishes it. The comparison runs against the keys the SQL alone derives,
+recorded before the declaration is merged in; the merged set always contains the
+declaration, so comparing against it would let the declaration vouch for itself.
 
-Comparing against the keys we store for the model would answer yes every time,
-because a declared key is merged into what we know about a model as soon as it is
-read, so the declaration ends up checking itself. What we compare against instead
-is the set of keys the SQL alone implies, which the propagator records separately
-before the merge.
-
-Two rules keep the answer honest.
-
-*We report only when we can point at a specific finer key.* Failing to find the
-declared key among the derived ones is weak evidence, because key derivation gives
-up on SQL it cannot model and returns nothing rather than guessing. Treating "we
-found nothing" as "the grain is wrong" would flag a large share of real models. So
-we speak up only when the SQL demonstrably carries a *finer* key all the way to the
-output, one that keeps the rows the declared grain says are collapsed.
-
-*The SQL is allowed to be stricter than the declaration.* Unique per order is also
-unique per (order, region), and a declared dependency can close a gap the columns
-alone leave open, so we ask whether the declared columns cover a derived key through
-the functional-dependency closure rather than looking for an exact match. This is the
-same reasoning ``detect_join_fanout`` uses to decide a join key covers a key.
-
-Even when we do report, the SQL failing to guarantee the grain is not proof that the
-data breaks it: every order may happen to have exactly one line. So the finding says
-the grain is not established rather than violated, and it warns rather than errors.
-``docs/design/refutation-and-verdicts.md`` works through why that distinction holds
-for claims about rows.
+The finding fires only on positive evidence: a strictly finer key survives to the
+output. A declared key that is merely absent from the derived set is not evidence,
+because key derivation returns nothing for SQL it cannot model. Even when it fires,
+the data may still satisfy the grain (every order might have exactly one line), so
+the finding says "not established" rather than "violated" and warns rather than
+errors. ``docs/design/refutation-and-verdicts.md`` has the vocabulary.
 """
 
 from __future__ import annotations
@@ -54,26 +35,16 @@ from dblect.manifest import Manifest
 
 
 def grain_established(declared: Key, inferred: frozenset[Key], fds: FDSet) -> bool:
-    """Whether the SQL already gives us the declared grain.
-
-    It does when one of the keys it derives sits inside the declared columns, since
-    a table unique on some columns is also unique on any larger set of them: unique
-    per order means unique per (order, region). Declared dependencies widen what the
-    declared columns reach, so unique on (order_id, region) plus ``order_id ->
-    region`` counts as unique on (order_id) too. With no dependencies in play this
-    is plain containment."""
+    """True if the SQL establishes the declared grain: some derived key is a subset
+    of the declared columns, closed under ``fds``. Unique per order is also unique
+    per (order, region)."""
     return any(all(determines(fds, declared, col) for col in key) for key in inferred)
 
 
 def grain_witness(declared: Key, inferred: frozenset[Key]) -> Key | None:
-    """The finer key we can point at as evidence the grain is not met, if there is one.
-
-    A key counts as evidence only when it contains every declared column and at
-    least one more: the SQL is keeping rows apart that the declared grain says are
-    one row. A key that is merely different, say a key on ``line_id`` against a grain
-    of ``order_id``, tells us nothing about how many rows an order gets, so it is not
-    evidence. Returns the smallest such key, so the finding reads the same on every
-    run."""
+    """The smallest derived key that is a strict superset of the declared grain, or
+    ``None``. A disjoint key (``line_id`` against a grain of ``order_id``) says
+    nothing about rows per order, so it is not a witness."""
     finer = [key for key in inferred if declared < key]
     if not finer:
         return None
@@ -87,20 +58,13 @@ def declared_grain_findings(
     inferred: Mapping[SourceRef, Annotation[CandidateKeySet]],
     fd: Mapping[SourceRef, Annotation[FDSet]],
 ) -> list[CheckFinding]:
-    """One finding per declared grain this model's SQL does not deliver.
+    """One finding per declared grain the model's SQL does not establish.
 
-    ``key_facts`` holds every key a user declared, read from the same place the
-    propagation reads them so the two cannot disagree about what was claimed.
-    ``inferred`` holds the keys each model's SQL implies on its own, recorded before
-    declared keys were merged in.
-
-    A model missing from ``inferred`` has no SQL of its own to judge, a source or a
-    model that failed to build, and is passed over; the coverage report is what
-    surfaces the ones that failed to build. We also stay quiet when the keys we
-    derived rest on contradictory upstream declarations, since evidence drawn from a
-    known contradiction is not worth reporting. A model whose write path dedups on
-    its own (:func:`model_dedups_on_write`) is passed over entirely: its SELECT is
-    expected to carry finer rows than any key claimed on it, whoever claimed it.
+    ``key_facts`` is every declared key, from the same source propagation grounds
+    on. ``inferred`` is the pre-merge derived key set per relation. Skipped: models
+    absent from ``inferred`` (no SQL to judge), provisional derivations (they rest
+    on a contradiction), and models whose write path dedups on its own
+    (:func:`model_dedups_on_write`), whose SELECT is expected to carry finer rows.
     """
     out: list[CheckFinding] = []
     judged: set[tuple[SourceRef, Key]] = set()
@@ -136,15 +100,9 @@ def declared_grain_findings(
 
 
 def _judged_provenance(provenance: Provenance) -> bool:
-    """Whether a key from this source is a claim about what the SELECT itself
-    produces, deciding every kind we can receive.
-
-    A key someone wrote down, in a contract or a dbt test, is such a claim, so we
-    check it. A native warehouse constraint is enforced when the table is written
-    rather than by the query, and whether the warehouse really enforces it is #48's
-    question. A compile-time value is not an assertion about the query either; the
-    incremental-write exemption is decided per model, not by this provenance switch
-    (see ``model_dedups_on_write``)."""
+    """Whether a key from this source claims something about the SELECT itself. A
+    native constraint is enforced on write, not by the query (#48 covers the
+    unenforced case); a compile-time value is config, not an assertion."""
     match provenance:
         case Declared():
             return True

--- a/src/dblect/check/run.py
+++ b/src/dblect/check/run.py
@@ -36,6 +36,7 @@ from dblect.check.findings import (
     SuppressedCheckFinding,
     UnbuiltModel,
 )
+from dblect.check.grain import declared_grain_findings
 from dblect.lineage.builder import (
     BuildIssue,
     BuildResult,
@@ -62,7 +63,6 @@ from dblect.lineage.properties.domain_type import (
     domain_type_property,
     join_key_conflicts,
 )
-from dblect.check.grain import declared_grain_findings
 from dblect.lineage.properties.functional_dependency import (
     FDSet,
     functional_dependency_grounded_scopes,
@@ -129,6 +129,14 @@ class WorldFacts:
     tag_facts: tuple[Fact[DomainTag, ColumnRef], ...]
 
 
+def _no_fd_annotations() -> dict[SourceRef, Annotation[FDSet]]:
+    return {}
+
+
+def _no_key_annotations() -> dict[SourceRef, Annotation[CandidateKeySet]]:
+    return {}
+
+
 @dataclass(frozen=True, slots=True)
 class WorldAnnotations:
     """One world's propagation result, keyed by the world it holds under. A bundle
@@ -142,11 +150,13 @@ class WorldAnnotations:
     world: WorldRef
     domain_type: Mapping[ColumnRef, Annotation[DomainTag]]
     coherence_clears: tuple[CoherenceClear[DomainTag], ...] = ()
-    functional_dependency: Mapping[SourceRef, Annotation[FDSet]] = field(default_factory=dict)
+    functional_dependency: Mapping[SourceRef, Annotation[FDSet]] = field(
+        default_factory=_no_fd_annotations
+    )
     """The FD flow per relation, kept for the readers that test coverage through the
     closure (the grain emitter) rather than recomputed per consumer."""
     uniqueness_inferred: Mapping[SourceRef, Annotation[CandidateKeySet]] = field(
-        default_factory=dict
+        default_factory=_no_key_annotations
     )
     """The pre-reconcile record for uniqueness: each derived relation's candidate keys
     as the SQL derived them, before the declared keys folded in. What the grain

--- a/src/dblect/check/run.py
+++ b/src/dblect/check/run.py
@@ -111,10 +111,10 @@ class CheckGraphs:
     the graph build keeps it in step with the graph instead of resting on the assumption
     that successive worlds share one."""
     uniqueness_facts: Mapping[SourceRef, tuple[Fact[CandidateKeySet, SourceRef], ...]]
-    """Every candidate-key grounding fact by relation: the manifest channels plus the
-    resolved contract keys. World-invariant, and the single bucket both the uniqueness
-    propagation and the grain emitter read, so what grounds and what is judged can
-    never drift apart."""
+    """Every key declared for a relation, however it was declared: dbt tests, native
+    constraints, incremental config, and the keys resolved from Python contracts. The
+    same values feed the uniqueness propagation and the grain check, so the two cannot
+    disagree about what a user claimed. Does not vary by world."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -153,15 +153,16 @@ class WorldAnnotations:
     functional_dependency: Mapping[SourceRef, Annotation[FDSet]] = field(
         default_factory=_no_fd_annotations
     )
-    """The FD flow per relation, kept for the readers that test coverage through the
-    closure (the grain emitter) rather than recomputed per consumer."""
+    """What each relation's functional dependencies came out as, kept so a consumer
+    that needs them (the grain check reads them to widen what a declared grain
+    covers) does not propagate the property a second time."""
     uniqueness_inferred: Mapping[SourceRef, Annotation[CandidateKeySet]] = field(
         default_factory=_no_key_annotations
     )
-    """The pre-reconcile record for uniqueness: each derived relation's candidate keys
-    as the SQL derived them, before the declared keys folded in. What the grain
-    emitter compares a declaration against; the flow value cannot serve (the
-    declaration unions into it and would check itself)."""
+    """The candidate keys each relation's SQL implies on its own, recorded before the
+    declared keys were folded in. This is what the grain check compares a declaration
+    against; the combined value cannot serve, because the declaration is part of it
+    and would end up vouching for itself."""
 
 
 def build_check_graphs(

--- a/src/dblect/check/run.py
+++ b/src/dblect/check/run.py
@@ -20,7 +20,7 @@ data, which belongs to the fixture/PBT loop, so the static check stays static.
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import sqlglot.expressions as exp
 from sqlglot import Expr
@@ -62,11 +62,17 @@ from dblect.lineage.properties.domain_type import (
     domain_type_property,
     join_key_conflicts,
 )
+from dblect.check.grain import declared_grain_findings
 from dblect.lineage.properties.functional_dependency import (
     FDSet,
     functional_dependency_grounded_scopes,
     functional_dependency_grounding,
     functional_dependency_property,
+)
+from dblect.lineage.properties.uniqueness import (
+    CandidateKeySet,
+    uniqueness_facts,
+    uniqueness_property_from_facts,
 )
 from dblect.lineage.property import propagate, resolved_column_ref
 from dblect.manifest import Manifest
@@ -104,6 +110,11 @@ class CheckGraphs:
     per world: it derives from the world-invariant declared facts, so colocating it with
     the graph build keeps it in step with the graph instead of resting on the assumption
     that successive worlds share one."""
+    uniqueness_facts: Mapping[SourceRef, tuple[Fact[CandidateKeySet, SourceRef], ...]]
+    """Every candidate-key grounding fact by relation: the manifest channels plus the
+    resolved contract keys. World-invariant, and the single bucket both the uniqueness
+    propagation and the grain emitter read, so what grounds and what is judged can
+    never drift apart."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -131,6 +142,16 @@ class WorldAnnotations:
     world: WorldRef
     domain_type: Mapping[ColumnRef, Annotation[DomainTag]]
     coherence_clears: tuple[CoherenceClear[DomainTag], ...] = ()
+    functional_dependency: Mapping[SourceRef, Annotation[FDSet]] = field(default_factory=dict)
+    """The FD flow per relation, kept for the readers that test coverage through the
+    closure (the grain emitter) rather than recomputed per consumer."""
+    uniqueness_inferred: Mapping[SourceRef, Annotation[CandidateKeySet]] = field(
+        default_factory=dict
+    )
+    """The pre-reconcile record for uniqueness: each derived relation's candidate keys
+    as the SQL derived them, before the declared keys folded in. What the grain
+    emitter compares a declaration against; the flow value cannot serve (the
+    declaration unions into it and would check itself)."""
 
 
 def build_check_graphs(
@@ -169,6 +190,9 @@ def build_check_graphs(
         contracts_resolved=len(reg.contracts),
         parsed=parsed,
         join_key_ground=domain_type_grounding(by_scope(resolved.tag_facts)),
+        uniqueness_facts=uniqueness_facts(
+            manifest, profile, extra_facts=resolved.key_facts, parsed=trees
+        ),
     )
 
 
@@ -187,7 +211,8 @@ def propagate_world(graphs: CheckGraphs, facts: WorldFacts) -> WorldAnnotations:
         functional_dependency_grounding(by_scope(facts.fd_facts))
     )
     store = AnnotationStore()
-    for scope, ann in propagate(graphs.relation_build.graph, fd_prop).items():
+    fd_anns = dict(propagate(graphs.relation_build.graph, fd_prop))
+    for scope, ann in fd_anns.items():
         store.record(fd_prop.name, scope, ann)
 
     dt_prop = domain_type_property(
@@ -197,8 +222,16 @@ def propagate_world(graphs: CheckGraphs, facts: WorldFacts) -> WorldAnnotations:
     ctx = PropertyRegistry((fd_prop, dt_prop)).dep_context(store)
     clears: list[CoherenceClear[DomainTag]] = []
     domain_type = propagate(graphs.column_build.graph, dt_prop, dep_context=ctx, sink=clears)
+
+    uniqueness_prop = uniqueness_property_from_facts(graphs.uniqueness_facts)
+    uniqueness_inferred: dict[SourceRef, Annotation[CandidateKeySet]] = {}
+    propagate(graphs.relation_build.graph, uniqueness_prop, inferred_sink=uniqueness_inferred)
     return WorldAnnotations(
-        world=facts.world, domain_type=domain_type, coherence_clears=tuple(clears)
+        world=facts.world,
+        domain_type=domain_type,
+        coherence_clears=tuple(clears),
+        functional_dependency=fd_anns,
+        uniqueness_inferred=uniqueness_inferred,
     )
 
 
@@ -321,6 +354,14 @@ def world_findings(graphs: CheckGraphs, world: WorldAnnotations) -> list[CheckFi
             world.domain_type,
             graphs.join_key_ground,
             line_maps,
+        )
+    )
+    findings.extend(
+        declared_grain_findings(
+            graphs.manifest,
+            graphs.uniqueness_facts,
+            world.uniqueness_inferred,
+            world.functional_dependency,
         )
     )
     return findings

--- a/src/dblect/check/run.py
+++ b/src/dblect/check/run.py
@@ -1,17 +1,17 @@
 """Run the declaration check: resolve contracts, propagate, derive findings.
 
-The pipeline is the substrate-first story made user-facing. Contracts resolve into
-the facts the properties ground from, two properties propagate (the
-functional-dependency property over the relation graph, then the domain-type
-property over the column graph reading it), and the findings fall out of what the
-substrate concluded:
+A user's contracts (a declared domain type, a declared grain, a declared key)
+resolve into facts, two properties propagate over the lineage graphs built from
+the project's SQL (functional dependencies over relations, then domain type over
+columns), and findings fall out of what propagation concluded:
 
-* a contract that did not resolve is a finding directly off the bridge;
-* a column whose flow value is provisional carries a declared type the inferred
-  one contradicts, which is currency creep, and it lands wherever the taint
-  reached, declared model or not;
-* an aggregate whose tag cleared to naked while an operand it summed still carried
-  one is a reduction the algebra cannot call well typed, the mixed-currency sum.
+* a contract that never resolved against the manifest is a finding on its own;
+* a column where the type propagation infers disagrees with a declared type is a
+  contradiction (currency creep), reported everywhere downstream the disagreement
+  reaches, not just where it was declared;
+* summing a column loses its domain type unless every other field in the row
+  stays constant across the group; when it doesn't, the sum is flagged as not well
+  typed (the mixed-currency sum).
 
 Predicates are collected and counted, not run: executing them needs materialized
 data, which belongs to the fixture/PBT loop, so the static check stays static.
@@ -120,9 +120,9 @@ class CheckGraphs:
 @dataclass(frozen=True, slots=True)
 class WorldFacts:
     """The facts that ground one world's propagation. The declared facts are
-    world-invariant (shared across worlds); a world's ``CompileValue`` leaves are
-    appended by the enumerator. Keeping the two apart means the enumerator only
-    adds, never recomputes, the declared facts."""
+    world-invariant (shared across worlds); a world's own ``CompileValue`` facts
+    are appended by the enumerator. Keeping the two apart means the enumerator
+    only adds, never recomputes, the declared facts."""
 
     world: WorldRef
     fd_facts: tuple[Fact[FDSet, SourceRef], ...]
@@ -500,8 +500,9 @@ def _contradiction_findings(
     column_graph: ColumnLineageGraph,
     line_maps: dict[str, LineMap],
 ) -> list[CheckFinding]:
-    """One finding per column whose flow value is provisional: a declared type the
-    inferred one contradicts, reported wherever the taint reached."""
+    """One finding per column where propagation found the type flowing in
+    conflicts with a declared type (skips ``NAKED``, which carries nothing to
+    conflict about), reported at every downstream column the conflict reaches."""
     out: list[CheckFinding] = []
     for ref, ann in _sorted(annotations):
         if not ann.provisional or ann.value == NAKED:

--- a/src/dblect/check/run.py
+++ b/src/dblect/check/run.py
@@ -112,10 +112,8 @@ class CheckGraphs:
     the graph build keeps it in step with the graph instead of resting on the assumption
     that successive worlds share one."""
     uniqueness_facts: Mapping[SourceRef, tuple[Fact[CandidateKeySet, SourceRef], ...]]
-    """Every key declared for a relation, however it was declared: dbt tests, native
-    constraints, incremental config, and the keys resolved from Python contracts. The
-    same values feed the uniqueness propagation and the grain check, so the two cannot
-    disagree about what a user claimed."""
+    """Every declared key per relation, from every channel. Feeds both the uniqueness
+    propagation and the grain check, so the two agree on what was claimed."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -144,14 +142,12 @@ class WorldAnnotations:
     domain_type: Mapping[ColumnRef, Annotation[DomainTag]]
     coherence_clears: tuple[CoherenceClear[DomainTag], ...]
     functional_dependency: Mapping[SourceRef, Annotation[FDSet]]
-    """What each relation's functional dependencies came out as, kept so a consumer
-    that needs them (the grain check reads them to widen what a declared grain
-    covers) does not propagate the property a second time."""
+    """Per-relation functional dependencies, kept so the grain check need not
+    propagate them again."""
     uniqueness_inferred: Mapping[SourceRef, Annotation[CandidateKeySet]]
-    """The candidate keys each relation's SQL implies on its own, recorded before the
-    declared keys were folded in. This is what the grain check compares a declaration
-    against; the combined value cannot serve, because the declaration is part of it
-    and would end up vouching for itself."""
+    """Per-relation keys derived from the SQL alone, before declared keys are merged
+    in. The grain check compares declarations against this; the merged value would
+    contain the declaration itself."""
 
 
 def build_check_graphs(

--- a/src/dblect/check/run.py
+++ b/src/dblect/check/run.py
@@ -20,7 +20,7 @@ data, which belongs to the fixture/PBT loop, so the static check stays static.
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 import sqlglot.expressions as exp
 from sqlglot import Expr
@@ -93,6 +93,7 @@ class CheckGraphs:
     enumerates. Do not mutate the graphs or their trees per world."""
 
     manifest: Manifest
+    profile: AdapterProfile
     resolved: ResolvedContracts
     relation_build: RelationBuildResult
     column_build: BuildResult
@@ -114,7 +115,7 @@ class CheckGraphs:
     """Every key declared for a relation, however it was declared: dbt tests, native
     constraints, incremental config, and the keys resolved from Python contracts. The
     same values feed the uniqueness propagation and the grain check, so the two cannot
-    disagree about what a user claimed. Does not vary by world."""
+    disagree about what a user claimed."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -129,14 +130,6 @@ class WorldFacts:
     tag_facts: tuple[Fact[DomainTag, ColumnRef], ...]
 
 
-def _no_fd_annotations() -> dict[SourceRef, Annotation[FDSet]]:
-    return {}
-
-
-def _no_key_annotations() -> dict[SourceRef, Annotation[CandidateKeySet]]:
-    return {}
-
-
 @dataclass(frozen=True, slots=True)
 class WorldAnnotations:
     """One world's propagation result, keyed by the world it holds under. A bundle
@@ -145,20 +138,20 @@ class WorldAnnotations:
 
     ``coherence_clears`` are the aggregate-guard clears the domain-type walk emitted in
     this world: the structured reason a sum cleared its tag, which the aggregation
-    finding reads instead of re-inferring the event from the cleared output."""
+    finding reads instead of re-inferring the event from the cleared output.
+
+    Every field is required: ``propagate_world`` is the only constructor, and a
+    default here would let some future constructor silently turn the grain check
+    into a no-op instead of failing to build."""
 
     world: WorldRef
     domain_type: Mapping[ColumnRef, Annotation[DomainTag]]
-    coherence_clears: tuple[CoherenceClear[DomainTag], ...] = ()
-    functional_dependency: Mapping[SourceRef, Annotation[FDSet]] = field(
-        default_factory=_no_fd_annotations
-    )
+    coherence_clears: tuple[CoherenceClear[DomainTag], ...]
+    functional_dependency: Mapping[SourceRef, Annotation[FDSet]]
     """What each relation's functional dependencies came out as, kept so a consumer
     that needs them (the grain check reads them to widen what a declared grain
     covers) does not propagate the property a second time."""
-    uniqueness_inferred: Mapping[SourceRef, Annotation[CandidateKeySet]] = field(
-        default_factory=_no_key_annotations
-    )
+    uniqueness_inferred: Mapping[SourceRef, Annotation[CandidateKeySet]]
     """The candidate keys each relation's SQL implies on its own, recorded before the
     declared keys were folded in. This is what the grain check compares a declaration
     against; the combined value cannot serve, because the declaration is part of it
@@ -195,6 +188,7 @@ def build_check_graphs(
     parsed = {uid: tree for uid, tree in trees.items() if uid not in unbuilt}
     return CheckGraphs(
         manifest=manifest,
+        profile=profile,
         resolved=resolved,
         relation_build=relation_build,
         column_build=column_build,
@@ -370,6 +364,7 @@ def world_findings(graphs: CheckGraphs, world: WorldAnnotations) -> list[CheckFi
     findings.extend(
         declared_grain_findings(
             graphs.manifest,
+            graphs.profile,
             graphs.uniqueness_facts,
             world.uniqueness_inferred,
             world.functional_dependency,

--- a/src/dblect/check/run.py
+++ b/src/dblect/check/run.py
@@ -138,11 +138,7 @@ class WorldAnnotations:
 
     ``coherence_clears`` are the aggregate-guard clears the domain-type walk emitted in
     this world: the structured reason a sum cleared its tag, which the aggregation
-    finding reads instead of re-inferring the event from the cleared output.
-
-    Every field is required: ``propagate_world`` is the only constructor, and a
-    default here would let some future constructor silently turn the grain check
-    into a no-op instead of failing to build."""
+    finding reads instead of re-inferring the event from the cleared output."""
 
     world: WorldRef
     domain_type: Mapping[ColumnRef, Annotation[DomainTag]]

--- a/src/dblect/lineage/properties/uniqueness.py
+++ b/src/dblect/lineage/properties/uniqueness.py
@@ -1289,25 +1289,20 @@ class _Projection:
 # --- the property ------------------------------------------------------------
 
 
-def uniqueness_property(
+def uniqueness_facts(
     manifest: Manifest,
     profile: AdapterProfile,
     *,
     extra: tuple[FactDiscoverer[CandidateKeySet, SourceRef], ...] = (),
+    extra_facts: tuple[Fact[CandidateKeySet, SourceRef], ...] = (),
     parsed: Mapping[str, Expr] | None = None,
-) -> Property[CandidateKeySet, SourceRef]:
-    """The manifest-backed uniqueness property: declared keys (unique tests,
-    ``unique_combination_of_columns``, native PRIMARY KEY / UNIQUE, the
-    config ``unique_key`` of a deduplicating incremental model, plus any
-    ``extra``) ground each relation, and the relation reducer infers more from the
-    SQL. Declared and inferred keys both hold, so they compose by meet
-    (``reconcile_by_meet``); no opaque opt-out reader is wired yet, so the opaque
-    set is empty. The property carries its relation-algebra walk as ``reducer`` so
-    the propagator dispatches it without a global registry.
-
-    ``profile`` is the run's resolved target: it fixes the adapter's enforcement
-    and dedup semantics, and carries any ``--dialect`` override so grammar and
-    semantics stay coherent."""
+) -> Mapping[SourceRef, tuple[Fact[CandidateKeySet, SourceRef], ...]]:
+    """Every candidate-key grounding fact, bucketed by relation: the manifest
+    discoverers (unique tests, ``unique_combination_of_columns``, native PRIMARY
+    KEY / UNIQUE, the config ``unique_key`` of a deduplicating incremental model,
+    the surrogate-hash expansion), any ``extra`` discoverers, and any
+    ``extra_facts`` already resolved in the caller's hand (the check threads the
+    contract-declared keys this way, so contracts are resolved once per run)."""
     discoverers = (
         unique_test_discoverer(),
         unique_combination_discoverer(),
@@ -1318,7 +1313,25 @@ def uniqueness_property(
     )
     # The uniqueness discoverers ground against the manifest directly, so they
     # need no name-to-source map; pass an empty one to the shared collector.
-    facts = collect(manifest, discoverers, name_to_source={})
+    collected = collect(manifest, discoverers, name_to_source={})
+    if not extra_facts:
+        return collected
+    merged: dict[SourceRef, list[Fact[CandidateKeySet, SourceRef]]] = {
+        scope: list(bucket) for scope, bucket in collected.items()
+    }
+    for fact in extra_facts:
+        merged.setdefault(fact.scope, []).append(fact)
+    return {scope: tuple(bucket) for scope, bucket in merged.items()}
+
+
+def uniqueness_property_from_facts(
+    facts: Mapping[SourceRef, tuple[Fact[CandidateKeySet, SourceRef], ...]],
+) -> Property[CandidateKeySet, SourceRef]:
+    """The uniqueness property grounded from ``facts``. Declared and inferred keys
+    both hold, so they compose by meet (``reconcile_by_meet``); no opaque opt-out
+    reader is wired yet, so the opaque set is empty. The property carries its
+    relation-algebra walk as ``reducer`` so the propagator dispatches it without a
+    global registry."""
     return relation_property(
         name="uniqueness",
         lattice=UNIQUENESS_LATTICE,
@@ -1327,6 +1340,24 @@ def uniqueness_property(
         ground=_grounding_with_conditional(facts),
         reconcile_by_meet=True,
         reducer=relation_reduce,
+    )
+
+
+def uniqueness_property(
+    manifest: Manifest,
+    profile: AdapterProfile,
+    *,
+    extra: tuple[FactDiscoverer[CandidateKeySet, SourceRef], ...] = (),
+    parsed: Mapping[str, Expr] | None = None,
+) -> Property[CandidateKeySet, SourceRef]:
+    """The manifest-backed uniqueness property: :func:`uniqueness_facts` grounds
+    each relation and the relation reducer infers more from the SQL.
+
+    ``profile`` is the run's resolved target: it fixes the adapter's enforcement
+    and dedup semantics, and carries any ``--dialect`` override so grammar and
+    semantics stay coherent."""
+    return uniqueness_property_from_facts(
+        uniqueness_facts(manifest, profile, extra=extra, parsed=parsed)
     )
 
 

--- a/src/dblect/lineage/properties/uniqueness.py
+++ b/src/dblect/lineage/properties/uniqueness.py
@@ -1297,12 +1297,15 @@ def uniqueness_facts(
     extra_facts: tuple[Fact[CandidateKeySet, SourceRef], ...] = (),
     parsed: Mapping[str, Expr] | None = None,
 ) -> Mapping[SourceRef, tuple[Fact[CandidateKeySet, SourceRef], ...]]:
-    """Every candidate-key grounding fact, bucketed by relation: the manifest
-    discoverers (unique tests, ``unique_combination_of_columns``, native PRIMARY
-    KEY / UNIQUE, the config ``unique_key`` of a deduplicating incremental model,
-    the surrogate-hash expansion), any ``extra`` discoverers, and any
-    ``extra_facts`` already resolved in the caller's hand (the check threads the
-    contract-declared keys this way, so contracts are resolved once per run)."""
+    """Every key the project declares, collected per relation.
+
+    Reads each way a dbt project can state one: ``unique`` and
+    ``unique_combination_of_columns`` tests, native PRIMARY KEY and UNIQUE
+    constraints, the ``unique_key`` of an incremental model whose strategy actually
+    deduplicates, and a key stated on a surrogate hash (which also tells us the
+    columns hashed into it). ``extra`` adds more readers. ``extra_facts`` takes keys
+    the caller already has in hand, which is how the check passes in keys declared in
+    Python contracts without resolving those contracts a second time."""
     discoverers = (
         unique_test_discoverer(),
         unique_combination_discoverer(),

--- a/src/dblect/lineage/properties/uniqueness.py
+++ b/src/dblect/lineage/properties/uniqueness.py
@@ -373,13 +373,9 @@ def native_key_discoverer(profile: AdapterProfile) -> FactDiscoverer[CandidateKe
 
 
 def model_dedups_on_write(config: ModelConfig | None, profile: AdapterProfile) -> bool:
-    """Whether this model's write path collapses duplicates on ``unique_key`` on its
-    own, independent of whatever a key declaration on the model claims.
-
-    True only for an incremental materialization whose effective strategy is one
-    that dedups: the write does the collapsing, so the SELECT is expected to carry
-    finer rows than the key, and no declaration channel on this model (a dbt test,
-    a contract, the config itself) is evidence the SELECT establishes the grain."""
+    """True if the model's write path dedups on ``unique_key``: an incremental
+    materialization under a deduplicating strategy. Its SELECT is expected to carry
+    finer rows than the key."""
     if config is None or not config.unique_key:
         return False
     if Materialization.from_raw(config.materialized) is not Materialization.INCREMENTAL:
@@ -1309,15 +1305,10 @@ def uniqueness_facts(
     extra_facts: tuple[Fact[CandidateKeySet, SourceRef], ...] = (),
     parsed: Mapping[str, Expr] | None = None,
 ) -> Mapping[SourceRef, tuple[Fact[CandidateKeySet, SourceRef], ...]]:
-    """Every key the project declares, collected per relation.
-
-    Reads each way a dbt project can state one: ``unique`` and
-    ``unique_combination_of_columns`` tests, native PRIMARY KEY and UNIQUE
-    constraints, the ``unique_key`` of an incremental model whose strategy actually
-    deduplicates, and a key stated on a surrogate hash (which also tells us the
-    columns hashed into it). ``extra`` adds more readers. ``extra_facts`` takes keys
-    the caller already has in hand, which is how the check passes in keys declared in
-    Python contracts without resolving those contracts a second time."""
+    """Every declared key, collected per relation: ``unique`` and
+    ``unique_combination_of_columns`` tests, native constraints, a deduplicating
+    incremental's ``unique_key``, and surrogate-hash keys. ``extra`` adds readers;
+    ``extra_facts`` adds keys the caller already resolved (Python contracts)."""
     discoverers = (
         unique_test_discoverer(),
         unique_combination_discoverer(),
@@ -1343,10 +1334,7 @@ def uniqueness_property_from_facts(
     facts: Mapping[SourceRef, tuple[Fact[CandidateKeySet, SourceRef], ...]],
 ) -> Property[CandidateKeySet, SourceRef]:
     """The uniqueness property grounded from ``facts``. Declared and inferred keys
-    both hold, so they compose by meet (``reconcile_by_meet``); no opaque opt-out
-    reader is wired yet, so the opaque set is empty. The property carries its
-    relation-algebra walk as ``reducer`` so the propagator dispatches it without a
-    global registry."""
+    both hold, so they compose by meet."""
     return relation_property(
         name="uniqueness",
         lattice=UNIQUENESS_LATTICE,
@@ -1366,11 +1354,8 @@ def uniqueness_property(
     parsed: Mapping[str, Expr] | None = None,
 ) -> Property[CandidateKeySet, SourceRef]:
     """The manifest-backed uniqueness property: :func:`uniqueness_facts` grounds
-    each relation and the relation reducer infers more from the SQL.
-
-    ``profile`` is the run's resolved target: it fixes the adapter's enforcement
-    and dedup semantics, and carries any ``--dialect`` override so grammar and
-    semantics stay coherent."""
+    each relation and the reducer infers more from the SQL. ``profile`` fixes the
+    adapter's enforcement and dedup semantics."""
     return uniqueness_property_from_facts(
         uniqueness_facts(manifest, profile, extra=extra, parsed=parsed)
     )

--- a/src/dblect/lineage/properties/uniqueness.py
+++ b/src/dblect/lineage/properties/uniqueness.py
@@ -66,6 +66,7 @@ from dblect.manifest import (
     ConstraintType,
     Manifest,
     Materialization,
+    ModelConfig,
     ResourceType,
     generic_test_target_uid,
 )
@@ -371,6 +372,21 @@ def native_key_discoverer(profile: AdapterProfile) -> FactDiscoverer[CandidateKe
 # to catch.
 
 
+def model_dedups_on_write(config: ModelConfig | None, profile: AdapterProfile) -> bool:
+    """Whether this model's write path collapses duplicates on ``unique_key`` on its
+    own, independent of whatever a key declaration on the model claims.
+
+    True only for an incremental materialization whose effective strategy is one
+    that dedups: the write does the collapsing, so the SELECT is expected to carry
+    finer rows than the key, and no declaration channel on this model (a dbt test,
+    a contract, the config itself) is evidence the SELECT establishes the grain."""
+    if config is None or not config.unique_key:
+        return False
+    if Materialization.from_raw(config.materialized) is not Materialization.INCREMENTAL:
+        return False
+    return profile.effective_strategy(config.incremental_strategy) in DEDUP_STRATEGIES
+
+
 class _ConfigKeyDiscoverer:
     """Grounds a candidate key from the ``unique_key`` / ``incremental_strategy``
     config pair, but only when the materialization actually deduplicates on write.
@@ -390,13 +406,9 @@ class _ConfigKeyDiscoverer:
             if node.resource_type is not ResourceType.MODEL:
                 continue
             config = node.config
-            if config is None or not config.unique_key:
-                continue
-            if Materialization.from_raw(config.materialized) is not Materialization.INCREMENTAL:
+            if config is None or not model_dedups_on_write(config, self._profile):
                 continue
             strategy = self._profile.effective_strategy(config.incremental_strategy)
-            if strategy not in DEDUP_STRATEGIES:
-                continue
             out.append(
                 Fact(
                     scope=SourceRef(SourceKind.MODEL, node.unique_id),

--- a/src/dblect/lineage/property.py
+++ b/src/dblect/lineage/property.py
@@ -28,7 +28,7 @@ property's :class:`~dblect.lineage.facts.DepContext` reads.
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping, MutableMapping
 from functools import reduce
 from typing import Any, TypeVar, cast
 
@@ -87,6 +87,7 @@ def propagate(
     dep_context: DepContext = _NULL_DEP_CONTEXT,
     subjects: Iterable[S] | None = None,
     sink: CoherenceSink[K] | None = None,
+    inferred_sink: MutableMapping[S, Annotation[K]] | None = None,
 ) -> Mapping[S, Annotation[K]]:
     """Compute ``prop``'s flow annotation for every subject in ``graph``.
 
@@ -117,6 +118,15 @@ def propagate(
     than re-inferring it from the output. It is per-call: the propagator never mutates
     the shared graph, so one ``sink`` belongs to one world's run. ``None`` clears
     silently (the substrate-only path).
+
+    ``inferred_sink`` is the pre-reconcile record (``refutation-and-verdicts.md``):
+    when supplied, each derived subject's inferred annotation is recorded there as
+    the reducer produced it, before reconciliation folds the grounded value in. The
+    flow value keeps its meaning (trust the declaration forward); the record is what
+    lets an emitter ask whether the derivation re-derived a declaration, which the
+    flow value cannot answer for a meet-reconciled property (the declaration unions
+    into it and would check itself). A leaf or a declared-opaque subject has no
+    derivation to judge, so neither is recorded.
     """
     reduce = _reducer_for(prop)
     lat = prop.lattice
@@ -145,6 +155,8 @@ def propagate(
                     result = grounded  # a leaf anchors on its grounded value
                 else:
                     inferred = reduce(deriv, prop, annotate, dep_context, default_ann, sink)
+                    if inferred_sink is not None:
+                        inferred_sink[subject] = inferred
                     result = _reconcile(lat, check, grounded, inferred, prop.reconcile_by_meet)
             annotations[subject] = result
             return result

--- a/src/dblect/lineage/property.py
+++ b/src/dblect/lineage/property.py
@@ -119,14 +119,16 @@ def propagate(
     the shared graph, so one ``sink`` belongs to one world's run. ``None`` clears
     silently (the substrate-only path).
 
-    ``inferred_sink`` is the pre-reconcile record (``refutation-and-verdicts.md``):
-    when supplied, each derived subject's inferred annotation is recorded there as
-    the reducer produced it, before reconciliation folds the grounded value in. The
-    flow value keeps its meaning (trust the declaration forward); the record is what
-    lets an emitter ask whether the derivation re-derived a declaration, which the
-    flow value cannot answer for a meet-reconciled property (the declaration unions
-    into it and would check itself). A leaf or a declared-opaque subject has no
-    derivation to judge, so neither is recorded.
+    ``inferred_sink``, when supplied, keeps what the SQL alone implied about each
+    node, before anything the user declared was folded in. Normally the two are
+    combined and only the combined value is kept, which is right for propagation but
+    leaves no way to ask whether the SQL supports a declaration: for a property whose
+    declared and derived values are both true and simply accumulate (candidate keys
+    are the case in hand), the declaration is part of the combined value, so checking
+    a declaration against it always succeeds. Keeping the derived value separately is
+    what lets a caller ask the question. Nodes with nothing to derive from, a source
+    or a node the modeller marked opaque, are absent rather than recorded empty.
+    ``refutation-and-verdicts.md`` covers what a caller can then conclude.
     """
     reduce = _reducer_for(prop)
     lat = prop.lattice

--- a/src/dblect/lineage/property.py
+++ b/src/dblect/lineage/property.py
@@ -91,8 +91,9 @@ def propagate(
 ) -> Mapping[S, Annotation[K]]:
     """Compute ``prop``'s flow annotation for every subject in ``graph``.
 
-    This is the one propagation engine: a memoised grounded fixpoint over the
-    lineage DAG. For each subject it grounds a declared annotation, short-circuits
+    This is the one propagation engine: one walk over the lineage graph, caching
+    each subject's result so a value read by many downstream columns is computed
+    once. For each subject it grounds a declared annotation, short-circuits
     on a declared opt-out, reduces the subject's derivation to an inferred
     annotation, and reconciles the two. The scope-specific part is the *reducer*:
     how a derivation reduces, and how recursion into referenced subjects is
@@ -116,8 +117,8 @@ def propagate(
     ``sink`` collects the :class:`CoherenceClear` events an aggregate guard records
     when it clears a tag, so a caller (the check) reads *why* a tag went to top rather
     than re-inferring it from the output. It is per-call: the propagator never mutates
-    the shared graph, so one ``sink`` belongs to one world's run. ``None`` clears
-    silently (the substrate-only path).
+    the shared graph, so one ``sink`` belongs to one world's run. ``None`` skips
+    that bookkeeping and just returns the computed value.
 
     ``inferred_sink``, when supplied, keeps what the SQL alone implied about each
     node, before anything the user declared was folded in. Normally the two are

--- a/src/dblect/lineage/property.py
+++ b/src/dblect/lineage/property.py
@@ -120,16 +120,10 @@ def propagate(
     the shared graph, so one ``sink`` belongs to one world's run. ``None`` skips
     that bookkeeping and just returns the computed value.
 
-    ``inferred_sink``, when supplied, keeps what the SQL alone implied about each
-    node, before anything the user declared was folded in. Normally the two are
-    combined and only the combined value is kept, which is right for propagation but
-    leaves no way to ask whether the SQL supports a declaration: for a property whose
-    declared and derived values are both true and simply accumulate (candidate keys
-    are the case in hand), the declaration is part of the combined value, so checking
-    a declaration against it always succeeds. Keeping the derived value separately is
-    what lets a caller ask the question. Nodes with nothing to derive from, a source
-    or a node the modeller marked opaque, are absent rather than recorded empty.
-    ``refutation-and-verdicts.md`` covers what a caller can then conclude.
+    ``inferred_sink``, when supplied, records each node's inferred annotation before
+    reconciliation with the grounded one. Under ``reconcile_by_meet`` the flow value
+    contains the declaration, so this is the only way to ask whether the SQL supports
+    it. Leaves and opted-out nodes are absent, not recorded empty.
     """
     reduce = _reducer_for(prop)
     lat = prop.lattice

--- a/src/dblect/severity.py
+++ b/src/dblect/severity.py
@@ -130,6 +130,11 @@ def _check_severity(kind: CheckFindingKind) -> Severity:
         # declared a floor to learn its coverage.
         case CheckFindingKind.RESOLUTION_BELOW_FLOOR:
             return Severity.WARN
+        # A witnessed not-established entailment, one grade below a contradiction:
+        # the construction fails to guarantee the declaration, but the data may
+        # still satisfy it, so it ships as a hazard rather than an error.
+        case CheckFindingKind.GRAIN_NOT_ESTABLISHED:
+            return Severity.WARN
     assert_never(kind)
 
 

--- a/src/dblect/severity.py
+++ b/src/dblect/severity.py
@@ -130,9 +130,8 @@ def _check_severity(kind: CheckFindingKind) -> Severity:
         # declared a floor to learn its coverage.
         case CheckFindingKind.RESOLUTION_BELOW_FLOOR:
             return Severity.WARN
-        # A witnessed not-established entailment, one grade below a contradiction:
-        # the construction fails to guarantee the declaration, but the data may
-        # still satisfy it, so it ships as a hazard rather than an error.
+        # One grade below a contradiction: the SQL does not guarantee the declared
+        # grain, but the data may still hold it, so this warns rather than errors.
         case CheckFindingKind.GRAIN_NOT_ESTABLISHED:
             return Severity.WARN
     assert_never(kind)

--- a/tests/check/test_grain_not_established.py
+++ b/tests/check/test_grain_not_established.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 
 from dblect.adapters import profile_for_adapter
-from dblect.check import CheckFindingKind, run_check
+from dblect.check import CheckFinding, CheckFindingKind, CheckReport, run_check
 from dblect.contracts import ContractSelf, contract
 from dblect.manifest import DbtTestMetadata, Manifest, ModelConfig, Node, ResourceType
 from dblect.manifest.parse import Column
@@ -87,13 +87,8 @@ def _declare_order_lines_key() -> None:
             return self.key(self.order_id, self.line_number)
 
 
-def _grain_findings(report: object) -> list[object]:
-    assert hasattr(report, "findings")
-    return [
-        f
-        for f in report.findings  # type: ignore[attr-defined]
-        if f.kind is CheckFindingKind.GRAIN_NOT_ESTABLISHED
-    ]
+def _grain_findings(report: CheckReport) -> list[CheckFinding]:
+    return [f for f in report.findings if f.kind is CheckFindingKind.GRAIN_NOT_ESTABLISHED]
 
 
 # --- the witnessed defeater fires -------------------------------------------------
@@ -125,8 +120,8 @@ def test_declared_grain_defeated_by_a_surviving_finer_key_is_a_finding() -> None
     findings = _grain_findings(report)
     assert len(findings) == 1
     finding = findings[0]
-    assert finding.model_unique_id == "model.shop.fct_orders"  # type: ignore[attr-defined]
-    message = finding.message  # type: ignore[attr-defined]
+    assert finding.model_unique_id == "model.shop.fct_orders"
+    message = finding.message
     assert "not established" in message
     assert "order_id" in message
     assert "line_number" in message
@@ -348,7 +343,7 @@ def test_a_dbt_unique_test_declaration_is_judged_like_a_contract_grain() -> None
     report = run_check(_manifest(_ORDER_LINES, fct, unique_test), _DUCKDB)
 
     findings = _grain_findings(report)
-    assert [f.model_unique_id for f in findings] == ["model.shop.fct_orders"]  # type: ignore[attr-defined]
+    assert [f.model_unique_id for f in findings] == ["model.shop.fct_orders"]
 
 
 def test_an_incremental_unique_key_is_discharged_by_the_write_not_the_select() -> None:

--- a/tests/check/test_grain_not_established.py
+++ b/tests/check/test_grain_not_established.py
@@ -2,18 +2,17 @@
 # A contract method's ``self`` is a ContractSelf proxy at capture, not a real
 # instance; annotating it that way trips pyright's self-supertype rule while keeping
 # the proxy usage checked. Typed ``self`` in authored contracts is the stubs concern.
-"""The declared-grain not-established emitter, through the ``run_check`` boundary.
+"""Declaring a grain and running the real check over SQL that does or does not meet it.
 
-These pin the wiring a declared grain travels: contract to fact to propagation to
-finding. The decision procedure itself is pinned against brute force in
-``test_pbt_grain_established.py``, and the verdict vocabulary the wording follows is
-``docs/design/refutation-and-verdicts.md``.
+These follow a declared grain the whole way, from the contract a user writes to the
+finding that comes out, so they catch a break anywhere along that path. Whether the
+underlying decision is correct is settled separately, against brute force, in
+``test_pbt_grain_established.py``.
 
-The load-bearing regression is the pre-reconcile record. Uniqueness reconciles
-declared and inferred keys by meet, so the flow value always contains the
-declaration and a declaration reading it would check itself; the drift test fails
-against any implementation that reads the flow value rather than the recorded
-inferred one.
+The case worth protecting hardest is the first one. A declared key is merged into
+what we know about a model as soon as it is read, so an implementation that compares
+a declaration against the merged keys finds the declaration sitting there and reports
+nothing. That test fails against any such implementation.
 """
 
 from __future__ import annotations

--- a/tests/check/test_grain_not_established.py
+++ b/tests/check/test_grain_not_established.py
@@ -21,8 +21,6 @@ any implementation that reads the flow value instead of the recorded inferred on
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-
 import pytest
 
 from dblect.adapters import profile_for_adapter
@@ -32,51 +30,16 @@ from dblect.manifest import (
     ConstraintSpec,
     ConstraintType,
     DbtTestMetadata,
-    Manifest,
     ModelConfig,
     Node,
     ResourceType,
 )
-from dblect.manifest.parse import Column
 from dblect.types import ModelContract
+from tests._manifest_builders import cols as _cols
+from tests._manifest_builders import manifest as _manifest
+from tests._manifest_builders import node as _node
 
 _DUCKDB = profile_for_adapter("duckdb")
-
-
-def _cols(**types: str) -> Mapping[str, Column]:
-    return {n: Column(name=n, data_type=t, description=None) for n, t in types.items()}
-
-
-def _node(
-    uid: str,
-    *,
-    sql: str | None,
-    columns: Mapping[str, Column],
-    config: ModelConfig | None = None,
-    constraints: tuple[ConstraintSpec, ...] = (),
-) -> Node:
-    return Node(
-        unique_id=uid,
-        name=uid.split(".")[-1],
-        resource_type=ResourceType.MODEL,
-        fqn=tuple(uid.split(".")[1:]),
-        package_name="shop",
-        schema="analytics",
-        raw_code=None,
-        compiled_code=sql,
-        original_file_path=f"models/{uid.split('.')[-1]}.sql",
-        columns=columns,
-        config=config,
-        constraints=constraints,
-    )
-
-
-def _manifest(*nodes: Node) -> Manifest:
-    return Manifest(
-        schema_version="v12",
-        adapter_type="duckdb",
-        nodes={n.unique_id: n for n in nodes},
-    )
 
 
 _LINE_COLS = _cols(order_id="INT", line_number="INT", amount="DECIMAL")
@@ -316,17 +279,9 @@ def test_an_unrelated_surviving_key_is_not_a_witness() -> None:
 
 
 def _unique_test_node(*, where: str | None) -> Node:
-    return Node(
-        unique_id="test.shop.unique_fct_orders_order_id",
-        name="unique_fct_orders_order_id",
-        resource_type=ResourceType.OTHER,
-        fqn=("shop", "unique_fct_orders_order_id"),
-        package_name="shop",
-        schema="analytics",
-        raw_code=None,
-        compiled_code=None,
-        original_file_path=None,
-        columns={},
+    return _node(
+        "test.shop.unique_fct_orders_order_id",
+        kind=ResourceType.OTHER,
         test_metadata=DbtTestMetadata(
             name="unique", kwargs={"column_name": "order_id"}, where=where
         ),

--- a/tests/check/test_grain_not_established.py
+++ b/tests/check/test_grain_not_established.py
@@ -25,7 +25,7 @@ from collections.abc import Mapping
 
 from dblect.adapters import profile_for_adapter
 from dblect.check import CheckFindingKind, run_check
-from dblect.contracts import contract
+from dblect.contracts import ContractSelf, contract
 from dblect.manifest import DbtTestMetadata, Manifest, ModelConfig, Node, ResourceType
 from dblect.manifest.parse import Column
 from dblect.types import ModelContract
@@ -83,7 +83,7 @@ def _declare_order_lines_key() -> None:
         dbt_model = "order_lines"
 
         @contract
-        def per_line(self):
+        def per_line(self: ContractSelf) -> object:
             return self.key(self.order_id, self.line_number)
 
 
@@ -112,7 +112,7 @@ def test_declared_grain_defeated_by_a_surviving_finer_key_is_a_finding() -> None
         dbt_model = "fct_orders"
 
         @contract
-        def one_row_per_order(self):
+        def one_row_per_order(self: ContractSelf) -> object:
             return self.grain(per=self.order_id)
 
     fct = _node(
@@ -144,7 +144,7 @@ def test_finding_lands_at_the_declaring_model_not_the_downstream_consumer() -> N
         dbt_model = "fct_orders"
 
         @contract
-        def one_row_per_order(self):
+        def one_row_per_order(self: ContractSelf) -> object:
             return self.grain(per=self.order_id)
 
     fct = _node(
@@ -174,7 +174,7 @@ def test_a_collapse_to_the_declared_grain_is_established_and_silent() -> None:
         dbt_model = "fct_orders"
 
         @contract
-        def one_row_per_order(self):
+        def one_row_per_order(self: ContractSelf) -> object:
             return self.grain(per=self.order_id)
 
     fct = _node(
@@ -196,7 +196,7 @@ def test_a_non_minimal_declared_grain_is_covered_and_silent() -> None:
         dbt_model = "fct_orders"
 
         @contract
-        def one_row_per_order_and_line(self):
+        def one_row_per_order_and_line(self: ContractSelf) -> object:
             return self.grain(per=(self.order_id, self.line_number))
 
     fct = _node(
@@ -218,18 +218,18 @@ def test_coverage_runs_through_the_fd_closure() -> None:
         dbt_model = "order_regions"
 
         @contract
-        def per_order_region(self):
+        def per_order_region(self: ContractSelf) -> object:
             return self.key(self.order_id, self.region)
 
         @contract
-        def order_pins_region(self):
+        def order_pins_region(self: ContractSelf) -> object:
             return self.order_id.determines(self.region)
 
     class FctOrders(ModelContract):
         dbt_model = "fct_orders"
 
         @contract
-        def one_row_per_order(self):
+        def one_row_per_order(self: ContractSelf) -> object:
             return self.grain(per=self.order_id)
 
     regions = _node(
@@ -258,7 +258,7 @@ def test_absence_of_any_inferred_key_is_not_a_witness() -> None:
         dbt_model = "fct_orders"
 
         @contract
-        def one_row_per_order(self):
+        def one_row_per_order(self: ContractSelf) -> object:
             return self.grain(per=self.order_id)
 
     fct = _node(
@@ -278,7 +278,7 @@ def test_a_leaf_declaration_has_no_entailment_to_judge() -> None:
         dbt_model = "order_lines"
 
         @contract
-        def per_line(self):
+        def per_line(self: ContractSelf) -> object:
             return self.grain(per=(self.order_id, self.line_number))
 
     report = run_check(_manifest(_ORDER_LINES), _DUCKDB)
@@ -293,14 +293,14 @@ def test_an_unrelated_surviving_key_is_not_a_witness() -> None:
         dbt_model = "order_lines"
 
         @contract
-        def per_line(self):
+        def per_line(self: ContractSelf) -> object:
             return self.key(self.line_id)
 
     class FctOrders(ModelContract):
         dbt_model = "fct_orders"
 
         @contract
-        def one_row_per_order(self):
+        def one_row_per_order(self: ContractSelf) -> object:
             return self.grain(per=self.order_id)
 
     lines = _node(

--- a/tests/check/test_grain_not_established.py
+++ b/tests/check/test_grain_not_established.py
@@ -1,0 +1,373 @@
+# pyright: reportInvalidTypeForm=false, reportUnusedClass=false, reportGeneralTypeIssues=false
+# A contract method's ``self`` is a ContractSelf proxy at capture, not a real
+# instance; annotating it that way trips pyright's self-supertype rule while keeping
+# the proxy usage checked. Typed ``self`` in authored contracts is the stubs concern.
+"""The declared-grain not-established emitter, through the ``run_check`` boundary.
+
+A declared grain is an assumption downstream consumers trust and a proof obligation
+at the declaring model: does the model's SQL, plus the upstream contracts, re-derive
+uniqueness on the declared columns? The verdict vocabulary is
+``docs/design/refutation-and-verdicts.md``: the finding fires only on a witnessed
+defeater (a strictly finer key surviving to the output with no collapse to the
+declared grain), never on the key walk's own silence, and it reports "declared but
+not established", never "violated" (every extensional claim holds vacuously on the
+empty relation).
+
+The load-bearing regression here is the pre-reconcile record: uniqueness reconciles
+declared and inferred keys by meet, so the post-reconcile flow value always contains
+the declaration and a declaration would check itself. The drift test fails against
+any implementation that reads the flow value instead of the recorded inferred one.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from dblect.adapters import profile_for_adapter
+from dblect.check import CheckFindingKind, run_check
+from dblect.contracts import contract
+from dblect.manifest import DbtTestMetadata, Manifest, ModelConfig, Node, ResourceType
+from dblect.manifest.parse import Column
+from dblect.types import ModelContract
+
+_DUCKDB = profile_for_adapter("duckdb")
+
+
+def _cols(**types: str) -> Mapping[str, Column]:
+    return {n: Column(name=n, data_type=t, description=None) for n, t in types.items()}
+
+
+def _node(
+    uid: str,
+    *,
+    sql: str | None,
+    columns: Mapping[str, Column],
+    config: ModelConfig | None = None,
+) -> Node:
+    return Node(
+        unique_id=uid,
+        name=uid.split(".")[-1],
+        resource_type=ResourceType.MODEL,
+        fqn=tuple(uid.split(".")[1:]),
+        package_name="shop",
+        schema="analytics",
+        raw_code=None,
+        compiled_code=sql,
+        original_file_path=f"models/{uid.split('.')[-1]}.sql",
+        columns=columns,
+        config=config,
+    )
+
+
+def _manifest(*nodes: Node) -> Manifest:
+    return Manifest(
+        schema_version="v12",
+        adapter_type="duckdb",
+        nodes={n.unique_id: n for n in nodes},
+    )
+
+
+_LINE_COLS = _cols(order_id="INT", line_number="INT", amount="DECIMAL")
+
+# A per-line leaf model: no FROM, so the relation walk infers nothing and its
+# declared compound key grounds it.
+_ORDER_LINES = _node(
+    "model.shop.order_lines",
+    sql="select 1 as order_id, 1 as line_number, 1.0 as amount",
+    columns=_LINE_COLS,
+)
+
+
+def _declare_order_lines_key() -> None:
+    class OrderLines(ModelContract):
+        dbt_model = "order_lines"
+
+        @contract
+        def per_line(self):
+            return self.key(self.order_id, self.line_number)
+
+
+def _grain_findings(report: object) -> list[object]:
+    assert hasattr(report, "findings")
+    return [
+        f
+        for f in report.findings  # type: ignore[attr-defined]
+        if f.kind is CheckFindingKind.GRAIN_NOT_ESTABLISHED
+    ]
+
+
+# --- the witnessed defeater fires -------------------------------------------------
+
+
+def test_declared_grain_defeated_by_a_surviving_finer_key_is_a_finding() -> None:
+    # fct_orders declares one row per order but selects from the per-line model
+    # without collapsing, so the strictly finer key (order_id, line_number) survives
+    # to its output: the witnessed defeater. This is also the pre-reconcile
+    # regression: the flow value contains the declared grain (meet unions it in), so
+    # an emitter reading the flow value would see the declaration satisfy itself and
+    # report nothing.
+    _declare_order_lines_key()
+
+    class FctOrders(ModelContract):
+        dbt_model = "fct_orders"
+
+        @contract
+        def one_row_per_order(self):
+            return self.grain(per=self.order_id)
+
+    fct = _node(
+        "model.shop.fct_orders",
+        sql="select order_id, line_number, amount from order_lines",
+        columns=_LINE_COLS,
+    )
+    report = run_check(_manifest(_ORDER_LINES, fct), _DUCKDB)
+
+    findings = _grain_findings(report)
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.model_unique_id == "model.shop.fct_orders"  # type: ignore[attr-defined]
+    message = finding.message  # type: ignore[attr-defined]
+    assert "not established" in message
+    assert "order_id" in message
+    assert "line_number" in message
+    # Honesty of grade: the construction fails to establish the grain; the data may
+    # still satisfy it, so the finding never claims a violation.
+    assert "violat" not in message.lower()
+
+
+def test_finding_lands_at_the_declaring_model_not_the_downstream_consumer() -> None:
+    # The point of the emitter (issue #202): raise the finding at the model whose
+    # grain is unestablished, not at the downstream sum that eventually trips.
+    _declare_order_lines_key()
+
+    class FctOrders(ModelContract):
+        dbt_model = "fct_orders"
+
+        @contract
+        def one_row_per_order(self):
+            return self.grain(per=self.order_id)
+
+    fct = _node(
+        "model.shop.fct_orders",
+        sql="select order_id, line_number, amount from order_lines",
+        columns=_LINE_COLS,
+    )
+    consumer = _node(
+        "model.shop.daily",
+        sql="select order_id, sum(amount) as total from fct_orders group by order_id",
+        columns=_cols(order_id="INT", total="DECIMAL"),
+    )
+    report = run_check(_manifest(_ORDER_LINES, fct, consumer), _DUCKDB)
+
+    assert [f.model_unique_id for f in _grain_findings(report)] == ["model.shop.fct_orders"]
+
+
+# --- the grain is established: silence ---------------------------------------------
+
+
+def test_a_collapse_to_the_declared_grain_is_established_and_silent() -> None:
+    # The same declaration over SQL that aggregates to the declared grain: the
+    # GROUP BY re-derives the key, so the entailment holds and nothing fires.
+    _declare_order_lines_key()
+
+    class FctOrders(ModelContract):
+        dbt_model = "fct_orders"
+
+        @contract
+        def one_row_per_order(self):
+            return self.grain(per=self.order_id)
+
+    fct = _node(
+        "model.shop.fct_orders",
+        sql="select order_id, sum(amount) as amount from order_lines group by order_id",
+        columns=_cols(order_id="INT", amount="DECIMAL"),
+    )
+    report = run_check(_manifest(_ORDER_LINES, fct), _DUCKDB)
+    assert _grain_findings(report) == []
+
+
+def test_a_non_minimal_declared_grain_is_covered_and_silent() -> None:
+    # The declared grain is coarser than the surviving key: unique on (order_id)
+    # implies unique on (order_id, line_number), so a non-minimal grain must not
+    # false-fire (the ``detect_join_fanout`` hardening, applied here).
+    _declare_order_lines_key()
+
+    class FctOrders(ModelContract):
+        dbt_model = "fct_orders"
+
+        @contract
+        def one_row_per_order_and_line(self):
+            return self.grain(per=(self.order_id, self.line_number))
+
+    fct = _node(
+        "model.shop.fct_orders",
+        sql="select order_id, line_number, sum(amount) as amount from order_lines "
+        "group by order_id, line_number",
+        columns=_LINE_COLS,
+    )
+    report = run_check(_manifest(_ORDER_LINES, fct), _DUCKDB)
+    assert _grain_findings(report) == []
+
+
+def test_coverage_runs_through_the_fd_closure() -> None:
+    # The surviving key is (order_id, region), strictly finer than the declared
+    # grain (order_id); but a declared ``order_id determines region`` closes the
+    # gap: unique on (order_id, region) plus the dependency is unique on (order_id),
+    # so the grain is established and nothing fires.
+    class OrderRegions(ModelContract):
+        dbt_model = "order_regions"
+
+        @contract
+        def per_order_region(self):
+            return self.key(self.order_id, self.region)
+
+        @contract
+        def order_pins_region(self):
+            return self.order_id.determines(self.region)
+
+    class FctOrders(ModelContract):
+        dbt_model = "fct_orders"
+
+        @contract
+        def one_row_per_order(self):
+            return self.grain(per=self.order_id)
+
+    regions = _node(
+        "model.shop.order_regions",
+        sql="select 1 as order_id, 'emea' as region, 1.0 as amount",
+        columns=_cols(order_id="INT", region="TEXT", amount="DECIMAL"),
+    )
+    fct = _node(
+        "model.shop.fct_orders",
+        sql="select order_id, region, amount from order_regions",
+        columns=_cols(order_id="INT", region="TEXT", amount="DECIMAL"),
+    )
+    report = run_check(_manifest(regions, fct), _DUCKDB)
+    assert _grain_findings(report) == []
+
+
+# --- no witness: the walk's silence is not evidence ---------------------------------
+
+
+def test_absence_of_any_inferred_key_is_not_a_witness() -> None:
+    # The upstream relation declares no key, so the walk infers nothing for
+    # fct_orders: the declared grain is neither re-derived nor defeated. Firing here
+    # would flag every model whose upstream declares nothing; the emitter must
+    # require a witnessed defeater, not an absent proof.
+    class FctOrders(ModelContract):
+        dbt_model = "fct_orders"
+
+        @contract
+        def one_row_per_order(self):
+            return self.grain(per=self.order_id)
+
+    fct = _node(
+        "model.shop.fct_orders",
+        sql="select order_id, line_number, amount from order_lines",
+        columns=_LINE_COLS,
+    )
+    report = run_check(_manifest(_ORDER_LINES, fct), _DUCKDB)
+    assert _grain_findings(report) == []
+
+
+def test_a_leaf_declaration_has_no_entailment_to_judge() -> None:
+    # A grain declared on a model with no upstream derivation to walk (a leaf
+    # SELECT with no FROM) grounds a trusted fact; there is no construction to
+    # re-derive it from, so nothing fires.
+    class OrderLines(ModelContract):
+        dbt_model = "order_lines"
+
+        @contract
+        def per_line(self):
+            return self.grain(per=(self.order_id, self.line_number))
+
+    report = run_check(_manifest(_ORDER_LINES), _DUCKDB)
+    assert _grain_findings(report) == []
+
+
+def test_an_unrelated_surviving_key_is_not_a_witness() -> None:
+    # The surviving key (line_id) is not strictly finer than the declared grain
+    # (order_id): it does not contain it, so it says nothing about rows per order
+    # (every order may have exactly one line). No witness, no finding.
+    class OrderLines(ModelContract):
+        dbt_model = "order_lines"
+
+        @contract
+        def per_line(self):
+            return self.key(self.line_id)
+
+    class FctOrders(ModelContract):
+        dbt_model = "fct_orders"
+
+        @contract
+        def one_row_per_order(self):
+            return self.grain(per=self.order_id)
+
+    lines = _node(
+        "model.shop.order_lines",
+        sql="select 1 as line_id, 1 as order_id, 1.0 as amount",
+        columns=_cols(line_id="INT", order_id="INT", amount="DECIMAL"),
+    )
+    fct = _node(
+        "model.shop.fct_orders",
+        sql="select line_id, order_id, amount from order_lines",
+        columns=_cols(line_id="INT", order_id="INT", amount="DECIMAL"),
+    )
+    report = run_check(_manifest(lines, fct), _DUCKDB)
+    assert _grain_findings(report) == []
+
+
+# --- provenance channels: every case of the closed type decided ---------------------
+
+
+def test_a_dbt_unique_test_declaration_is_judged_like_a_contract_grain() -> None:
+    # The same claim authored through the dbt ``unique`` test channel: provenance
+    # carries no authority ordering, so a declared key is a declared key whichever
+    # surface stated it. The drift shape that fires for a contract grain fires here.
+    _declare_order_lines_key()
+
+    fct = _node(
+        "model.shop.fct_orders",
+        sql="select order_id, line_number, amount from order_lines",
+        columns=_LINE_COLS,
+    )
+    unique_test = Node(
+        unique_id="test.shop.unique_fct_orders_order_id",
+        name="unique_fct_orders_order_id",
+        resource_type=ResourceType.OTHER,
+        fqn=("shop", "unique_fct_orders_order_id"),
+        package_name="shop",
+        schema="analytics",
+        raw_code=None,
+        compiled_code=None,
+        original_file_path=None,
+        columns={},
+        test_metadata=DbtTestMetadata(name="unique", kwargs={"column_name": "order_id"}),
+        attached_node="model.shop.fct_orders",
+    )
+    report = run_check(_manifest(_ORDER_LINES, fct, unique_test), _DUCKDB)
+
+    findings = _grain_findings(report)
+    assert [f.model_unique_id for f in findings] == ["model.shop.fct_orders"]  # type: ignore[attr-defined]
+
+
+def test_an_incremental_unique_key_is_discharged_by_the_write_not_the_select() -> None:
+    # A deduplicating incremental materialization enforces its ``unique_key`` on
+    # write: the SELECT is expected to carry finer rows and the merge collapses
+    # them. That key is a CompileValue fact, not a declaration about the SELECT's
+    # own output, so the emitter must not judge it (the incremental-grain stream,
+    # issue #7, owns that write-path reasoning).
+    _declare_order_lines_key()
+
+    fct = _node(
+        "model.shop.fct_orders",
+        sql="select order_id, line_number, amount from order_lines",
+        columns=_LINE_COLS,
+        config=ModelConfig(
+            materialized="incremental",
+            incremental_strategy="merge",
+            unique_key=("order_id",),
+        ),
+    )
+    report = run_check(_manifest(_ORDER_LINES, fct), _DUCKDB)
+    assert _grain_findings(report) == []

--- a/tests/check/test_grain_not_established.py
+++ b/tests/check/test_grain_not_established.py
@@ -4,22 +4,21 @@
 # the proxy usage checked. Typed ``self`` in authored contracts is the stubs concern.
 """The declared-grain not-established emitter, through the ``run_check`` boundary.
 
-A declared grain is an assumption downstream consumers trust and a proof obligation
-at the declaring model: does the model's SQL, plus the upstream contracts, re-derive
-uniqueness on the declared columns? The verdict vocabulary is
-``docs/design/refutation-and-verdicts.md``: the finding fires only on a witnessed
-defeater (a strictly finer key surviving to the output with no collapse to the
-declared grain), never on the key walk's own silence, and it reports "declared but
-not established", never "violated" (every extensional claim holds vacuously on the
-empty relation).
+These pin the wiring a declared grain travels: contract to fact to propagation to
+finding. The decision procedure itself is pinned against brute force in
+``test_pbt_grain_established.py``, and the verdict vocabulary the wording follows is
+``docs/design/refutation-and-verdicts.md``.
 
-The load-bearing regression here is the pre-reconcile record: uniqueness reconciles
-declared and inferred keys by meet, so the post-reconcile flow value always contains
-the declaration and a declaration would check itself. The drift test fails against
-any implementation that reads the flow value instead of the recorded inferred one.
+The load-bearing regression is the pre-reconcile record. Uniqueness reconciles
+declared and inferred keys by meet, so the flow value always contains the
+declaration and a declaration reading it would check itself; the drift test fails
+against any implementation that reads the flow value rather than the recorded
+inferred one.
 """
 
 from __future__ import annotations
+
+from dataclasses import dataclass
 
 import pytest
 
@@ -38,6 +37,7 @@ from dblect.types import ModelContract
 from tests._manifest_builders import cols as _cols
 from tests._manifest_builders import manifest as _manifest
 from tests._manifest_builders import node as _node
+from tests._manifest_builders import source as _source
 
 _DUCKDB = profile_for_adapter("duckdb")
 
@@ -71,13 +71,10 @@ def _grain_findings(report: CheckReport) -> list[CheckFinding]:
 
 def test_declared_grain_defeated_by_a_surviving_finer_key_is_a_finding() -> None:
     # fct_orders declares one row per order but selects from the per-line model
-    # without collapsing, so the strictly finer key (order_id, line_number) survives
-    # to its output: the witnessed defeater. This is also the pre-reconcile
-    # regression: the flow value contains the declared grain (meet unions it in), so
-    # an emitter reading the flow value would see the declaration satisfy itself and
-    # report nothing. The downstream consumer pins where the finding lands (issue
-    # #202): at the model whose grain is unestablished, not at the sum that
-    # eventually trips over it.
+    # without collapsing, so the finer key (order_id, line_number) survives to its
+    # output: the witnessed defeater, and the case an emitter reading the flow value
+    # would miss. The downstream consumer pins where the finding lands: at the model
+    # whose grain is unestablished, not at the sum that eventually trips over it.
     _declare_order_lines_key()
 
     class FctOrders(ModelContract):
@@ -129,29 +126,6 @@ def test_a_collapse_to_the_declared_grain_is_established_and_silent() -> None:
         "model.shop.fct_orders",
         sql="select order_id, sum(amount) as amount from order_lines group by order_id",
         columns=_cols(order_id="INT", amount="DECIMAL"),
-    )
-    report = run_check(_manifest(_ORDER_LINES, fct), _DUCKDB)
-    assert _grain_findings(report) == []
-
-
-def test_a_non_minimal_declared_grain_is_covered_and_silent() -> None:
-    # The declared grain is coarser than the surviving key: unique on (order_id)
-    # implies unique on (order_id, line_number), so a non-minimal grain must not
-    # false-fire (the ``detect_join_fanout`` hardening, applied here).
-    _declare_order_lines_key()
-
-    class FctOrders(ModelContract):
-        dbt_model = "fct_orders"
-
-        @contract
-        def one_row_per_order_and_line(self: ContractSelf) -> object:
-            return self.grain(per=(self.order_id, self.line_number))
-
-    fct = _node(
-        "model.shop.fct_orders",
-        sql="select order_id, line_number, sum(amount) as amount from order_lines "
-        "group by order_id, line_number",
-        columns=_LINE_COLS,
     )
     report = run_check(_manifest(_ORDER_LINES, fct), _DUCKDB)
     assert _grain_findings(report) == []
@@ -218,50 +192,25 @@ def test_absence_of_any_inferred_key_is_not_a_witness() -> None:
     assert _grain_findings(report) == []
 
 
-def test_a_leaf_declaration_has_no_entailment_to_judge() -> None:
-    # A grain declared on a model with no upstream derivation to walk (a leaf
-    # SELECT with no FROM) grounds a trusted fact; there is no construction to
-    # re-derive it from, so nothing fires.
-    class OrderLines(ModelContract):
-        dbt_model = "order_lines"
-
-        @contract
-        def per_line(self: ContractSelf) -> object:
-            return self.grain(per=(self.order_id, self.line_number))
-
-    report = run_check(_manifest(_ORDER_LINES), _DUCKDB)
-    assert _grain_findings(report) == []
-
-
-def test_an_unrelated_surviving_key_is_not_a_witness() -> None:
-    # The surviving key (line_id) is not strictly finer than the declared grain
-    # (order_id): it does not contain it, so it says nothing about rows per order
-    # (every order may have exactly one line). No witness, no finding.
-    class OrderLines(ModelContract):
-        dbt_model = "order_lines"
-
-        @contract
-        def per_line(self: ContractSelf) -> object:
-            return self.key(self.line_id)
-
-    class FctOrders(ModelContract):
-        dbt_model = "fct_orders"
-
-        @contract
-        def one_row_per_order(self: ContractSelf) -> object:
-            return self.grain(per=self.order_id)
-
-    lines = _node(
-        "model.shop.order_lines",
-        sql="select 1 as line_id, 1 as order_id, 1.0 as amount",
-        columns=_cols(line_id="INT", order_id="INT", amount="DECIMAL"),
+def test_a_declared_key_on_a_source_has_no_construction_to_judge() -> None:
+    # A source carries no SQL of its own, so the walk derives nothing for it and it
+    # is absent from the record entirely. There is no entailment to judge, and the
+    # emitter has to pass over it rather than reach for a value never recorded. A
+    # ``unique`` test on a source is ordinary in a dbt project, so this is the shape
+    # that would crash a whole run.
+    orders = _source("source.shop.raw.orders", columns=_cols(order_id="INT", amount="DECIMAL"))
+    unique_test = _node(
+        "test.shop.unique_orders_order_id",
+        kind=ResourceType.OTHER,
+        test_metadata=DbtTestMetadata(name="unique", kwargs={"column_name": "order_id"}),
+        attached_node="source.shop.raw.orders",
     )
     fct = _node(
         "model.shop.fct_orders",
-        sql="select line_id, order_id, amount from order_lines",
-        columns=_cols(line_id="INT", order_id="INT", amount="DECIMAL"),
+        sql="select order_id, amount from orders",
+        columns=_cols(order_id="INT", amount="DECIMAL"),
     )
-    report = run_check(_manifest(lines, fct), _DUCKDB)
+    report = run_check(_manifest(orders, unique_test, fct), _DUCKDB)
     assert _grain_findings(report) == []
 
 
@@ -289,42 +238,48 @@ def _unique_test_node(*, where: str | None) -> Node:
     )
 
 
-@pytest.mark.parametrize(
-    ("channel", "fires"),
-    [
-        ("dbt_unique_test", True),
-        ("conditional_unique_test", False),
-        ("native_constraint", False),
-        ("incremental_unique_key", False),
-    ],
-)
-def test_declaration_channels_decide_what_is_judged(channel: str, fires: bool) -> None:
-    _declare_order_lines_key()
+@dataclass(frozen=True)
+class _Channel:
+    """One surface a key on ``order_id`` can arrive through, as the manifest carries it."""
 
-    extra_nodes: list[Node] = []
+    label: str
+    fires: bool
+    test_node: Node | None = None
     config: ModelConfig | None = None
     constraints: tuple[ConstraintSpec, ...] = ()
-    if channel == "dbt_unique_test":
-        extra_nodes.append(_unique_test_node(where=None))
-    elif channel == "conditional_unique_test":
-        extra_nodes.append(_unique_test_node(where="order_id > 0"))
-    elif channel == "native_constraint":
-        constraints = (ConstraintSpec(type=ConstraintType.UNIQUE, columns=("order_id",)),)
-    elif channel == "incremental_unique_key":
-        config = ModelConfig(
-            materialized="incremental",
-            incremental_strategy="merge",
-            unique_key=("order_id",),
-        )
 
+
+_CHANNELS = (
+    _Channel("dbt_unique_test", True, test_node=_unique_test_node(where=None)),
+    _Channel("conditional_unique_test", False, test_node=_unique_test_node(where="order_id > 0")),
+    _Channel(
+        "native_constraint",
+        False,
+        constraints=(ConstraintSpec(type=ConstraintType.UNIQUE, columns=("order_id",)),),
+    ),
+    _Channel(
+        "incremental_unique_key",
+        False,
+        config=ModelConfig(
+            materialized="incremental", incremental_strategy="merge", unique_key=("order_id",)
+        ),
+    ),
+)
+
+
+@pytest.mark.parametrize("channel", _CHANNELS, ids=lambda c: c.label)
+def test_declaration_channels_decide_what_is_judged(channel: _Channel) -> None:
+    _declare_order_lines_key()
     fct = _node(
         "model.shop.fct_orders",
         sql="select order_id, line_number, amount from order_lines",
         columns=_LINE_COLS,
-        config=config,
-        constraints=constraints,
+        config=channel.config,
+        constraints=channel.constraints,
     )
-    report = run_check(_manifest(_ORDER_LINES, fct, *extra_nodes), _DUCKDB)
+    extra = (channel.test_node,) if channel.test_node is not None else ()
+    report = run_check(_manifest(_ORDER_LINES, fct, *extra), _DUCKDB)
 
     findings = _grain_findings(report)
-    assert [f.model_unique_id for f in findings] == (["model.shop.fct_orders"] if fires else [])
+    expected = ["model.shop.fct_orders"] if channel.fires else []
+    assert [f.model_unique_id for f in findings] == expected

--- a/tests/check/test_grain_not_established.py
+++ b/tests/check/test_grain_not_established.py
@@ -23,10 +23,20 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 
+import pytest
+
 from dblect.adapters import profile_for_adapter
 from dblect.check import CheckFinding, CheckFindingKind, CheckReport, run_check
 from dblect.contracts import ContractSelf, contract
-from dblect.manifest import DbtTestMetadata, Manifest, ModelConfig, Node, ResourceType
+from dblect.manifest import (
+    ConstraintSpec,
+    ConstraintType,
+    DbtTestMetadata,
+    Manifest,
+    ModelConfig,
+    Node,
+    ResourceType,
+)
 from dblect.manifest.parse import Column
 from dblect.types import ModelContract
 
@@ -43,6 +53,7 @@ def _node(
     sql: str | None,
     columns: Mapping[str, Column],
     config: ModelConfig | None = None,
+    constraints: tuple[ConstraintSpec, ...] = (),
 ) -> Node:
     return Node(
         unique_id=uid,
@@ -56,6 +67,7 @@ def _node(
         original_file_path=f"models/{uid.split('.')[-1]}.sql",
         columns=columns,
         config=config,
+        constraints=constraints,
     )
 
 
@@ -100,39 +112,9 @@ def test_declared_grain_defeated_by_a_surviving_finer_key_is_a_finding() -> None
     # to its output: the witnessed defeater. This is also the pre-reconcile
     # regression: the flow value contains the declared grain (meet unions it in), so
     # an emitter reading the flow value would see the declaration satisfy itself and
-    # report nothing.
-    _declare_order_lines_key()
-
-    class FctOrders(ModelContract):
-        dbt_model = "fct_orders"
-
-        @contract
-        def one_row_per_order(self: ContractSelf) -> object:
-            return self.grain(per=self.order_id)
-
-    fct = _node(
-        "model.shop.fct_orders",
-        sql="select order_id, line_number, amount from order_lines",
-        columns=_LINE_COLS,
-    )
-    report = run_check(_manifest(_ORDER_LINES, fct), _DUCKDB)
-
-    findings = _grain_findings(report)
-    assert len(findings) == 1
-    finding = findings[0]
-    assert finding.model_unique_id == "model.shop.fct_orders"
-    message = finding.message
-    assert "not established" in message
-    assert "order_id" in message
-    assert "line_number" in message
-    # Honesty of grade: the construction fails to establish the grain; the data may
-    # still satisfy it, so the finding never claims a violation.
-    assert "violat" not in message.lower()
-
-
-def test_finding_lands_at_the_declaring_model_not_the_downstream_consumer() -> None:
-    # The point of the emitter (issue #202): raise the finding at the model whose
-    # grain is unestablished, not at the downstream sum that eventually trips.
+    # report nothing. The downstream consumer pins where the finding lands (issue
+    # #202): at the model whose grain is unestablished, not at the sum that
+    # eventually trips over it.
     _declare_order_lines_key()
 
     class FctOrders(ModelContract):
@@ -154,7 +136,15 @@ def test_finding_lands_at_the_declaring_model_not_the_downstream_consumer() -> N
     )
     report = run_check(_manifest(_ORDER_LINES, fct, consumer), _DUCKDB)
 
-    assert [f.model_unique_id for f in _grain_findings(report)] == ["model.shop.fct_orders"]
+    findings = _grain_findings(report)
+    assert [f.model_unique_id for f in findings] == ["model.shop.fct_orders"]
+    message = findings[0].message
+    assert "not established" in message
+    assert "order_id" in message
+    assert "line_number" in message
+    # Honesty of grade: the construction fails to establish the grain; the data may
+    # still satisfy it, so the finding never claims a violation.
+    assert "violat" not in message.lower()
 
 
 # --- the grain is established: silence ---------------------------------------------
@@ -312,21 +302,21 @@ def test_an_unrelated_surviving_key_is_not_a_witness() -> None:
     assert _grain_findings(report) == []
 
 
-# --- provenance channels: every case of the closed type decided ---------------------
+# --- declaration channels: every case of the closed provenance type decided ---------
+#
+# The contract channel's fire case is the drift test above; the table here covers the
+# rest. A dbt ``unique`` test is judged like a contract grain (provenance carries no
+# authority ordering), and it is the only other channel that fires. A ``where``-filtered
+# test claims uniqueness only over a row filter, so it is activation's business, not a
+# grain claim about the whole output. A native constraint is discharged (or not) by the
+# warehouse's write path; the advisory-unenforced case is the unenforced-constraint
+# finding's (#48). A deduplicating incremental's ``unique_key`` is enforced by the merge
+# on write, so the SELECT is expected to carry finer rows (the incremental-grain
+# stream, #7).
 
 
-def test_a_dbt_unique_test_declaration_is_judged_like_a_contract_grain() -> None:
-    # The same claim authored through the dbt ``unique`` test channel: provenance
-    # carries no authority ordering, so a declared key is a declared key whichever
-    # surface stated it. The drift shape that fires for a contract grain fires here.
-    _declare_order_lines_key()
-
-    fct = _node(
-        "model.shop.fct_orders",
-        sql="select order_id, line_number, amount from order_lines",
-        columns=_LINE_COLS,
-    )
-    unique_test = Node(
+def _unique_test_node(*, where: str | None) -> Node:
+    return Node(
         unique_id="test.shop.unique_fct_orders_order_id",
         name="unique_fct_orders_order_id",
         resource_type=ResourceType.OTHER,
@@ -337,32 +327,49 @@ def test_a_dbt_unique_test_declaration_is_judged_like_a_contract_grain() -> None
         compiled_code=None,
         original_file_path=None,
         columns={},
-        test_metadata=DbtTestMetadata(name="unique", kwargs={"column_name": "order_id"}),
+        test_metadata=DbtTestMetadata(
+            name="unique", kwargs={"column_name": "order_id"}, where=where
+        ),
         attached_node="model.shop.fct_orders",
     )
-    report = run_check(_manifest(_ORDER_LINES, fct, unique_test), _DUCKDB)
-
-    findings = _grain_findings(report)
-    assert [f.model_unique_id for f in findings] == ["model.shop.fct_orders"]
 
 
-def test_an_incremental_unique_key_is_discharged_by_the_write_not_the_select() -> None:
-    # A deduplicating incremental materialization enforces its ``unique_key`` on
-    # write: the SELECT is expected to carry finer rows and the merge collapses
-    # them. That key is a CompileValue fact, not a declaration about the SELECT's
-    # own output, so the emitter must not judge it (the incremental-grain stream,
-    # issue #7, owns that write-path reasoning).
+@pytest.mark.parametrize(
+    ("channel", "fires"),
+    [
+        ("dbt_unique_test", True),
+        ("conditional_unique_test", False),
+        ("native_constraint", False),
+        ("incremental_unique_key", False),
+    ],
+)
+def test_declaration_channels_decide_what_is_judged(channel: str, fires: bool) -> None:
     _declare_order_lines_key()
+
+    extra_nodes: list[Node] = []
+    config: ModelConfig | None = None
+    constraints: tuple[ConstraintSpec, ...] = ()
+    if channel == "dbt_unique_test":
+        extra_nodes.append(_unique_test_node(where=None))
+    elif channel == "conditional_unique_test":
+        extra_nodes.append(_unique_test_node(where="order_id > 0"))
+    elif channel == "native_constraint":
+        constraints = (ConstraintSpec(type=ConstraintType.UNIQUE, columns=("order_id",)),)
+    elif channel == "incremental_unique_key":
+        config = ModelConfig(
+            materialized="incremental",
+            incremental_strategy="merge",
+            unique_key=("order_id",),
+        )
 
     fct = _node(
         "model.shop.fct_orders",
         sql="select order_id, line_number, amount from order_lines",
         columns=_LINE_COLS,
-        config=ModelConfig(
-            materialized="incremental",
-            incremental_strategy="merge",
-            unique_key=("order_id",),
-        ),
+        config=config,
+        constraints=constraints,
     )
-    report = run_check(_manifest(_ORDER_LINES, fct), _DUCKDB)
-    assert _grain_findings(report) == []
+    report = run_check(_manifest(_ORDER_LINES, fct, *extra_nodes), _DUCKDB)
+
+    findings = _grain_findings(report)
+    assert [f.model_unique_id for f in findings] == (["model.shop.fct_orders"] if fires else [])

--- a/tests/check/test_grain_not_established.py
+++ b/tests/check/test_grain_not_established.py
@@ -213,6 +213,37 @@ def test_a_declared_key_on_a_source_has_no_construction_to_judge() -> None:
     assert _grain_findings(report) == []
 
 
+# --- a collapse the walk cannot yet see: expected failure --------------------------
+
+
+@pytest.mark.xfail(strict=True, reason="the emitter needs the walk's exactness record")
+def test_correlated_subquery_collapse_is_not_yet_recognized() -> None:
+    # A correlated subquery picking each order's max line collapses the per-line
+    # relation to one row per order just as surely as a GROUP BY would, but the walk
+    # has no exactness record for this shape yet, so the finer key still looks like
+    # it survives. This pins the gap rather than hiding it.
+    _declare_order_lines_key()
+
+    class TopLine(ModelContract):
+        dbt_model = "top_line"
+
+        @contract
+        def one_row_per_order(self: ContractSelf) -> object:
+            return self.grain(per=self.order_id)
+
+    top_line = _node(
+        "model.shop.top_line",
+        sql=(
+            "select order_id, line_number, amount from order_lines "
+            "where line_number = (select max(x.line_number) from order_lines x "
+            "where x.order_id = order_lines.order_id)"
+        ),
+        columns=_LINE_COLS,
+    )
+    report = run_check(_manifest(_ORDER_LINES, top_line), _DUCKDB)
+    assert _grain_findings(report) == []
+
+
 # --- declaration channels: every case of the closed provenance type decided ---------
 #
 # The contract channel's fire case is the drift test above; the table here covers the
@@ -223,7 +254,8 @@ def test_a_declared_key_on_a_source_has_no_construction_to_judge() -> None:
 # warehouse's write path; the advisory-unenforced case is the unenforced-constraint
 # finding's (#48). A deduplicating incremental's ``unique_key`` is enforced by the merge
 # on write, so the SELECT is expected to carry finer rows (the incremental-grain
-# stream, #7).
+# stream, #7); a ``unique`` test riding on that same model is exempt too, since the
+# exemption is a property of the model's write path, not of which channel stated the key.
 
 
 def _unique_test_node(*, where: str | None) -> Node:
@@ -259,6 +291,14 @@ _CHANNELS = (
     _Channel(
         "incremental_unique_key",
         False,
+        config=ModelConfig(
+            materialized="incremental", incremental_strategy="merge", unique_key=("order_id",)
+        ),
+    ),
+    _Channel(
+        "incremental_unique_key_with_unique_test",
+        False,
+        test_node=_unique_test_node(where=None),
         config=ModelConfig(
             materialized="incremental", incremental_strategy="merge", unique_key=("order_id",)
         ),

--- a/tests/check/test_grain_not_established.py
+++ b/tests/check/test_grain_not_established.py
@@ -2,17 +2,11 @@
 # A contract method's ``self`` is a ContractSelf proxy at capture, not a real
 # instance; annotating it that way trips pyright's self-supertype rule while keeping
 # the proxy usage checked. Typed ``self`` in authored contracts is the stubs concern.
-"""Declaring a grain and running the real check over SQL that does or does not meet it.
+"""The grain check end to end, from a declared contract to the finding. The decision
+itself is checked against brute force in ``test_pbt_grain_established.py``.
 
-These follow a declared grain the whole way, from the contract a user writes to the
-finding that comes out, so they catch a break anywhere along that path. Whether the
-underlying decision is correct is settled separately, against brute force, in
-``test_pbt_grain_established.py``.
-
-The case worth protecting hardest is the first one. A declared key is merged into
-what we know about a model as soon as it is read, so an implementation that compares
-a declaration against the merged keys finds the declaration sitting there and reports
-nothing. That test fails against any such implementation.
+The first test is the one that matters most: an implementation that compares the
+declaration against the merged key set finds the declaration there and never fires.
 """
 
 from __future__ import annotations
@@ -43,8 +37,7 @@ _DUCKDB = profile_for_adapter("duckdb")
 
 _LINE_COLS = _cols(order_id="INT", line_number="INT", amount="DECIMAL")
 
-# A per-line leaf model: no FROM, so the relation walk infers nothing and its
-# declared compound key grounds it.
+# A per-line leaf model: no FROM, so only its declared compound key grounds it.
 _ORDER_LINES = _node(
     "model.shop.order_lines",
     sql="select 1 as order_id, 1 as line_number, 1.0 as amount",
@@ -70,10 +63,8 @@ def _grain_findings(report: CheckReport) -> list[CheckFinding]:
 
 def test_declared_grain_defeated_by_a_surviving_finer_key_is_a_finding() -> None:
     # fct_orders declares one row per order but selects from the per-line model
-    # without collapsing, so the finer key (order_id, line_number) survives to its
-    # output: the witnessed defeater, and the case an emitter reading the flow value
-    # would miss. The downstream consumer pins where the finding lands: at the model
-    # whose grain is unestablished, not at the sum that eventually trips over it.
+    # without collapsing. The consumer pins where the finding lands: at fct_orders,
+    # not at the sum downstream.
     _declare_order_lines_key()
 
     class FctOrders(ModelContract):
@@ -101,8 +92,7 @@ def test_declared_grain_defeated_by_a_surviving_finer_key_is_a_finding() -> None
     assert "not established" in message
     assert "order_id" in message
     assert "line_number" in message
-    # Honesty of grade: the construction fails to establish the grain; the data may
-    # still satisfy it, so the finding never claims a violation.
+    # The data may still satisfy the grain, so the finding never claims a violation.
     assert "violat" not in message.lower()
 
 
@@ -110,8 +100,7 @@ def test_declared_grain_defeated_by_a_surviving_finer_key_is_a_finding() -> None
 
 
 def test_a_collapse_to_the_declared_grain_is_established_and_silent() -> None:
-    # The same declaration over SQL that aggregates to the declared grain: the
-    # GROUP BY re-derives the key, so the entailment holds and nothing fires.
+    # The GROUP BY re-derives the declared key.
     _declare_order_lines_key()
 
     class FctOrders(ModelContract):
@@ -131,10 +120,8 @@ def test_a_collapse_to_the_declared_grain_is_established_and_silent() -> None:
 
 
 def test_coverage_runs_through_the_fd_closure() -> None:
-    # The surviving key is (order_id, region), strictly finer than the declared
-    # grain (order_id); but a declared ``order_id determines region`` closes the
-    # gap: unique on (order_id, region) plus the dependency is unique on (order_id),
-    # so the grain is established and nothing fires.
+    # The derived key is (order_id, region); the declared ``order_id -> region``
+    # closes it to (order_id).
     class OrderRegions(ModelContract):
         dbt_model = "order_regions"
 
@@ -171,10 +158,8 @@ def test_coverage_runs_through_the_fd_closure() -> None:
 
 
 def test_absence_of_any_inferred_key_is_not_a_witness() -> None:
-    # The upstream relation declares no key, so the walk infers nothing for
-    # fct_orders: the declared grain is neither re-derived nor defeated. Firing here
-    # would flag every model whose upstream declares nothing; the emitter must
-    # require a witnessed defeater, not an absent proof.
+    # No upstream key, so nothing is derived for fct_orders: neither established
+    # nor defeated. Firing here would flag every model whose upstream declares nothing.
     class FctOrders(ModelContract):
         dbt_model = "fct_orders"
 
@@ -192,11 +177,8 @@ def test_absence_of_any_inferred_key_is_not_a_witness() -> None:
 
 
 def test_a_declared_key_on_a_source_has_no_construction_to_judge() -> None:
-    # A source carries no SQL of its own, so the walk derives nothing for it and it
-    # is absent from the record entirely. There is no entailment to judge, and the
-    # emitter has to pass over it rather than reach for a value never recorded. A
-    # ``unique`` test on a source is ordinary in a dbt project, so this is the shape
-    # that would crash a whole run.
+    # A source has no SQL, so it is absent from the derived record. A ``unique`` test
+    # on a source is ordinary, so this shape must not crash the run.
     orders = _source("source.shop.raw.orders", columns=_cols(order_id="INT", amount="DECIMAL"))
     unique_test = _node(
         "test.shop.unique_orders_order_id",
@@ -218,10 +200,8 @@ def test_a_declared_key_on_a_source_has_no_construction_to_judge() -> None:
 
 @pytest.mark.xfail(strict=True, reason="the emitter needs the walk's exactness record")
 def test_correlated_subquery_collapse_is_not_yet_recognized() -> None:
-    # A correlated subquery picking each order's max line collapses the per-line
-    # relation to one row per order just as surely as a GROUP BY would, but the walk
-    # has no exactness record for this shape yet, so the finer key still looks like
-    # it survives. This pins the gap rather than hiding it.
+    # The correlated subquery collapses to one row per order, but the derivation is
+    # not exact for this shape, so the finer key still appears to survive.
     _declare_order_lines_key()
 
     class TopLine(ModelContract):
@@ -246,16 +226,11 @@ def test_correlated_subquery_collapse_is_not_yet_recognized() -> None:
 
 # --- declaration channels: every case of the closed provenance type decided ---------
 #
-# The contract channel's fire case is the drift test above; the table here covers the
-# rest. A dbt ``unique`` test is judged like a contract grain (provenance carries no
-# authority ordering), and it is the only other channel that fires. A ``where``-filtered
-# test claims uniqueness only over a row filter, so it is activation's business, not a
-# grain claim about the whole output. A native constraint is discharged (or not) by the
-# warehouse's write path; the advisory-unenforced case is the unenforced-constraint
-# finding's (#48). A deduplicating incremental's ``unique_key`` is enforced by the merge
-# on write, so the SELECT is expected to carry finer rows (the incremental-grain
-# stream, #7); a ``unique`` test riding on that same model is exempt too, since the
-# exemption is a property of the model's write path, not of which channel stated the key.
+# The contract channel fires in the first test; this table covers the rest. A dbt
+# ``unique`` test is judged like a contract grain. A ``where``-filtered test is a claim
+# over a row filter, owned by activation. A native constraint is the warehouse's to
+# enforce (#48). A deduplicating incremental's ``unique_key`` is enforced on write (#7),
+# and so is any other key declared on that model.
 
 
 def _unique_test_node(*, where: str | None) -> Node:

--- a/tests/check/test_pbt_grain_established.py
+++ b/tests/check/test_pbt_grain_established.py
@@ -83,9 +83,13 @@ def test_established_implies_uniqueness_on_the_declared_grain(
 # --- the edges the closure marks, pinned as counterexamples -------------------------
 
 
-def test_fd_closure_is_what_licenses_coverage() -> None:
-    # unique on (a, b) plus a -> b entails unique on (a); without the dependency the
-    # same key entails nothing about (a) (two rows (1, 1) and (1, 2) separate them).
+def test_coverage_is_containment_through_the_closure_not_an_exact_match() -> None:
+    # A key within the declared columns covers them: unique on (a) is unique on
+    # (a, b), so a non-minimal declaration is established.
+    assert grain_established(frozenset({"a", "b"}), frozenset({frozenset({"a"})}), FDSet.of())
+    # The closure extends that reach: unique on (a, b) plus a -> b entails unique on
+    # (a), where without the dependency the same key entails nothing about (a) (two
+    # rows (1, 1) and (1, 2) separate them).
     grain = frozenset({"a"})
     inferred = frozenset({frozenset({"a", "b"})})
     assert grain_established(grain, inferred, FDSet.of(FD(frozenset({"a"}), "b")))

--- a/tests/check/test_pbt_grain_established.py
+++ b/tests/check/test_pbt_grain_established.py
@@ -1,0 +1,110 @@
+"""Soundness PBT for the grain-established decision procedure.
+
+``grain_established`` claims an entailment: a relation unique on each inferred key
+and satisfying the given functional dependencies is unique on the declared grain.
+The property checks that claim against brute force. Generate a small relation, hand
+the decision only claims the relation actually satisfies (its true uniqueness sets
+and true dependencies, any subset of them), and require that whenever the decision
+answers "established" the relation is in fact unique on the declared columns. The
+decision may be conservative (a False on a relation that happens to be unique is
+fine); it must never be credulous.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from dblect.check.grain import grain_established, grain_witness
+from dblect.lineage.properties.functional_dependency import FD, FDSet
+
+_COLS = ("c0", "c1", "c2", "c3")
+
+_ROWS = st.lists(
+    st.tuples(*(st.integers(0, 2) for _ in _COLS)),
+    min_size=0,
+    max_size=6,
+)
+
+_INDEX_SUBSETS: tuple[tuple[int, ...], ...] = tuple(
+    subset for n in range(1, len(_COLS) + 1) for subset in combinations(range(len(_COLS)), n)
+)
+
+
+def _unique_on(relation: list[tuple[int, ...]], cols: tuple[int, ...]) -> bool:
+    projected = [tuple(row[i] for i in cols) for row in relation]
+    return len(projected) == len(set(projected))
+
+
+def _satisfies_fd(relation: list[tuple[int, ...]], det: tuple[int, ...], target: int) -> bool:
+    seen: dict[tuple[int, ...], int] = {}
+    for row in relation:
+        key = tuple(row[i] for i in det)
+        if key in seen and seen[key] != row[target]:
+            return False
+        seen.setdefault(key, row[target])
+    return True
+
+
+def _names(indices: tuple[int, ...]) -> frozenset[str]:
+    return frozenset(_COLS[i] for i in indices)
+
+
+@given(_ROWS, st.data())
+def test_established_implies_uniqueness_on_the_declared_grain(
+    relation: list[tuple[int, ...]], data: st.DataObject
+) -> None:
+    true_keys = [s for s in _INDEX_SUBSETS if _unique_on(relation, s)]
+    true_fds = [
+        (det, target)
+        for det in _INDEX_SUBSETS
+        for target in range(len(_COLS))
+        if target not in det and _satisfies_fd(relation, det, target)
+    ]
+    claimed_keys = (
+        data.draw(st.lists(st.sampled_from(true_keys), max_size=4), label="keys")
+        if true_keys
+        else []
+    )
+    claimed_fds = (
+        data.draw(st.lists(st.sampled_from(true_fds), max_size=4), label="fds")
+        if true_fds
+        else []
+    )
+    grain = data.draw(st.sampled_from(_INDEX_SUBSETS), label="grain")
+
+    inferred = frozenset(_names(k) for k in claimed_keys)
+    fds = FDSet.of(*(FD(_names(det), _COLS[target]) for det, target in claimed_fds))
+
+    if grain_established(_names(grain), inferred, fds):
+        assert _unique_on(relation, grain)
+
+
+# --- the edges the closure marks, pinned as counterexamples -------------------------
+
+
+def test_fd_closure_is_what_licenses_coverage() -> None:
+    # unique on (a, b) plus a -> b entails unique on (a); without the dependency the
+    # same key entails nothing about (a) (two rows (1, 1) and (1, 2) separate them).
+    grain = frozenset({"a"})
+    inferred = frozenset({frozenset({"a", "b"})})
+    assert grain_established(grain, inferred, FDSet.of(FD(frozenset({"a"}), "b")))
+    assert not grain_established(grain, inferred, FDSet.of())
+
+
+def test_no_inferred_key_never_establishes() -> None:
+    # FDs alone say nothing about row multiplicity: a -> b holds on a relation with
+    # duplicate (a, b) rows, so with no uniqueness claim at all nothing establishes.
+    grain = frozenset({"a"})
+    assert not grain_established(grain, frozenset(), FDSet.of(FD(frozenset({"a"}), "b")))
+
+
+def test_witness_requires_a_strictly_finer_key() -> None:
+    # (a, b) defeats a declared grain (a); a disjoint key (c) says nothing about
+    # rows per (a) and must not witness. The witness is the smallest finer key.
+    fine = frozenset({"a", "b"})
+    assert grain_witness(frozenset({"a"}), frozenset({fine})) == fine
+    assert grain_witness(frozenset({"a"}), frozenset({frozenset({"c"})})) is None
+    assert grain_witness(frozenset({"a"}), frozenset({frozenset({"a"})})) is None

--- a/tests/check/test_pbt_grain_established.py
+++ b/tests/check/test_pbt_grain_established.py
@@ -1,13 +1,14 @@
-"""Soundness PBT for the grain-established decision procedure.
+"""Checking the grain decision against brute force over small tables.
 
-``grain_established`` claims an entailment: a relation unique on each inferred key
-and satisfying the given functional dependencies is unique on the declared grain.
-The property checks that claim against brute force. Generate a small relation, hand
-the decision only claims the relation actually satisfies (its true uniqueness sets
-and true dependencies, any subset of them), and require that whenever the decision
-answers "established" the relation is in fact unique on the declared columns. The
-decision may be conservative (a False on a relation that happens to be unique is
-fine); it must never be credulous.
+``grain_established`` answers "given these keys and dependencies, is the table
+guaranteed unique on the declared columns?" Here we build an actual small table,
+work out which keys and dependencies genuinely hold over its rows, hand the decision
+some of those true facts, and require that any time it answers yes, the table really
+is unique on the declared columns.
+
+Only that direction is a bug. Answering no about a table that happens to be unique
+costs a missed finding; answering yes about one that is not would let a wrong grain
+through, which is what these rule out.
 """
 
 from __future__ import annotations

--- a/tests/check/test_pbt_grain_established.py
+++ b/tests/check/test_pbt_grain_established.py
@@ -69,9 +69,7 @@ def test_established_implies_uniqueness_on_the_declared_grain(
         else []
     )
     claimed_fds = (
-        data.draw(st.lists(st.sampled_from(true_fds), max_size=4), label="fds")
-        if true_fds
-        else []
+        data.draw(st.lists(st.sampled_from(true_fds), max_size=4), label="fds") if true_fds else []
     )
     grain = data.draw(st.sampled_from(_INDEX_SUBSETS), label="grain")
 

--- a/tests/lineage/test_propagator.py
+++ b/tests/lineage/test_propagator.py
@@ -228,6 +228,44 @@ def test_reconcile_by_meet_composes_declared_and_inferred_without_conflict() -> 
     assert not anns[out].provisional
 
 
+def test_inferred_sink_records_the_pre_reconcile_value_beside_the_flow() -> None:
+    """The pre-reconcile record (``refutation-and-verdicts.md``): under
+    ``reconcile_by_meet`` the flow value folds the declaration in, so the value the
+    SQL actually derived is otherwise discarded, and a declaration would check
+    itself. The sink must hold the inferred value as derived, distinct from the
+    reconciled flow value."""
+    graph = build_model_graph(
+        model_uid="model.test.m",
+        sql="SELECT u.id FROM users u",
+        name_to_source={"users": _src("users")},
+        schema={"users": {"id": "INT"}},
+    )
+    leaf = ColumnRef(_src("users"), "id")
+    out = ColumnRef(_model(), "id")
+    ground = _concrete_for({leaf: frozenset({1, 2}), out: frozenset({0, 1})})
+    inferred: dict[ColumnRef, Annotation[_Set]] = {}
+    anns = propagate(graph, _subset_prop(ground, reconcile_by_meet=True), inferred_sink=inferred)
+    assert anns[out].value == frozenset({1})
+    assert inferred[out].value == frozenset({1, 2})
+
+
+def test_inferred_sink_covers_only_derived_subjects() -> None:
+    """A leaf has no derivation, so there is no entailment to record: the sink holds
+    the derived subject and not the leaf."""
+    graph = build_model_graph(
+        model_uid="model.test.m",
+        sql="SELECT u.id FROM users u",
+        name_to_source={"users": _src("users")},
+        schema={"users": {"id": "INT"}},
+    )
+    leaf = ColumnRef(_src("users"), "id")
+    out = ColumnRef(_model(), "id")
+    inferred: dict[ColumnRef, Annotation[_Set]] = {}
+    propagate(graph, _subset_prop(_concrete_for({})), inferred_sink=inferred)
+    assert out in inferred
+    assert leaf not in inferred
+
+
 def test_opaque_inferred_keeps_grounded_without_a_taint() -> None:
     """When the SQL reveals nothing (inferred top), the grounded value stands and
     is not tainted."""


### PR DESCRIPTION
## What this does

A user can declare a model's grain: "fct_orders has one row per order_id" (via `grain(per=...)`, `self.key(...)`, or a dbt `unique` test). Until now dblect only ever *consumed* that declaration — it trusted it to clear downstream findings — and never asked whether the model's SQL actually produces one row per order. A model that selects from a per-line-item table without aggregating claims order grain while producing line grain, and nothing catches it until some downstream sum double counts.

This PR adds that check. When a model declares a grain its own SQL visibly fails to produce, `dblect check` reports a new finding, `GRAIN_NOT_ESTABLISHED`, at that model:

> declared grain (order_id) is not established: the construction carries the strictly finer key (line_number, order_id) to the output with no collapse to the declared grain.

## The internal change that makes it possible

For each model, dblect knows keys from two sources: what the user **declared**, and what it can **derive** from the SQL (a GROUP BY produces a key, a join can destroy one, and so on). Previously the two were merged into one set the moment they met, and only the merged set was kept. That made this check impossible to write: the declared key is always in the merged set, so asking "does the merged set contain the declared key?" always answers yes — the declaration would be checking itself.

The fix is to also keep the derived-only set instead of throwing it away (a small change in the propagation engine). Everything downstream still uses the merged set, so declarations are still trusted everywhere they were before; the new check is the one place that looks at the derived-only set and asks: did the SQL earn this declaration on its own?

## When it fires, and when it stays quiet

dblect's key derivation is deliberately conservative: SQL it can't fully analyze yields *no* keys rather than wrong ones. So "the declared key isn't in the derived set" is weak evidence — it usually just means the analysis couldn't see enough. Firing on that would flag half of every real project.

The finding therefore requires positive evidence, in both directions:

- **Quiet because proven**: the SQL derives the declared grain (it groups by `order_id`, or the derived keys plus a declared functional dependency like `order_id determines region` add up to it). Also quiet when the declared grain is coarser than needed — unique per order implies unique per (order, line).
- **Fires**: a *finer* key demonstrably survives to the output — the model is keyed by (order_id, line_number) and nothing collapses it to (order_id). That's a concrete "here is where your grain claim goes wrong."
- **Quiet because unknown**: no derived keys, or derived keys that say nothing about rows-per-order (a key on `line_id` doesn't tell us an order has multiple lines). No evidence, no finding.

Even when it fires, the wording is "not established", not "violated", and severity is warn: the SQL doesn't guarantee the grain, but the data may still satisfy it (every order might happen to have exactly one line). Statically we can prove the guarantee is missing, not that the data is bad. This vocabulary comes from `docs/design/refutation-and-verdicts.md`.

Two kinds of declared keys are deliberately *not* checked this way: native warehouse constraints (the warehouse enforces those at write time, and the unenforced-advisory case is #48's territory) and an incremental model's `unique_key` under a merge strategy (there the SELECT is *supposed* to produce finer rows; the merge dedups on write — #7's territory).

## Tests

Written before the implementation, then verified to bite by breaking the code three ways (reading the merged set instead of the derived one, firing without evidence, skipping the functional-dependency reasoning) and confirming a test fails for each:

- End-to-end tests through `run_check` for each fire/quiet case above, including one per declaration channel.
- A property-based test that brute-forces small relations: whenever the decision procedure says "established", the relation really is unique on the declared columns.
- Engine-level tests that the derived-only record is kept and differs from the merged value.

## Follow-ups (the 0.2 arc)

- The functional-dependency version of this check reuses the same machinery (#202's second half).
- The nullability version (#227) reads the same record.
- Findings currently carry no source line (there's no single operator to point at yet), so they aren't line-noqa-suppressible; anchoring them is a recorded open question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAE4C5m7unT2uPjd1XthjN
