### PR TITLE
docs: rewrite lineage and check prose for a reader without the design docs

### DIFF
--- a/src/dblect/check/coverage.py
+++ b/src/dblect/check/coverage.py
@@ -2,19 +2,19 @@
 opposite things.
 
 **Resolution coverage** is the fraction of model output columns whose lineage the
-propagator could follow against the fraction it fell blind on (a column reading a
-reference qualify could not attach a source to, an unexpanded ``SELECT *``, a
+propagator could follow, against the fraction it fell blind on (a column whose
+reference sqlglot could not attach to a source, an unexpanded ``SELECT *``, a
 macro that escaped rendering). Counting model output columns rather than every
 reference in every nested scope keeps a deep CTE chain from inflating the
 denominator. Blindness is a capability gap, so a configurable floor turns
 sustained blindness into a finding, and the floor keys on resolution only.
 
-**Grounding coverage** is, among resolved columns, how many a fact grounded,
-reported per property. An ungrounded column is the expected case under "absence
-is silence", not a defect, so grounding never trips a floor on its own. Where it
-earns attention is scoped to declared intent: of the columns a contract names,
-how many resolved to a checkable annotation, which tells a partial adopter
-whether their declarations are actually being checked.
+**Grounding coverage** is, among resolved columns, how many a declared fact
+actually set a value for, reported per property. A column with no fact touching it
+is the expected, unremarkable case, not a defect, so grounding never trips a floor
+on its own. Where it earns attention is scoped to declared intent: of the columns
+a contract names, how many resolved to a checkable annotation, which tells a
+partial adopter whether their declarations are actually being checked.
 
 See ``docs/design/lineage-facts.md`` ("Coverage and degradation").
 """
@@ -112,9 +112,11 @@ class WorldCoverage:
     assumption that a clean report covers every configuration.
 
     Per-contract attribution (which worlds each contract was actually checked under)
-    awaits the flag-influence cone. Until it exists every enumerated contract is
-    checked under every enumerated world, so the honest report is the global count
-    and the axes swept, not a per-contract claim the analysis cannot yet back."""
+    needs dblect to first work out which flags can actually change a given
+    contract's outcome, as opposed to flags that never reach it. Until that exists,
+    every enumerated contract is checked under every enumerated world, so the
+    honest report is the global count and the axes swept, not a per-contract claim
+    the analysis cannot yet back."""
 
     worlds_enumerated: int
     axes_enumerated: tuple[str, ...]

--- a/src/dblect/check/flags.py
+++ b/src/dblect/check/flags.py
@@ -1,20 +1,20 @@
-"""The flag-world bridge: a hand-declared flag becomes per-world compile facts.
+"""Turning a hand-declared flag into the per-world facts the checker enumerates over.
 
-A :class:`DomainFlag` is the hand-authored form of a compile-time flag: its name, the
-domain of values to enumerate, and, per value, the fully-refined domain type the
-scopes it governs take in that world. The bridge lowers it to the ``CompileFact``\\ s
-the enumerator already consumes, so a project gets a cross-world finding from a flag
-declared by hand, ahead of the var-inference layer that will discover and scaffold
-flags automatically.
+A :class:`DomainFlag` is how a user tells dblect about a dbt var (or similar
+compile-time flag) that changes a column's domain type depending on its value: the
+flag's name, the values it can take, and for each value, the type the columns it
+governs should carry when that value is set. This module lowers a flag into the
+``CompileFact``\\ s the world enumerator already consumes, one set per value, so a
+project gets a cross-configuration finding from a flag declared by hand, ahead of
+future work that discovers such flags automatically from ``var()`` usage.
 
-Responsiveness (which scopes a flag grounds) is declared directly on the flag for
-now. The design's model-responsiveness rule infers it from per-model var usage, which
-var-inference produces; until then a hand-declared flag names its responsive scopes,
-and the bridge runs unchanged once that inference replaces the hand-declaration.
+Which columns a flag governs is named directly on the flag for now (``scopes``); a
+later pass is meant to infer that from which models actually read the flag's var,
+and this module will not need to change when that lands.
 
-The world the bridge fixes makes each fact concrete: a flag value is ground truth in
-exactly its world, so the fact is a single point, never a disjunction. The
-disjunction across values lives in the enumeration over worlds, never in a fact.
+Each world fixes one value per flag, so the fact this module produces for a world
+is always a single concrete type, never "one of these values." The uncertainty
+across values lives in having several worlds, not in any one fact.
 """
 
 from __future__ import annotations
@@ -32,11 +32,11 @@ from dblect.types import DomainType, domain_tag
 
 @dataclass(frozen=True, slots=True)
 class DomainFlag:
-    """A hand-authored compile-time flag.
+    """A hand-declared compile-time flag.
 
-    ``affects`` maps each value in the flag's domain to the fully-refined domain type
-    the responsive scopes take when the flag holds that value. ``scopes`` are the
-    columns the flag governs (its declared responsiveness)."""
+    ``affects`` maps each value the flag can take to the domain type its columns
+    should carry when the flag holds that value. ``scopes`` are the columns the
+    flag governs."""
 
     name: str
     affects: Mapping[Hashable, type[DomainType]]
@@ -44,8 +44,8 @@ class DomainFlag:
 
 
 def lower_flag(flag: DomainFlag, value: Hashable, world: WorldRef) -> list[TagCompileFact]:
-    """The compile facts a flag grounds at one value, in one world: the domain tag the
-    value's refined type carries, placed at each responsive scope. A scope whose type
+    """The compile facts one flag value implies, in one world: the domain tag the
+    value's type carries, placed at each scope the flag governs. A scope whose type
     carries no magnitude (nothing to tag) is skipped."""
     spec = flag.affects[value].spec()
     provenance = CompileValue(origin=CompileOrigin.DBT_VAR, world=world)
@@ -58,10 +58,10 @@ def lower_flag(flag: DomainFlag, value: Hashable, world: WorldRef) -> list[TagCo
 
 
 def flag_worlds(flags: Sequence[DomainFlag]) -> dict[WorldRef, tuple[CompileFact, ...]]:
-    """The worlds the flags induce: the product of their domains, each world carrying
-    the compile facts its assignment grounds. With no flags this is the single base
-    world (an empty assignment, no facts), so the enumeration degrades to the
-    single-world check."""
+    """The worlds the flags induce: one world per combination of flag values, each
+    carrying the compile facts that combination produces. With no flags this is just
+    the single base world (empty assignment, no facts), so the enumeration degrades
+    to the single-world check."""
     worlds: dict[WorldRef, tuple[CompileFact, ...]] = {}
     for combo in product(*(tuple(flag.affects) for flag in flags)):
         assignment = tuple(zip(flags, combo, strict=True))

--- a/src/dblect/check/incremental.py
+++ b/src/dblect/check/incremental.py
@@ -1,14 +1,18 @@
-"""Check a project across its incremental worlds: compile both ways, run the
-project's detectors over each, and difference the findings.
+"""Check a project both ways an incremental dbt model can compile, and diff the
+findings.
 
-These are control-flow worlds, so each is built independently from its own manifest
-(the shared-build enumerator in :mod:`dblect.check.worlds` serves value-substitution
-worlds, where the SQL is identical). Each world's findings come through the single
-analysis door, :func:`dblect.analysis.analyze`, so both detector families are present
-by construction rather than by this module remembering to call each. Because the SQL
-differs, a finding's message and line span drift between worlds even when the issue is
-the same, so the diff keys on a stable :data:`~dblect.analysis.FindingIdentity` rather
-than whole-finding equality. Issue #107 weighs unifying the finding representations.
+A ``{% if is_incremental() %}`` block means a model's SQL can be genuinely
+different text on a full refresh versus a steady-state incremental run, not just
+the same SQL with a different value substituted in (that case is what
+:mod:`dblect.check.worlds` handles, and each of its worlds is built independently
+from its own manifest). This module compiles the project both ways and runs every
+detector over each compile through the one shared entry point,
+:func:`dblect.analysis.analyze`, so both detector families are present by
+construction rather than by this module remembering to call each. Because the SQL
+text differs between the two compiles, a finding's message and line span can drift
+even when it is the same underlying issue, so the diff matches on the stable
+:data:`~dblect.analysis.FindingIdentity` rather than comparing findings for exact
+equality. Issue #107 weighs unifying the finding representations.
 """
 
 from __future__ import annotations
@@ -30,12 +34,13 @@ from dblect.types import ContractRegistry
 
 @dataclass(frozen=True, slots=True)
 class CrossWorldFinding:
-    """A finding that holds in a strict subset of the analyzed worlds.
+    """A finding that holds in some of the checked worlds but not all of them (for
+    example, only on a full refresh, not on steady state).
 
     ``worlds`` are the worlds the finding holds under, and ``representative`` is one
     world's instance of it for display (the message and span are that world's). A
-    finding present in every analyzed world is world-invariant and is not a
-    ``CrossWorldFinding``; the single-manifest analysis already reports it.
+    finding present in every checked world is not a ``CrossWorldFinding``; the
+    ordinary single-manifest analysis already reports it.
     """
 
     identity: FindingIdentity
@@ -46,7 +51,7 @@ class CrossWorldFinding:
 def cross_world_findings(
     per_world: Mapping[WorldRef, Sequence[AnalysisFinding]],
 ) -> tuple[CrossWorldFinding, ...]:
-    """The findings holding in a strict subset of ``per_world``'s worlds.
+    """The findings that hold in some of ``per_world``'s worlds but not all of them.
 
     Findings are grouped by :func:`~dblect.analysis.cross_world_identity` so a message
     or line span that drifts between the two compiled SQLs is not mistaken for a
@@ -106,7 +111,8 @@ def check_incremental_worlds(
     registry: ContractRegistry | None = None,
     dbt_executable: str = "dbt",
 ) -> IncrementalWorldCheck:
-    """Compile ``project_dir`` into its incremental worlds and check each.
+    """Compile ``project_dir`` both ways an incremental model can build (full
+    refresh and steady state) and check each.
 
     ``profile`` is the resolved target whose dialect parses every model, and
     ``registry`` the contracts to resolve (defaulting to the active one), the same

--- a/src/dblect/check/worlds.py
+++ b/src/dblect/check/worlds.py
@@ -1,23 +1,25 @@
 """The fact-level world enumerator: one shared build, many worlds.
 
-A world is a set of ``CompileValue`` facts layered on top of the manifest's declared
-facts. The enumerator holds one ``CheckGraphs`` build and, for each world, grounds
-that world's facts over the shared graph and re-propagates, collecting the findings
-keyed by the world they hold under. This is the design's "shared walk, only the
-leaves vary": the declared facts and the graph are shared, the compile facts are the
-per-world leaves.
+A world is a set of ``CompileValue`` facts (say, one value a dbt var could take)
+layered on top of the manifest's declared facts. The enumerator builds the lineage
+graphs once and, for each world, grounds that world's facts over the shared graph
+and re-propagates, collecting the findings keyed by the world they hold under. The
+graph and the declared facts are shared across worlds; only each world's own facts
+change.
 
-It covers value-substitution worlds, where the SQL is identical across worlds and
-only the grounded values differ. Control-flow worlds, where the SQL itself changes,
-need graph patching or the variability-aware front end and are out of scope here.
+It covers worlds where the SQL text is identical and only a substituted value
+differs. A world where the SQL itself branches, such as a dbt incremental model's
+full-refresh versus steady-state compile, needs a different mechanism (see
+:mod:`dblect.check.incremental`) and is out of scope here.
 
-A finding present in some worlds and absent in others is data, not an error: that is
-exactly the "holds under world A, fails under world B" signal the analysis exists to
-surface. The enumerator never raises on disagreement.
+A finding present in some worlds and absent in others is exactly the signal this
+analysis exists to surface: the issue holds under one configuration and not
+another. The enumerator reports that as data and never raises on the disagreement.
 
-The enumerator does not cache annotations across worlds. Sharing propagation work
-across worlds is the lifted-representation optimization the design defers to the
-factoring stream; doing it here would couple worlds that must stay independent.
+The enumerator re-propagates from scratch for every world rather than reusing work
+across them. Sharing propagation results across worlds is a real optimization for
+later, deferred because doing it now would let worlds that must stay independent
+leak into each other.
 """
 
 from __future__ import annotations
@@ -42,14 +44,16 @@ from dblect.lineage.properties.functional_dependency import FDSet
 
 @dataclass(frozen=True, slots=True)
 class TagCompileFact:
-    """A per-world domain-type fact (a refinement axis the flag layer sets)."""
+    """A per-world fact about a column's domain type: what a flag value pins the
+    column's type to in that world."""
 
     fact: Fact[DomainTag, ColumnRef]
 
 
 @dataclass(frozen=True, slots=True)
 class FdCompileFact:
-    """A per-world functional-dependency fact (a key the flag layer grounds)."""
+    """A per-world fact about a relation's functional-dependency key: what a flag
+    value pins the key to in that world."""
 
     fact: Fact[FDSet, SourceRef]
 
@@ -80,9 +84,9 @@ class EnumeratedFindings:
         return WorldCoverage.over(result.world for result in self.per_world)
 
     def by_finding(self) -> Mapping[CheckFinding, frozenset[WorldRef]]:
-        """Each finding mapped to the worlds it holds under. A finding whose world
-        set is a strict subset of the enumerated worlds is the cross-world signal: it
-        failed in those worlds and held in the rest."""
+        """Each finding mapped to the worlds it fired in. When that set is a strict
+        subset of all enumerated worlds, that's the cross-world signal: whatever the
+        finding flags broke in those worlds while working fine in the rest."""
         out: dict[CheckFinding, set[WorldRef]] = {}
         for result in self.per_world:
             for finding in result.findings:
@@ -114,8 +118,9 @@ def enumerate_worlds(
     order, so a caller that passes an ordered mapping gets a deterministic report.
 
     A world carrying no compile facts (``BASE_WORLD`` mapped to ``()``) reproduces
-    ``run_check``'s world-varying findings, which makes base-world identity the
-    enumerator's anchoring contract."""
+    ``run_check``'s world-varying findings exactly; keeping that agreement is what
+    verifies the enumerator has not drifted from the single-world check it
+    generalizes."""
     results: list[WorldResult] = []
     for world, compile_facts in world_facts.items():
         annotations = propagate_world(graphs, _world_facts(graphs, world, compile_facts))

--- a/src/dblect/lineage/builder.py
+++ b/src/dblect/lineage/builder.py
@@ -732,8 +732,8 @@ class _Walker:
     def _aggregation_input(self, sel: exp.Select, scope: Scope) -> SourceRef | None:
         """The one relation the scope aggregates over: a join-free FROM of a single
         resolvable table (a manifest relation, or a CTE/derived table's synthetic
-        ref). ``None`` closes the guard's dependency read, since the FD property
-        has no scope to answer for."""
+        ref). ``None`` means there is no relation to check a companion column's
+        functional dependency against, so the guard can't discharge it that way."""
         if sg.joins_of(sel):
             return None
         from_ = sg.from_of(sel)
@@ -993,7 +993,7 @@ def build_name_to_source(manifest: Manifest) -> Mapping[str, SourceRef]:
 
     Includes models (by ``name``), sources (by ``identifier or name`` since
     dbt compiles ``{{ source(...) }}`` to ``identifier``), and seeds. On a
-    name collision, models win — matching the convention that ``ref('x')``
+    name collision, models win, matching the convention that ``ref('x')``
     refers to a model named ``x`` over a source that happens to share it.
 
     This is the single owner of the compiled-SQL name resolution convention. The

--- a/src/dblect/lineage/facts/__init__.py
+++ b/src/dblect/lineage/facts/__init__.py
@@ -1,11 +1,13 @@
-"""The facts substrate: declarations become grounded values that enter the
-property walk, under one soundness contract.
+"""Turns what a user declared, a dbt test, a schema.yml contract, a Python
+``SemanticType``, into the values dblect's propagator checks the SQL against.
 
-The design is in ``docs/design/lineage-facts.md`` and the full type surface in
-``docs/design/lineage-facts-types.md``. A :class:`Fact` is a typed,
-provenance-carrying claim about one column or one relation; a property's
-:class:`Lattice` resolves several facts at a node into the :class:`Annotation`
-the propagator reads at leaves and checks at derived nodes.
+A :class:`Fact` is one such declaration, addressed to a column or a relation
+and tagged with where it came from. A property's :class:`Lattice` resolves
+every fact at a node down to one :class:`Annotation`, which the propagator
+reads at the leaves of the lineage graph and checks again at every node
+derived from them. See ``docs/design/lineage-facts.md`` (and
+``docs/design/lineage-facts-types.md`` for the full type surface) for the
+theory.
 """
 
 from dblect.lineage.facts.grounding import (

--- a/src/dblect/lineage/facts/grounding.py
+++ b/src/dblect/lineage/facts/grounding.py
@@ -1,11 +1,12 @@
-"""Turning declarations into grounded annotations: collection, grounding, and
-the typed/untyped seam combine.
+"""Resolving what a user declared into what dblect actually knows about a
+column or relation.
 
 ``collect`` runs the discoverers and buckets their facts by scope; ``grounding``
-folds each bucket through ``resolve`` into the per-node grounded annotation
-(EXPLICIT for an opt-out, CONCRETE for a resolved value, IMPLICIT otherwise);
-``combine`` is the binary seam rule that decides whether a cleared refinement
-speaks. The errors are a small sealed set so a caller can react to each.
+folds each bucket into one value per scope: CONCRETE for a resolved value,
+EXPLICIT for a declared opt-out, IMPLICIT when nothing was declared at all;
+``combine`` is the rule for two such values meeting at an expression: it
+decides whether an unresolved side warns or stays quiet. The errors below are
+a small, closed set so a caller can react to each.
 """
 
 from __future__ import annotations
@@ -51,8 +52,9 @@ class FactConflictError(Exception):
 
 
 class SeamContradictionError(Exception):
-    """Raised by ``combine`` when two committed, incompatible operands meet at a
-    scalar expression. It becomes a finding at the combine site."""
+    """Raised by ``combine`` when two concrete values meeting at the same
+    expression disagree, so there is no value both sides could be right about.
+    Surfaces as a finding at that expression."""
 
     def __init__(self, a: Annotation[Any], b: Annotation[Any]) -> None:
         self.a = a
@@ -95,24 +97,23 @@ def _ground(
     opaque: Collection[S],
     lat: Lattice[K],
 ) -> dict[S, Annotation[K]]:
-    """The fold itself: the explicit map from scope to grounded annotation, with
-    no IMPLICIT-top default applied. The single home for "what grounds", shared by
-    ``grounding`` (which wraps it in the default-filling lookup) and
-    ``grounded_scopes`` (which reads back which scopes a fact actually grounded).
+    """Build the scope-to-annotation map, with no default filled in for a scope
+    that has nothing recorded. ``grounding`` wraps this in the "nothing
+    declared" default, and ``grounded_scopes`` reads it back to report which
+    scopes actually came from a fact; both stay in sync because they share
+    this one fold.
 
-    An opaque scope grounds ``Annotation(top, EXPLICIT)`` regardless of any facts
-    present (an opt-out is consulted before facts). A scope whose bucket resolves
-    grounds ``Annotation(value, CONCRETE)``.
+    A scope opted out of refinement always maps to top, tagged EXPLICIT, no
+    matter what facts exist for it. Otherwise, a scope's facts that hold
+    unconditionally (``condition is None``) resolve to one value, tagged
+    CONCRETE. A fact scoped to a row filter is skipped here rather than
+    applied everywhere, since that would claim more than it proved; if only
+    such facts exist for a scope, the scope is left out of the map, exactly as
+    if nothing were declared, though the facts themselves are kept for later
+    filter-matching to use.
 
-    Conditional facts (those carrying a ``condition``) are excluded from the fold:
-    they hold only over a row filter, so grounding them unconditionally would
-    over-claim. A scope whose only facts are conditional is absent from the map,
-    so it falls to the IMPLICIT-top default exactly as if nothing were declared;
-    the facts stay captured in the bucket for an activation step to consume.
-
-    A bucket that resolves to ``bottom`` is a contradiction and raises
-    ``FactConflictError`` here, at build time, rather than swallowing it; recovery
-    is a propagator concern that lands with the findings layer.
+    Facts that cannot be reconciled to one value raise ``FactConflictError``
+    here, at build time, instead of silently picking an answer.
     """
     opaque_set = set(opaque)
     grounded: dict[S, Annotation[K]] = {}
@@ -167,13 +168,16 @@ def grounded_scopes(
 
 
 def combine(lat: Lattice[K], a: Annotation[K], b: Annotation[K]) -> Annotation[K]:
-    """The binary seam rule at a scalar expression.
+    """The rule for two annotations meeting at one scalar expression, for
+    example the two sides of a binary operator.
 
-    Meet the two values; a ``bottom`` meet is two committed, incompatible operands
-    and raises ``SeamContradictionError``. Agreeing operands preserve their value. When
-    one operand is top and the other committed, the result clears to top and
-    inherits *that operand's* opacity, so an un-annotated (IMPLICIT) clear speaks
-    at the seam while a declared (EXPLICIT) opt-out flows silently.
+    Two concrete values that disagree raise ``SeamContradictionError``. Two
+    that agree keep their shared value. When one side is concrete and the
+    other has no information, the result loses the concrete side's
+    information too, since the uninformed side could still turn out to break
+    it; the opacity of *that* side then decides whether the loss warns or
+    stays quiet: a declared opt-out (EXPLICIT) stays quiet, a genuine gap
+    (IMPLICIT) warns.
     """
     provisional = a.provisional or b.provisional
     m = lat.meet(a.value, b.value)

--- a/src/dblect/lineage/facts/lattice.py
+++ b/src/dblect/lineage/facts/lattice.py
@@ -55,10 +55,11 @@ def consistent(lat: Lattice[K]) -> Callable[[K, K], bool]:
     declaration when the SQL revealed nothing (top) or proved something at least
     as precise.
 
-    ``top`` is checked before ``bottom`` so an opaque inference passes even on a
-    degenerate lattice (``top == bottom``). ``bottom`` is then handled explicitly:
-    it refines every value, so without its own arm an inferred contradiction would
-    pass vacuously, when it should be a finding.
+    ``top`` is checked before ``bottom`` so a value of top (nothing was
+    inferred) still passes even in a degenerate lattice where top and bottom
+    coincide. ``bottom`` is then handled explicitly: since bottom refines
+    every value, skipping this check would let an inferred contradiction pass
+    by default instead of being reported as a finding.
     """
 
     def check(declared: K, inferred: K) -> bool:

--- a/src/dblect/lineage/facts/model.py
+++ b/src/dblect/lineage/facts/model.py
@@ -135,8 +135,9 @@ class Fact(Generic[K, S]):
 
 
 def by_scope(facts: tuple[Fact[K, S], ...]) -> dict[S, tuple[Fact[K, S], ...]]:
-    """Bucket ``facts`` by their scope, preserving order. The one grouping every
-    grounding fold takes (the check family and the audit's FD grounding both read it)."""
+    """Bucket ``facts`` by their scope, preserving order. Every place in the
+    codebase that folds facts into a grounded value groups them with this same
+    function first, so they can never disagree about how facts are bucketed."""
     grouped: dict[S, list[Fact[K, S]]] = {}
     for fact in facts:
         grouped.setdefault(fact.scope, []).append(fact)

--- a/src/dblect/lineage/facts/property.py
+++ b/src/dblect/lineage/facts/property.py
@@ -1,10 +1,12 @@
-"""``Property[K, S]``: a lattice, transfer catalogs, and a grounding function.
+"""``Property[K, S]``: everything the propagator needs to check one property,
+such as nullability or uniqueness, across a SQL model.
 
-A property bundles everything the propagator needs to walk one axis: its
-:class:`Lattice`, per-operator and per-aggregate transfers, the ``ground``
-function that gives each node its declared :class:`Annotation`, and an optional
-:class:`Semiring` for counting or accumulating axes. The transfer calculus and
-its obligations are in ``docs/design/propagation-soundness.md``.
+A property bundles its :class:`Lattice` (the order of how precise a value
+is), a transfer for each SQL operator and aggregate function, the ``ground``
+function that reads a node's declared :class:`Annotation`, and an optional
+:class:`Semiring` for a property that counts or accumulates rather than just
+refines. What a transfer is obliged to preserve is worked out in
+``docs/design/propagation-soundness.md``.
 
 A property's typed handle, :class:`PropertyRef`, is minted once by the smart
 constructors behind a module-private token, so a caller cannot forge a handle of
@@ -137,14 +139,15 @@ class UndischargedCompanion:
 @dataclass(frozen=True, slots=True)
 class CoherenceClear(Generic[K]):
     """The structured event a coherence guard records when it clears an aggregate: the
-    real reason the output tag went to top, surfaced rather than re-inferred downstream.
+    real reason the result went to top, surfaced here instead of a caller having to
+    re-derive it downstream.
 
-    ``cleared_value`` is the operand's tag at the moment of the clear (the tag that
-    carried the live companions, the one a diagnostic renders through
+    ``cleared_value`` is the operand's value at the moment of the clear (the value
+    that still carried the live companions, the one a diagnostic renders through
     :attr:`Property.display`). ``aggregate`` is the cleared call (its line and function),
     ``site`` the scope it was judged in, and ``undischarged`` the companions that blocked
     it. An empty ``undischarged`` is never recorded: the guard clears only when at least
-    one companion survives, so a naked operand (no companion) emits nothing."""
+    one companion survives, so an aggregate with no companion at all emits nothing."""
 
     aggregate: exp.AggFunc
     site: AggregationSite | None
@@ -219,14 +222,16 @@ class Property(Generic[K, S]):
     display: Callable[[K], AxisDisplay] | None = None
     depends_on: tuple[PropertyRef[Any, Any], ...] = ()
     reconcile_by_meet: bool = False
-    """How a derived node's declared and inferred annotations combine.
+    """How a node's declared value (from a fact) and its value inferred from
+    the SQL combine when both exist.
 
-    Default (``False``): an inferred value that fails ``consistent`` against the
-    declaration is a conflict; the flow value keeps the declaration, tainted
-    provisional (nullability: a declared ``NOT NULL`` the SQL can violate). Set
-    (``True``): declared and inferred are the same-polarity lower bounds and
-    compose by the lattice ``meet``, never conflicting (uniqueness: a declared
-    candidate key and a SQL-derived one both hold, so they union)."""
+    Default (``False``): an inferred value that does not honour the
+    declaration is a conflict. The declared value wins but is marked
+    provisional, since the two disagree (nullability: a column declared
+    ``NOT NULL`` that the SQL can still make null). Set (``True``): declared
+    and inferred can never conflict, since both are lower bounds on the same
+    answer; they combine by the lattice ``meet`` and both stick (uniqueness: a
+    declared candidate key and one the SQL derives both hold at once)."""
     reducer: Reducer | None = None
     """The scope-specific step that turns a derivation into an inferred annotation.
 

--- a/src/dblect/lineage/graph.py
+++ b/src/dblect/lineage/graph.py
@@ -38,16 +38,16 @@ S = TypeVar("S", "ColumnRef", "SourceRef")
 
 
 class LineageView(Protocol[S]):
-    """The minimal view the propagator's grounded-fixpoint driver needs of a
-    lineage graph, independent of scope.
+    """The minimal view ``propagate`` (in ``property.py``) needs of a lineage
+    graph, independent of scope.
 
-    A *subject* is a node the propagator annotates (a column for column-scoped
+    A *subject* is a node the walk annotates (a column for column-scoped
     properties, a relation for relation-scoped ones). ``derivation`` returns the
     sqlglot expression that produced a subject, or ``None`` when the subject is a
-    leaf (a source or seed) that grounds from facts. The scope-specific reducer
-    is what walks a derivation; the driver only needs to enumerate subjects and
-    fetch each one's derivation, so both the column and relation graphs satisfy
-    this same protocol.
+    leaf (a source or seed) whose value comes only from what was declared. The
+    scope-specific reducer is what walks a derivation; the walk itself only needs
+    to enumerate subjects and fetch each one's derivation, so both the column and
+    relation graphs satisfy this same protocol.
     """
 
     def subjects(self) -> Iterable[S]: ...
@@ -88,9 +88,9 @@ class SourceRef:
     * ``CTE``: ``cte.<model_uid>.<scope_path>``, where ``scope_path`` is a
       dot-joined chain of CTE / derived-table aliases from outermost to
       innermost. Disambiguates same-named CTEs in different scopes.
-    * ``UNION``: ``union.<model_uid>.<scope_path>.<col>`` — the combined
+    * ``UNION``: ``union.<model_uid>.<scope_path>.<col>``, the combined
       output node for a UNION ALL's column.
-    * ``UNION_ARM``: ``union.<model_uid>.<scope_path>#<arm_index>`` —
+    * ``UNION_ARM``: ``union.<model_uid>.<scope_path>#<arm_index>``, the
       individual arm projection, indexed in source order.
     """
 
@@ -214,17 +214,21 @@ def source_ref_meta(table: exp.Table) -> SourceRef | None:
 
 @dataclass(frozen=True, slots=True)
 class AggregationSite:
-    """The scope context an aggregate's coherence obligation is judged in.
+    """What a guard needs to know to decide whether an aggregate's result can be
+    trusted: which relation it aggregates over, what it groups by, and what the
+    query's own WHERE clause already pins to a constant.
 
-    The column builder resolves it once per SELECT scope and stamps it onto each
-    aggregate call in that scope's projections, because the projection expression
-    alone (``Alias(Sum(Column))``) carries neither the GROUP BY nor the relation
-    being aggregated over. The guard then has the three things a discharge can
-    rest on, all resolved to graph identities rather than names:
+    An aggregate like ``SUM(amount)`` can carry a companion column (say,
+    ``currency``) whose value must stay constant within each group for the
+    aggregate to mean anything; a guard checks that here. The column builder
+    resolves this once per SELECT scope and stamps it onto each aggregate call in
+    that scope's projections, because the projection expression alone
+    (``Alias(Sum(Column))``) carries none of that context. Each field below is
+    already resolved to a graph identity rather than a name copied out of the SQL:
 
     * ``input_source``: the single FROM relation the scope aggregates over, when
-      it is one resolvable relation with no joins; ``None`` closes the dependency
-      read (the FD property has no scope to answer for).
+      it is one resolvable relation with no joins; ``None`` means there is no
+      relation to check a companion column's dependency against at all.
     * ``group_refs``: the GROUP BY columns; the empty set is the whole-relation
       fold (no GROUP BY, or the ``GROUP BY ()`` grand-total grouping set), and
       ``None`` marks a group shape the builder cannot resolve to plain columns

--- a/src/dblect/lineage/properties/aggregation_depth.py
+++ b/src/dblect/lineage/properties/aggregation_depth.py
@@ -2,9 +2,9 @@
 
 **Demo, not a production detector.** A ``SUM(t.x)`` in a CTE re-aggregated by
 ``SUM(r.total)`` at the outer projection surfaces as depth 2; a "double
-aggregation" check is ``depth > 1`` per model column. The gaps before this is a
-real detector (window functions, GROUP BY/HAVING context, DISTINCT/FILTER inside
-aggregates) are unchanged by this migration.
+aggregation" check is ``depth > 1`` per model column. Window functions, GROUP
+BY/HAVING context, and DISTINCT/FILTER inside aggregates are not modelled yet,
+so those gaps stand between this and a real detector.
 
 The engine is the max-semiring on non-negative ints: ``plus`` and ``times`` both
 take the max, so UNION arms and times-folded children inherit the deepest path.

--- a/src/dblect/lineage/properties/domain_type.py
+++ b/src/dblect/lineage/properties/domain_type.py
@@ -4,10 +4,10 @@ A magnitude column (``amount``) carries a :class:`DomainTag`: a dimensional
 monomial (currency and units, which do exponent arithmetic under ``*`` and ``/``)
 plus categorical nominal tags (``contains_tax``, ``country``, carried by equality
 only). Each tag binds either to a literal (a pinned currency) or to a companion
-column travelling with the amount (a per-row currency column). This is the
-multi-column companion binding the substrate-readiness notes name as the first
-genuine build over the lineage engine: the property value is structured, so the
-work is a lattice and transfer rules rather than engine plumbing.
+column travelling with the amount (a per-row currency column). Unlike the other
+properties in this package, its value is a structured, multi-part tag rather
+than a single flat value, so the work here is a genuinely new lattice and set
+of transfer rules rather than reuse of existing plumbing.
 
 The lattice orders by tag knowledge. ``NAKED`` (no tag) is the top, the
 freely-summable magnitude making no claim; a known tagging refines it; two known
@@ -26,9 +26,9 @@ coherence guard then blocks a downstream sum until a dependency discharges it.
 The guard is armed by :func:`domain_type_property` when the caller passes the
 functional-dependency property's ref.
 
-Grounding for the first version comes from synthetic facts supplied by a caller
-(the same way the uniqueness and nullability tests ground their properties); the
-typed source is the contract bridge in the authoring layer.
+Today, grounding comes from synthetic facts a caller supplies directly (the same
+way the uniqueness and nullability tests ground their properties); the typed
+source will eventually be the contract bridge in the authoring layer.
 """
 
 from __future__ import annotations
@@ -442,9 +442,10 @@ def _dot_rule(
 def _comparison_rule(
     _expr: Expr, kids: tuple[Annotation[DomainTag], ...], _ctx: DepContext
 ) -> Annotation[DomainTag]:
-    """A comparison yields a boolean, which carries no magnitude tag. The operands'
-    tags must agree for the comparison to mean anything, but that obligation is a
-    seam concern; the produced value is always tag-free."""
+    """A comparison such as ``a = b`` yields a boolean, which carries no magnitude
+    tag regardless of the operands' tags. Whether those tags actually agree is
+    checked separately, where a declared tag meets an inferred one; this rule
+    only fixes the comparison's own tag-free result."""
     return Annotation(NAKED, Opacity.IMPLICIT, provisional=any(k.provisional for k in kids))
 
 
@@ -569,7 +570,7 @@ def companion_columns(tag: DomainTag) -> frozenset[ColumnRef]:
     return frozenset(out)
 
 
-# --- the seam-diagnostic display ---------------------------------------------
+# --- naming a tag for the dropped-refinement warning --------------------------
 
 
 def _unit_label(unit: Unit) -> str:
@@ -593,13 +594,16 @@ def _dimension_label(dim: DimClaim) -> str | None:
 
 
 def domain_type_display(tag: DomainTag) -> AxisDisplay:
-    """The structural name the seam diagnostic renders a tag through: the dimensional
-    monomial and the nominal bindings the tag carries.
+    """The human-readable name for a tag, shown when the checker warns that a
+    magnitude's currency or category was silently dropped because it combined
+    with an untagged value: the dimensional monomial and the nominal bindings
+    the tag carries.
 
-    This is the fallback rendering the :class:`AxisDisplay` hook documents, off the tag
-    value alone. Naming the declared type the tag came from (``Money over (amount,
-    currency)``, with the contract's file) is the declaration-trace follow-on (#48);
-    the value here carries the structure, not the declaration."""
+    This is the fallback rendering the :class:`AxisDisplay` hook documents, built
+    from the tag value alone. Naming the declared type the tag came from
+    (``Money over (amount, currency)``, with the contract's file) is a follow-on
+    improvement (#48); the value here carries the structure, not the
+    declaration."""
     if isinstance(tag, _Conflict):
         return AxisDisplay(name="conflicting domain types")
     pieces: list[str] = []

--- a/src/dblect/lineage/properties/functional_dependency.py
+++ b/src/dblect/lineage/properties/functional_dependency.py
@@ -1,13 +1,13 @@
 """Functional-dependency property: the dependencies a relation's rows satisfy.
 
 A relation's value is a set of functional dependencies over its output column
-names, each one ``X -> y``: rows equal on ``X`` are equal on ``y``. This is the
-discharge substrate the aggregate coherence guard reads. ``sum(amount) group by
-country`` over a per-row currency is well typed exactly when the group key holds
-the currency constant per group, and a ``country -> currency`` dependency is the
-summarizability argument for that (Lenz & Shoshani, SSDBM 1997; Hurtado &
-Mendelzon, ICDT 2001). Entailment (:func:`determines`) is attribute closure under
-Armstrong's axioms.
+names, each one ``X -> y``: rows equal on ``X`` are equal on ``y``. This is what
+the aggregate coherence guard checks before trusting an aggregate:
+``sum(amount) group by country`` over a per-row currency is well typed exactly
+when the group key holds the currency constant per group, and a ``country ->
+currency`` dependency is the summarizability argument for that (Lenz &
+Shoshani, SSDBM 1997; Hurtado & Mendelzon, ICDT 2001). Entailment
+(:func:`determines`) is attribute closure under Armstrong's axioms.
 
 The lattice orders by precision exactly as uniqueness orders keys: knowing more
 dependencies is more precise, so ``meet`` (resolution of declarations) unions the


### PR DESCRIPTION
## What this does

Rewrites docstrings and comments across `lineage/`, `lineage/facts/`,
`lineage/properties/`, and `check/` so they read for someone who understands
dblect generally but hasn't read the design docs. No logic changes.

This continues the feedback that shaped #230's `grain.py` cleanup (75c2d2b):
several docstrings leaned on vocabulary coined in `docs/design/*.md` (e.g.
"seam", "discharge substrate", "flag-influence cone", "flow value") without
ever explaining it, which reads as incantation to a reader arriving cold.

## How

Four passes, one per package, each reading every docstring and comment
directly and rewriting only what didn't hold up — rather than matching
against a term list. A term list over- and under-fires: `confluence` and
`propagator` are this codebase's real vocabulary and are fine as-is, while a
block can use no jargon at all and still explain a mechanism by its name
instead of its consequence. Genuine local API names are left alone;
unexplained borrowed concepts are replaced with what actually happens, with
the relevant design doc kept as a pointer at the end rather than the
vocabulary source throughout.

## Two things beyond wording

- `graph.py`'s `LineageView` docstring called the walk a "grounded-fixpoint
  driver", but `docs/design` says it's explicitly single-pass, not iterative.
  That was a real inaccuracy, not just unreadable prose.
- Two internal word collisions in `lineage/facts/`: "tag" meant the generic
  value in one docstring and the `Opacity` label in another a few files away;
  "opaque inference" in `lattice.py` collided with the same package's
  `Opacity`/`OpaqueReader` vocabulary meaning something different.

## Test plan

- [x] `ruff check`
- [x] `ruff format --check`
- [x] `pyright`
- [x] `pytest` (full suite, 1601 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAE4C5m7unT2uPjd1XthjN