### PR TITLE
docs: extend the plain-language prose pass to the rest of src/dblect

### DIFF
--- a/src/dblect/analysis.py
+++ b/src/dblect/analysis.py
@@ -6,8 +6,8 @@ the declaration-level ones (contract resolution, domain-type contradictions acro
 the DAG, not-well-typed aggregations), located by model, column, and contract.
 :func:`~dblect.audit.run_audit` reports the SQL-structural ones (join fan-out,
 window order, the nullability hazards, the rest), located by a span in one compiled
-statement. The two stay distinct in representation and altitude; issue #107 weighs
-whether to merge the representations as well.
+statement. The two stay distinct in shape rather than merged into one; issue #107
+weighs whether to unify them too.
 
 What this module removes is the obligation to *know* there are two families. Asking
 for "the findings of a manifest" should not require remembering to call both
@@ -72,8 +72,9 @@ def cross_world_identity(finding: AnalysisFinding) -> FindingIdentity:
 class AnalysisReport:
     """Every finding for one manifest, from every detector family, plus each family's
     own report so a caller that needs the family-specific extras (coverage blocks,
-    suppressed directives) still has them. ``findings`` is the merged, sealed view the
-    finding-threading consumers read; the rest is there when an altitude matters."""
+    suppressed directives) still has them. ``findings`` is the merged, sealed list
+    most callers read; ``check`` and ``audit`` are there when a caller needs one
+    family's own view instead."""
 
     findings: tuple[AnalysisFinding, ...]
     check: CheckReport

--- a/src/dblect/audit/__init__.py
+++ b/src/dblect/audit/__init__.py
@@ -1,4 +1,5 @@
-"""Audit pipeline: static detectors, replay-determinism, heuristic invariants."""
+"""Runs SQL detectors over a manifest, locates each finding in the developer's
+source, and applies ``-- noqa`` suppressions."""
 
 from dblect.audit.sourcemap import SourceSpan, SpanBasis
 from dblect.audit.suppress import SuppressionDirective

--- a/src/dblect/audit/suppress.py
+++ b/src/dblect/audit/suppress.py
@@ -88,10 +88,9 @@ class Suppressible(Protocol):
 _F = TypeVar("_F", bound=Suppressible)
 
 # Match ``noqa`` only when it stands alone: followed by ``:``, whitespace, or
-# end-of-token. The ``(?![\w-])`` is load-bearing: it stops ``noqa-file`` and
-# ``noqa-fixture`` (SQLFluff's file-level directive, and dblect's retired one) from
-# being misread as a bare ``noqa`` that silences everything. That misread is the
-# exact collision this rewrite exists to avoid.
+# end-of-token. The ``(?![\w-])`` lookahead is load-bearing: without it, ``noqa-file``
+# and ``noqa-fixture`` (SQLFluff's file-level directive, and a retired dblect one) would
+# be misread as a bare ``noqa`` that silences everything on the line.
 _NOQA = re.compile(r"--\s*noqa(?![\w-])\s*(?::\s*(?P<codes>[^\n]*))?", re.IGNORECASE)
 
 
@@ -209,9 +208,10 @@ class FramedDirectives:
 
     @classmethod
     def for_node(cls, node: Node) -> FramedDirectives:
-        """Both frames for a manifest node: the source frame from its template and the
-        compiled frame from the SQL the analysis layer parses. The single place the
-        node-field-to-frame binding lives, shared by the structural and declaration runs."""
+        """Both frames for a manifest node: ``raw_code`` is the source frame, and
+        ``analysis_sql`` (the SQL the analysis layer parses) is the compiled frame. The
+        one place that binding lives, so the structural and declaration runs agree on
+        which of a node's texts is which."""
         return cls.parse(raw=node.raw_code, compiled=node.analysis_sql)
 
 

--- a/src/dblect/audit/walker.py
+++ b/src/dblect/audit/walker.py
@@ -58,12 +58,14 @@ from dblect.uniqueness.detector import (
 
 Detector = Callable[[Expr], tuple[Finding, ...]]
 
-# The dialect-agnostic structural detectors. Context-bound detectors (non-determinism
-# from the resolved adapter, uniqueness and nullability grounded against declared
-# facts, inner-flatten grounded against propagated array non-emptiness) are built per
-# run in `run_audit` and appended there, so they are not listed. The inner-flatten check
-# in particular is run only through its fact-grounded factory so it sees the cross-model
-# non-emptiness map; listing the structural form here too would double-report it.
+# The dialect-agnostic structural detectors: the ones that need nothing beyond the SQL
+# itself. Context-aware detectors (non-determinism checked against the resolved
+# adapter; uniqueness and nullability checked against declared facts; inner-flatten
+# checked against array non-emptiness propagated from other models) are built per run
+# in `run_audit` and appended there, so they are not listed here. The inner-flatten
+# check in particular runs only through that context-aware factory, so it can see
+# non-emptiness facts from other models; listing the plain structural form here too
+# would double-report the same hazard.
 DEFAULT_DETECTORS: tuple[Detector, ...] = (
     detect_null_group_after_outer_join,
     detect_coalesce_on_join_key,
@@ -161,35 +163,36 @@ def run_audit(
 ) -> AuditReport:
     """Run `detectors` over every model in `manifest`.
 
-    ``profile`` is the run's resolved target: its dialect parses every model and
-    its semantics ground the fact-based detectors, so parsing and enforcement read
-    the same adapter.
+    ``profile`` is the run's resolved target: its dialect parses every model, and its
+    adapter-specific facts (e.g. which builtins are non-deterministic) feed the
+    detectors that need them, so parsing and detection agree on the same adapter.
 
     Sources, seeds, and snapshots are not scanned: they have no SQL we own.
     Models whose ``compiled_code`` is missing or unparseable are listed in
     the report's ``skipped`` field with a reason rather than raising.
 
-    Context-bound detectors run alongside the configured `detectors` list, each
-    built from the resolved profile and the pre-parsed trees: the non-determinism
-    detector (its builtin names come from the profile), the uniqueness window
-    order-keys, join-fanout, and non-deterministic-``LIMIT`` detectors (grounded
-    against declared keys, the last also against each model's materialization), the
-    nullability hazard detectors (GROUP BY, join key, and NOT IN on an
-    inherited-nullable column, grounded against the propagated nullability
-    property), the inner-flatten row-drop detector (grounded against the
-    propagated array-non-emptiness property, so a rebuilt-then-unnested array is
-    not flagged), and the snapshot temporal-filter detector (grounded against the
-    manifest's snapshots and their validity columns). The fact-grounded ones are
-    opportunistic, silent on projects that declare nothing, so they need no opt-in
-    flag. They share the audit's pre-parsed trees, so the SQL is parsed once.
+    Besides the configured `detectors` list, this run also builds and appends detectors
+    that need the resolved profile or a prior analysis pass: the non-determinism
+    detector (its builtin names come from the profile), the uniqueness detectors for
+    window order-keys, join fanout, and non-deterministic ``LIMIT`` (checked against a
+    model's declared keys, the last also against its materialization), the nullability
+    hazard detectors for GROUP BY, join keys, and NOT IN on a column that inherited
+    nullability (checked against nullability already propagated through the lineage
+    graph), the inner-flatten row-drop detector (checked against array non-emptiness
+    propagated the same way, so a rebuilt-then-unnested array is not flagged), and the
+    snapshot temporal-filter detector (checked against the manifest's snapshots and
+    their validity columns). These detectors stay quiet on a project that has declared
+    nothing to check against, so they need no opt-in flag. They share the audit's
+    pre-parsed trees, so the SQL is parsed once.
 
-    This is the structural family alone. A consumer that needs every family's
-    findings over a manifest (any multi-world or finding-threading path) calls
-    :func:`dblect.analysis.analyze` instead, which carries both families so a family
-    is never dropped by being forgotten.
+    This is the structural family alone. A caller that also needs the declaration-level
+    findings, or that has to track findings across multiple build variants of the
+    project, should call :func:`dblect.analysis.analyze` instead, which runs both
+    families so neither is forgotten.
     """
-    # ``analyze`` shares the parse and both lineage graphs it already built (rebuilding them,
-    # the heavy substrate, dominates a run); omitted, this builds them, the standalone path.
+    # `analyze` passes in the parse and both lineage graphs it already built, since
+    # rebuilding them is the expensive part of a run; omitted, as in a standalone
+    # audit run, this function builds them itself.
     if parsed is None:
         parsed, trees = parse_manifest_models(manifest, dialect=profile.sqlglot_dialect)
     else:

--- a/src/dblect/cli/__init__.py
+++ b/src/dblect/cli/__init__.py
@@ -170,8 +170,8 @@ def check(
 
     Both detector families run over the project. The structural family needs only the
     compiled SQL, so it reports on any project. The declaration family resolves the
-    contracts under ``<project_dir>/dblect/`` if present; with none declared it simply
-    reports zero contracts resolved rather than nothing to do.
+    contracts under ``<project_dir>/dblect/`` if present; with none declared, it still
+    runs and reports zero contracts resolved instead of skipping silently.
     """
     from dataclasses import replace
 

--- a/src/dblect/contracts/__init__.py
+++ b/src/dblect/contracts/__init__.py
@@ -5,9 +5,9 @@ SQL for the execution path.
 A model contract relates several columns, rows, or models through methods marked
 :func:`contract`. The method body manipulates column proxies (``self.col``,
 ``models.other.col``), and the operators build an :mod:`~dblect.contracts.ast`
-tree the framework reads. A returned fact feeds the substrate; a returned
-predicate is checked by running. See ``docs/design/declaration-dsl.md`` and
-``docs/design/dblect_technical_intro.md``.
+tree the framework reads. A returned fact is trusted outright, the way a declared
+key is; a returned predicate is checked by actually running it. See
+``docs/design/declaration-dsl.md`` and ``docs/design/dblect_technical_intro.md``.
 """
 
 from __future__ import annotations

--- a/src/dblect/contracts/ast.py
+++ b/src/dblect/contracts/ast.py
@@ -23,8 +23,9 @@ from enum import StrEnum, auto
 
 
 class AggFunc(StrEnum):
-    """The reductions a column proxy offers. ``COUNT`` and ``COUNT_DISTINCT`` are
-    always well typed; the rest carry the coherence obligation the algebra names."""
+    """The reductions a column proxy offers. ``COUNT`` and ``COUNT_DISTINCT`` need
+    no unit checking; the rest (sum, average, min, max) require the values being
+    combined to share one unit or currency, which dblect verifies separately."""
 
     SUM = auto()
     AVG = auto()
@@ -35,8 +36,8 @@ class AggFunc(StrEnum):
 
 
 class ArithOp(StrEnum):
-    """Binary arithmetic over magnitudes (the dimensional algebra lives downstream;
-    here we only record the operator)."""
+    """Binary arithmetic (add, subtract, multiply, divide) over magnitude columns.
+    Unit and currency checking happens elsewhere; this only records the operator."""
 
     ADD = auto()
     SUB = auto()
@@ -170,9 +171,10 @@ Pred = Compare | IsNull | InSet | Between | BoolNode
 
 # --- facts ----------------------------------------------------------------------
 #
-# A contract method that returns one of these feeds the substrate rather than
-# being run: it is a vouched assertion the analyzer trusts to discharge
-# obligations and propagate. The bridge lowers each to the matching substrate fact.
+# A contract method that returns one of these is never run: it hands dblect a
+# fact to trust outright, the same way a declared key is trusted, and that fact
+# then feeds every check downstream. The fact bridge (outside this package)
+# converts each into the matching internal fact record.
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/dblect/contracts/compile.py
+++ b/src/dblect/contracts/compile.py
@@ -7,13 +7,14 @@ aggregate call), :func:`compile_predicate` renders a row-level predicate, and
 denotes. Rendering through sqlglot keeps the dialect handling and quoting in one
 well-exercised place.
 
-:func:`evaluate_predicate` is the execution end: a comparison of two aggregates
-(the conservation shape, ``a.sum() == b.sum()`` per group) compiled to a query per
-side, run against generated rows in an in-memory DuckDB, and compared group by
-group under the predicate's tolerance. This is the runtime-checked half of the
-contract surface, the analyzer never reasons over it. Cross-relation joins
-(``joined_on``) and the materialized-DataFrame escape hatch are not lowered here
-yet; they are the natural next increment.
+:func:`evaluate_predicate` is the execution end: a comparison of two aggregates,
+for example ``a.sum() == b.sum()`` per group (checking that a total tallied one
+way matches a total tallied another way), compiled to a query per side, run
+against generated rows in an in-memory DuckDB, and compared group by group under
+the predicate's tolerance. This is the runtime-checked half of the contract
+surface; the analyzer never reasons over it. Cross-relation joins (``joined_on``)
+and a planned way to skip the proxy DSL and hand dblect an already-computed
+DataFrame directly are not lowered here yet; both are natural next steps.
 """
 
 from __future__ import annotations

--- a/src/dblect/contracts/decorator.py
+++ b/src/dblect/contracts/decorator.py
@@ -1,11 +1,12 @@
 """``@contract``: mark a method whose body builds a symbolic expression.
 
-The marker is intentionally tiny. It tags the function so the model contract's
-metaclass finds it during the scan, then :func:`capture` runs the body once with
-a :class:`~dblect.contracts.proxy.ContractSelf` standing in for ``self`` and
-records the AST it returns. Dispatch on that AST decides what the contract does:
-a :data:`~dblect.contracts.ast.FactNode` feeds the substrate (read and trusted
-unless contradicted), a :data:`~dblect.contracts.ast.Pred` is checked by running.
+The marker is intentionally tiny: it tags the function so ``ModelContract``
+picks it up, via ``__init_subclass__``, when a contract class is defined.
+:func:`capture` then runs the body once with a
+:class:`~dblect.contracts.proxy.ContractSelf` standing in for ``self`` and
+records the AST it returns. A returned :data:`~dblect.contracts.ast.FactNode` is
+trusted as a fact about the data unless something else contradicts it; a
+returned :data:`~dblect.contracts.ast.Pred` is checked by actually running it.
 See ``docs/design/dsl-reference.md`` (Contracts).
 """
 
@@ -25,9 +26,9 @@ from dblect.contracts.proxy import (
 _MARKER = "_dblect_contract"
 
 # A contract body takes a self-proxy and returns a fact or predicate proxy. The
-# return is typed ``object`` because authors annotate it loosely (or not at all)
-# and the materialized escape hatch returns other shapes; :func:`capture` checks
-# the actual proxy kind at runtime.
+# return is typed ``object`` rather than that union because authors annotate
+# loosely (or not at all); :func:`capture` checks what actually came back at
+# runtime and rejects anything else.
 ContractMethod = Callable[[ContractSelf], object]
 
 

--- a/src/dblect/contracts/proxy.py
+++ b/src/dblect/contracts/proxy.py
@@ -262,8 +262,9 @@ def _existing_ref(cmp: Compare) -> ValueExpr | None:
 
 
 class FactProxy:
-    """A fact a contract method returns. Inert: it only carries the AST node the
-    bridge lowers to a substrate fact."""
+    """A fact a contract method returns. Inert on its own: it just carries the AST
+    node that the fact bridge (outside this package) later turns into a fact
+    dblect trusts about the data."""
 
     __slots__ = ("fact",)
 

--- a/src/dblect/demo/enums.py
+++ b/src/dblect/demo/enums.py
@@ -1,9 +1,10 @@
 """Illustrative enum vocabularies: ISO 4217 currencies and ISO 3166-1 countries.
 
-Partial slices, enough to exercise the tag algebra in the walkthrough. They are
-ordinary :class:`~dblect.types.UnitEnum` / :class:`~dblect.types.NominalEnum`
-subclasses, the markers that live in ``dblect.types``; a project declares its
-own categories the same way. Widening these is a data edit, not a design change.
+Partial slices, enough to give the walkthrough's unit and category types
+something to hold. They are ordinary :class:`~dblect.types.UnitEnum` /
+:class:`~dblect.types.NominalEnum` subclasses, the markers that live in
+``dblect.types``; a project declares its own categories the same way.
+Widening these is a data edit, not a design change.
 """
 
 from __future__ import annotations

--- a/src/dblect/execution/incremental.py
+++ b/src/dblect/execution/incremental.py
@@ -9,8 +9,8 @@ with nothing built. Each world is read back as an ordinary
 
 The override reaches the bare ``{{ is_incremental() }}`` call. A model that calls
 ``dbt.is_incremental()`` explicitly, or a branch that introspects the existing
-relation's schema at compile, is not reached and degrades to an opaque world
-(reported with its error) while the other world still stands.
+relation's schema at compile, is not reached, so that world's compile fails and
+is reported with its error, while the other world still stands.
 """
 
 from __future__ import annotations
@@ -34,9 +34,10 @@ from dblect.execution.project_env import (
 from dblect.lineage.facts.model import WorldRef
 from dblect.manifest import Manifest
 
-# The run-mode axis and its two worlds, expressed as the same ``WorldRef``
-# assignment vocabulary the flag layer uses, so an incremental world composes
-# with flag worlds as a union of assignments rather than a separate notion.
+# is_incremental is represented as a WorldRef assignment, the same
+# representation the flag layer uses for its own axes. That lets code combine
+# an incremental world with a flag world by merging assignments, instead of
+# treating incrementality as a special case.
 INCREMENTAL_AXIS = "is_incremental"
 FULL_REFRESH_WORLD: WorldRef = WorldRef(frozenset({(INCREMENTAL_AXIS, False)}))
 STEADY_STATE_WORLD: WorldRef = WorldRef(frozenset({(INCREMENTAL_AXIS, True)}))
@@ -136,7 +137,8 @@ def _compile_world(
     env: Mapping[str, str],
 ) -> CompiledWorld:
     """Write the override for ``value``, compile, and harvest the manifest. A
-    non-zero compile or a missing manifest yields an opaque world, never a raise."""
+    non-zero compile or a missing manifest is reported as a world whose compile
+    failed, never raised as an exception."""
     macro_path.write_text(_override_macro(value))
     proc = run_dbt(dbt, ["compile", "--project-dir", str(work)], env=env)
     if proc.returncode != 0:

--- a/src/dblect/execution/run.py
+++ b/src/dblect/execution/run.py
@@ -1,8 +1,10 @@
 """Run dbt models end-to-end in DuckDB and capture the output.
 
-This is the substrate the static-analysis invariant checks and the runtime
-PBT loop sit on. We use a subprocess as the v1 approach for fidelity:
-in-process Jinja rendering is a follow-up when perf bites.
+Other parts of dblect build on this: the static-analysis invariant checks and
+the runtime PBT loop both call `run_model` when they need a model's actual
+materialized rows, not an inferred fact. We run dbt as a subprocess for
+fidelity; rendering Jinja in-process ourselves is a possible optimization if
+performance becomes a problem.
 
 The contract:
 

--- a/src/dblect/flatten/__init__.py
+++ b/src/dblect/flatten/__init__.py
@@ -1,4 +1,4 @@
-"""Inner-flatten row-drop detection grounded against propagated array non-emptiness.
+"""Cross-model check for an inner ``UNNEST`` that can silently drop a parent row.
 
 The structural detector in :mod:`dblect.sql.patterns` flags an inner ``UNNEST`` that
 can drop a parent row, clearing only the locally provable cases (an outer form, a

--- a/src/dblect/loader.py
+++ b/src/dblect/loader.py
@@ -9,7 +9,7 @@ under a unique synthetic package name; the framework imports the modules use
 project's own relative imports (``from ..types import ...``) resolve within the
 synthetic package. And one broken module must not abort the scan, so an import
 failure is recorded as a :class:`LoadIssue` and the remaining modules still load.
-The whole import runs inside a fresh registry, returned for the bridge to resolve.
+The whole import runs inside a fresh registry, returned for the fact bridge to resolve.
 
 See ``docs/design/dblect_technical_intro.md`` (loading lifecycle).
 """

--- a/src/dblect/manifest/parse.py
+++ b/src/dblect/manifest/parse.py
@@ -225,12 +225,13 @@ class Column:
 class Macro:
     """A macro definition as carried in the manifest's ``macros`` block.
 
-    The source body (`macro_sql`) is what the var-inference macro-following
-    engine expands to reach `var()` calls; `depends_on_macros` is the
-    macro-to-macro edge set that walk recurses through. This view is a faithful
-    transcription of the manifest entry; resolving a name to a definition (the
-    bare-name-then-package lookup) lands with macro-following, which defines what
-    that resolution must satisfy.
+    Lets a caller look inside a macro call instead of treating it as opaque:
+    `macro_sql` is the macro's own source, and `depends_on_macros` lists the
+    other macros it calls, so a caller can follow a chain of calls to find,
+    say, a `var()` buried several macros deep. This is a straight
+    transcription of the manifest entry; resolving a bare macro name to one
+    of these definitions is a separate concern, worked out in
+    ``docs/design/var-inference-spec.md``.
     """
 
     unique_id: str
@@ -294,9 +295,9 @@ class Node:
         """How faithfully ``compiled_code`` represents this model.
 
         ``NOT_COMPILED`` when dbt's own flag says so. Otherwise ``STALE_OR_ABSENT``
-        when there is a non-trivial source template but no compiled code (the
-        non-hermetic-compile gap), and ``COMPILED`` when there is compiled code or
-        nothing non-trivial to compile.
+        when there is a non-trivial source template but no compiled code (a compile
+        that never reached the warehouse), and ``COMPILED`` when there is compiled
+        code or nothing non-trivial to compile.
 
         Only SQL nodes carry this signal: a Python (or other non-SQL) model is not
         SQL-analysable, so an empty SQL ``compiled_code`` is not the compile gap and the
@@ -346,7 +347,7 @@ def generic_test_target_uid(
     Prefer ``attached_node`` (the modern manifest shape); fall back to the first
     eligible entry in ``depends_on`` for older manifests where ``attached_node``
     isn't populated. ``eligible_prefixes`` narrows which target kinds count, so a
-    caller that grounds only models and sources can pass a subset of the
+    caller that only cares about models and sources can pass a subset of the
     data-flow default.
     """
     if node.attached_node and node.attached_node.startswith(eligible_prefixes):
@@ -401,8 +402,8 @@ class Manifest:
             raise ValueError("manifest is missing metadata.adapter_type")
 
         # Macros live under their own top-level `macros` block, separate from
-        # the data-flow `nodes`. They carry no edges into the DAG; the registry
-        # is consumed by macro-following, not by lineage.
+        # the data-flow `nodes`. They carry no edges into the DAG; see
+        # :class:`Macro` for what consumes this registry.
         macros = {uid: _macro_from_parsed(uid, m) for uid, m in (parsed.macros or {}).items()}
         return cls(
             schema_version=schema_version,

--- a/src/dblect/nullability/__init__.py
+++ b/src/dblect/nullability/__init__.py
@@ -1,9 +1,10 @@
 """Fact-grounded audit detectors for nullability hazards.
 
-The nullability *property* (per-column tri-state, with outer-join taint and conditional
-NON_NULL activation) lives on the lineage.facts substrate as
+The nullability *property* tracks, per column, whether it can be NULL: an outer join
+can make it NULL, and a NOT NULL declared only under a filter activates once a
+downstream query applies that filter. Implemented in
 ``dblect.lineage.properties.nullability``. This package is the audit-facing consumer:
-detectors that read the proven nullability and flag NULL-sensitive constructs where the
+detectors that read the proven nullability and flag NULL-sensitive constructs where a
 null silently changes the result: a GROUP BY on an inherited-nullable key, a join keyed
 on one, a ``NOT IN`` over a subquery that projects one, and a ``NOT EXISTS`` whose probe
 correlation key is one.

--- a/src/dblect/sarif.py
+++ b/src/dblect/sarif.py
@@ -409,7 +409,7 @@ def _notification(descriptor_id: str, text: str, logical_name: str) -> _Notifica
 
 
 def _fingerprint(finding: AnalysisFinding) -> str:
-    # Hash the cross-run identity (kind plus where it lands, no line numbers) so a
+    # Hash the cross-world identity (kind plus where it lands, no line numbers) so a
     # consumer can track the same finding across compilations.
     return hashlib.sha256(repr(cross_world_identity(finding)).encode("utf-8")).hexdigest()
 

--- a/src/dblect/severity.py
+++ b/src/dblect/severity.py
@@ -101,13 +101,13 @@ def _structural_severity(kind: FindingKind) -> Severity:
             | FindingKind.LIMIT_WITHOUT_DETERMINISTIC_ORDER
             | FindingKind.NON_DETERMINISTIC_FUNCTION
             # Real-project calibration (#125) found the fanout pair firing on every
-            # intended fact-to-dimension surrogate-key
-            # join: the dimension declares its key on the natural key, and the surrogate
-            # key is a function of it that uniqueness does not yet ground through. They
-            # ship advisory so a textbook star schema stays visible without failing the
-            # build. Raise them back to error once uniqueness grounds through the
-            # surrogate-key expression, or once the lenient/strict split (#116) can hold
-            # the error default in the strict profile.
+            # intended fact-to-dimension surrogate-key join: the dimension declares its
+            # key on the natural key, and the surrogate key is computed from it, but the
+            # analysis does not yet know that a function of a unique column is itself
+            # unique. They ship as warn so a textbook star schema stays visible without
+            # failing the build. Raise them back to error once the analysis can prove
+            # that, or once the lenient/strict split (#116) can hold the error default
+            # in the stricter mode.
             | FindingKind.JOIN_FANOUT
             | FindingKind.CROSS_MODEL_FANOUT
         ):

--- a/src/dblect/sql/_sqlglot.py
+++ b/src/dblect/sql/_sqlglot.py
@@ -71,11 +71,12 @@ class GroupBinding(StrEnum):
     projection is that very column. ``PRESUMED`` is a renaming alias, where SQL
     would bind an input column of that name first and the AST cannot rule one out.
 
-    A detector may read all three, since over-reporting is its safe direction. A consumer that
-    *grounds* a fact from the group key stops at ``DECIDED`` (see
-    :attr:`GroupTarget.grounded_expression`): keys and dependencies are read downstream to
-    clear hazards, so a wrong resolution there silences real findings instead of adding a
-    spurious one.
+    A detector may read all three, since over-reporting is its safe direction. Code that treats
+    the resolved group key as an established fact about the query (its grain, say, or a
+    functional dependency) should trust only ``DECIDED`` (see
+    :attr:`GroupTarget.grounded_expression`): those facts get used downstream to clear other
+    findings, so a wrong resolution here would wrongly silence a real finding rather than raise
+    a spurious one.
     """
 
     WRITTEN = "written"
@@ -91,8 +92,8 @@ class GroupTarget:
     A finding about the *grouping decision* belongs at ``written_at``, so ``GROUP BY 1`` is
     diagnosed at the clause an analyst reads. One about something written inside the target (a
     ``now()`` call) belongs at ``expression``, where that call is spelled out. The two nodes
-    coincide for a target written in full. ``binding`` decides whether a consumer may ground a
-    fact from ``expression``: see :attr:`grounded_expression`.
+    coincide for a target written in full. ``binding`` decides whether ``expression`` can be
+    trusted as that established fact: see :attr:`grounded_expression`.
     """
 
     expression: Expr
@@ -101,8 +102,9 @@ class GroupTarget:
 
     @property
     def grounded_expression(self) -> Expr:
-        """The reading a consumer may ground a fact from: the resolved expression where SQL's
-        own rules decide the binding, and the written node where they do not.
+        """The reading downstream code can trust as the real group-by target: the resolved
+        expression where SQL's own rules decide the binding, and the written node where they
+        do not.
 
         Falling back to ``written_at`` on a ``PRESUMED`` binding is the conservative reading, and
         it is the one SQL takes whenever the name really is an input column. Two targets can also
@@ -363,9 +365,9 @@ def fn_of(w: exp.Window) -> Expr | None:
 
 
 def row_number_window(node: Expr) -> exp.Window | None:
-    """``node`` as a ``ROW_NUMBER() OVER (...)`` window, or ``None``. Only ``ROW_NUMBER`` grounds
-    a dedup key: it ranks distinctly within a partition, so ``= 1`` keeps exactly one row, whereas
-    ``RANK`` / ``DENSE_RANK`` share a rank across ties and can keep several."""
+    """``node`` as a ``ROW_NUMBER() OVER (...)`` window, or ``None``. Only ``ROW_NUMBER`` can be
+    trusted as a dedup key: it ranks distinctly within a partition, so ``= 1`` keeps exactly one
+    row, whereas ``RANK`` / ``DENSE_RANK`` share a rank across ties and can keep several."""
     if isinstance(node, exp.Window) and isinstance(node.this, exp.RowNumber):
         return node
     return None
@@ -379,7 +381,8 @@ def rank_one_guard_operand(leaf: Expr) -> Expr | None:
     """The operand a ``= 1`` / ``<= 1`` dedup guard constrains to the top rank, or ``None``.
     Recognises ``X = 1``, ``1 = X``, ``X <= 1`` and ``1 >= X`` with a literal integer ``1`` (a
     row number is ``>= 1``, so ``<= 1`` coincides with ``= 1``). Any other comparison keeps more
-    than the top row and grounds no key. ``X`` is returned unevaluated for the caller to test."""
+    than the top row, so it does not pin down a dedup key. ``X`` is returned unevaluated for the
+    caller to test."""
     if isinstance(leaf, exp.EQ):
         if _is_literal_one(leaf.expression):
             return leaf.this

--- a/src/dblect/sql/aggregates.py
+++ b/src/dblect/sql/aggregates.py
@@ -5,18 +5,21 @@ the propagator's aggregate dispatch already uses, dialect-neutral: bigquery
 ``min_by``/``max_by`` arrive as ``ArgMin``/``ArgMax``, duckdb ``median``/``quantile`` have
 dedicated nodes). They are recorded together rather than in two parallel tables.
 
-**Magnitude (result domain).** What domain the result lives in, which decides the
-currency-coherence obligation (``docs/design/domain-type-algebra.md``):
+**Magnitude (result domain).** What domain the result lives in. A COMBINE aggregate like
+``sum`` blends every row into one new value, so if the rows carry different per-row tags
+(mixed currencies, say) the blend is meaningless; this axis is what tells the domain-type
+checker to demand a constant tag across the group before trusting the result
+(``docs/design/domain-type-algebra.md``):
 
 * **COMBINE** synthesizes a new value out of many (``sum``, ``avg``, a spread, a middle).
-  A per-row companion that varies within the group corrupts the result, so a combining
-  reduction carries the coherence obligation.
+  A per-row tag that varies within the group corrupts the result, so this class needs the
+  constant-tag check.
 * **SELECT** returns one of the input values (``min``, ``max``, ``arg_min``). The value is
-  real, so the operation does not fail; only its tag is uncertain, because the comparison
-  that chose it was tag-blind. The result widens to top.
+  real, so the operation does not fail; only its tag is uncertain, since the comparison
+  that chose it never looked at tags. The result's tag widens to "unknown".
 * **COUNT** ignores the magnitude and yields a tag-free cardinality.
-* ``None`` is "no magnitude obligation": the boolean, bitwise, and collection folds live
-  on non-magnitude domains, so the lenient default reads them as having no obligation
+* ``None`` means no magnitude obligation applies: the boolean, bitwise, and collection folds
+  live outside this domain typing, so the lenient default treats them as unconstrained
   rather than guessing.
 
 **Multiplicity (duplicate-sensitivity).** Whether a fan-out that duplicates input rows
@@ -110,7 +113,7 @@ _REGISTRY: Mapping[type[exp.AggFunc], AggregateProfile] = {
     exp.Count: AggregateProfile(AggregateBehavior.COUNT, duplicate_sensitive=True),
     exp.CountIf: AggregateProfile(AggregateBehavior.COUNT, duplicate_sensitive=True),
     exp.ApproxDistinct: AggregateProfile(AggregateBehavior.COUNT, duplicate_sensitive=False),
-    # Non-magnitude folds (no coherence obligation), classified on the multiplicity axis.
+    # Non-magnitude folds (outside the constant-tag check), classified on the multiplicity axis.
     # Boolean and bitwise-and/or have an idempotent combine (``x AND x = x``, ``x & x = x``),
     # so they are safe; bitwise xor cancels a duplicated row (``x ^ x = 0``) and collection
     # folds gather every row into a container, so both are sensitive.
@@ -161,12 +164,12 @@ def strips_duplicates(agg: exp.Func) -> bool:
 def duplicate_sensitive(agg: exp.Func, *, safe_builtins: frozenset[str] = frozenset()) -> bool:
     """True if a fan-out that duplicates ``agg``'s input rows would distort its result.
 
-    The duplicate-sensitivity predicate of the hazard algebra. A ``DISTINCT`` on the input
-    removes the duplicates before the fold, so any aggregate becomes safe
-    (``count(distinct x)``). Otherwise the answer is the aggregate type's registry fact;
-    a ``max`` or ``bool_or`` is safe, a ``sum`` or ``array_agg`` is sensitive. An
-    ``exp.Anonymous`` UDF has no registry type, so it is sensitive unless the adapter names
-    it in ``safe_builtins`` (case-insensitive): the firewall posture keeps an unknown fold
+    This is the duplicate-sensitivity check from ``docs/design/hazard-algebra.md``. A
+    ``DISTINCT`` on the input removes the duplicates before the fold, so any aggregate
+    becomes safe (``count(distinct x)``). Otherwise the answer is the aggregate type's
+    registry fact; a ``max`` or ``bool_or`` is safe, a ``sum`` or ``array_agg`` is
+    sensitive. An ``exp.Anonymous`` UDF has no registry type, so it is sensitive unless
+    the adapter names it in ``safe_builtins`` (case-insensitive): an unknown fold keeps
     firing rather than clearing a fan-out on a guess."""
     if strips_duplicates(agg):
         return False

--- a/src/dblect/sql/anti_join.py
+++ b/src/dblect/sql/anti_join.py
@@ -10,10 +10,11 @@ or the ``LEFT JOIN ... IS NULL`` idiom): a filter over the probe side preserves 
 cannot fan out. The nullability detector consumes every form, since a NULL probe key is kept
 as a spurious non-match rather than dropped, the inverse of an ordinary join's hazard.
 
-The classifier is deliberately oracle-free: it decides each form structurally so any consumer
-can call it without threading the nullability substrate. The one edge that needs nullability,
-a ``LEFT JOIN ... IS NULL`` on a column that is not a join key, is left unrecognised here (see
-:func:`_left_is_null_anti_join`); a consumer that holds the substrate decides it itself.
+The classifier is deliberately oracle-free: it decides each form structurally so any caller
+can use it without first working out which columns can be NULL. The one edge that needs that
+information, a ``LEFT JOIN ... IS NULL`` on a column that is not a join key, is left
+unrecognised here (see :func:`_left_is_null_anti_join`); a caller that already has it decides
+that case itself.
 """
 
 from __future__ import annotations
@@ -147,8 +148,8 @@ def _left_is_null_anti_join(j: exp.Join, *, leaves: list[Expr], from_alias: str)
     column is one of ``R``'s join-key columns in ``P``. A matched row then has ``l.x = R.col`` so
     ``R.col`` is non-NULL there and the filter drops it, keeping exactly the unmatched rows. The
     equality match proves the column non-NULL, so the recognition needs no nullability oracle. An
-    ``IS NULL`` on a non-key column can leak matched rows and is left for a substrate-backed
-    consumer to decide."""
+    ``IS NULL`` on a non-key column can leak matched rows and is left for a caller that knows
+    which columns can be NULL to decide."""
     matched_alias = j.this.alias_or_name
     matched_cols = _sides_of(sg.on_of(j)).get(matched_alias, frozenset())
     if not matched_cols:
@@ -218,8 +219,8 @@ def _not_in_anti_join(in_node: exp.In, *, from_alias: str, node: Expr) -> AntiJo
 
 def single_projected_column(query: Expr) -> tuple[str, str] | None:
     """The ``(relation, column)`` a subquery projects, when it is a single bare column over a
-    single bare-table FROM with no joins; else ``None``. The lower-cased column matches the
-    nullability substrate's own column keys."""
+    single bare-table FROM with no joins; else ``None``. The column name is lower-cased to
+    match how dblect's nullability tracking keys its own columns."""
     select = query.this if isinstance(query, exp.Subquery) else query
     if not isinstance(select, exp.Select) or sg.joins_of(select):
         return None

--- a/src/dblect/sql/findings.py
+++ b/src/dblect/sql/findings.py
@@ -2,10 +2,11 @@
 
 A ``Finding`` is a single structural observation about one SQL statement, located
 by a line span. Every detector layer emits these: the structural pattern detectors
-in :mod:`dblect.sql.patterns`, the lineage-grounded detectors under
-:mod:`dblect.nullability`, :mod:`dblect.uniqueness`, :mod:`dblect.snapshot`, and
-:mod:`dblect.flatten`. ``FindingKind`` is their shared vocabulary, so it lives here
-rather than in any one detector module.
+in :mod:`dblect.sql.patterns`, which look at one statement alone, and the detectors
+under :mod:`dblect.nullability`, :mod:`dblect.uniqueness`, :mod:`dblect.snapshot`,
+and :mod:`dblect.flatten`, which draw on facts traced across model boundaries.
+``FindingKind`` is their shared vocabulary, so it lives here rather than in any one
+detector module.
 
 These are span-in-one-statement findings, distinct from the declaration-level
 findings :mod:`dblect.check.findings` carries (``CheckFindingKind`` /
@@ -69,7 +70,7 @@ class Finding:
     """A single static-analysis observation about a SQL statement.
 
     ``line_start`` and ``line_end`` are 1-indexed line numbers in the SQL
-    the detector was given — the model's ``compiled_code``, which dbt
+    the detector was given: the model's ``compiled_code``, which dbt
     renders with refs and macro calls expanded inline. Line numbers
     correspond to the compiled output; the reporter still surfaces the
     model's source file path so navigation works as expected.

--- a/src/dblect/sql/guards.py
+++ b/src/dblect/sql/guards.py
@@ -14,12 +14,13 @@ The guards read one fact about the surrounding query: which relation aliases the
 join NULL-pads (``nullable``, from :func:`outer_join_optional_aliases`). A column whose
 qualifier is not among them is drawn from a relation the join keeps present, so it is a
 guaranteed-present value for the fallback rules. An unqualified column carries no alias to
-check, so it is treated as not-guaranteed-present: the firewall posture keeps firing under
-uncertainty rather than clearing on a guess.
+check, so it is treated as not-guaranteed-present: uncertainty keeps the finding firing
+rather than clearing it on a guess.
 
-The catalog is the evidence side of the broad-net posture (``docs/design/hazard-algebra.md``):
-each guard recognises a proven-safe shape, and an unrecognised shape keeps firing, so an
-incomplete catalog costs a false positive, never a false negative.
+That is the same conservative default the catalog as a whole follows
+(``docs/design/hazard-algebra.md``): each guard recognises a proven-safe shape, and an
+unrecognised shape keeps firing, so an incomplete catalog costs a false positive, never a
+false negative.
 """
 
 from __future__ import annotations

--- a/src/dblect/sql/parse.py
+++ b/src/dblect/sql/parse.py
@@ -3,9 +3,10 @@
 A model usually compiles to a single ``SELECT``, but a macro that emits a helper UDF
 inline produces a script: leading ``CREATE [TEMPORARY] FUNCTION`` / ``DECLARE`` /
 ``SET`` statements before the terminal query. `parse_result_statement` keeps the final
-top-level query and drops the prelude. A call to an inline-defined function stays an
-ordinary call, which the propagator reads as a value-erasing transform, so an inline
-UDF degrades to the opaque posture rather than failing the parse.
+top-level query and drops the prelude. A call to the inline-defined function itself still
+parses as an ordinary function call; lineage tracking can't see inside it, so it treats
+that call like any other function it doesn't recognize, unable to say what happens to the
+value, rather than treating it as a parse failure.
 
 A script with more than one query, or none, cannot be reduced to a single model, so
 the caller records a resolution-coverage miss instead of guessing. `parse_sql` is the

--- a/src/dblect/sql/patterns.py
+++ b/src/dblect/sql/patterns.py
@@ -548,10 +548,10 @@ def detect_inner_flatten_row_drop(
     spelling (``UNNEST``, spark ``explode``, snowflake ``FLATTEN``): a literal ``ARRAY[...]``
     constructor with one or more elements is the local, always-on case (the wide-to-long pivot
     idiom). ``column_is_nonempty``, when supplied, answers
-    whether an unnested *column* is provably non-empty; the audit builds it over the
-    ``array_nonemptiness`` property resolved across model and CTE boundaries, so a
-    rebuilt-then-unnested array stays quiet. The detector treats columns as opaque
-    otherwise, which keeps this module free of lineage types.
+    whether an unnested *column* is provably non-empty; the audit builds it from the
+    ``array_nonemptiness`` property, resolved across model and CTE boundaries, so a
+    rebuilt-then-unnested array stays quiet. Without it, a column's non-emptiness is simply
+    unknown, which keeps this module free of lineage types.
     """
     out: list[Finding] = []
     for sel in sg.find_all_selects(tree):
@@ -808,9 +808,9 @@ def _array_expr_nonempty(
 
     The intrinsic constructors the SQL vocabulary proves from the node alone are the always-on
     local cases: a literal ``ARRAY[...]``, a ``GENERATE_ARRAY`` over literal bounds. For a
-    column, the answer comes from ``column_is_nonempty``, the lineage-grounded predicate the
-    audit supplies; without it, a column is treated as opaque, so the detector module stays
-    free of lineage types.
+    column, the answer comes from ``column_is_nonempty``, a check the audit supplies from facts
+    traced across model boundaries; without it, a column's non-emptiness is simply unknown, so
+    this module stays free of lineage types.
 
     Non-emptiness is proved where the array is *produced*. A column that arrives through the
     nullable side of an outer join can still be NULL at the unnest, and ``UNNEST(NULL)`` drops

--- a/src/dblect/templating.py
+++ b/src/dblect/templating.py
@@ -75,9 +75,9 @@ def make_environment() -> Environment:
 def shared_environment() -> Environment:
     """The dbt-template parsing environment, materialized once on first use.
 
-    Building an environment wires three extensions, and a caller parsing one
-    environment per node otherwise. The environment only ever ``parse``s (it never
-    renders and holds no per-source state), so a single instance serves every walk.
-    Callers that want an isolated environment build one with :func:`make_environment`.
+    Building an environment wires up three extensions, wasted work if a caller built
+    one per node instead. The environment only ever ``parse``s (it never renders and
+    holds no per-source state), so one instance can safely serve every walk. Callers
+    that want an isolated environment build one with :func:`make_environment`.
     """
     return make_environment()

--- a/src/dblect/types/__init__.py
+++ b/src/dblect/types/__init__.py
@@ -1,10 +1,10 @@
-"""The dblect declaration layer: domain types, model contracts, and the bridge
-that turns them into substrate facts.
+"""dblect's declaration layer: domain types, model contracts, and the bridge
+that turns them into facts the lineage engine can act on.
 
 A project declares meaning here, in Python beside its dbt project: domain types
 built from SQL primitives, bound to models by contracts. The framework reads the
-classes as schemas (never instantiating them), resolves them against the dbt
-manifest, and feeds the lineage engine the facts it propagates. See
+classes as schemas (it never instantiates them), resolves them against the dbt
+manifest, and feeds the resulting facts to the lineage engine. See
 ``docs/design/declaration-dsl.md``.
 """
 

--- a/src/dblect/types/bridge.py
+++ b/src/dblect/types/bridge.py
@@ -1,8 +1,9 @@
-"""The fact bridge: registered contracts become substrate facts and findings.
+"""Turns registered contracts into the facts and findings the lineage engine
+consumes.
 
-This is the connective tissue between the authoring surface and the lineage
-engine. It resolves every contract's ``dbt_model`` and column references against
-the manifest, then emits the facts the propagation properties ground from:
+This module connects the Python declarations in this package to the dbt
+project: it resolves each contract's ``dbt_model`` and column references
+against the manifest, then produces:
 
 * a :class:`~dblect.lineage.properties.domain_type.DomainTag` per typed
   magnitude column, with its unit and nominal companions bound to the columns
@@ -12,10 +13,11 @@ the manifest, then emits the facts the propagation properties ground from:
   ``collect`` with the keys read from dbt ``unique`` tests and constraints;
 * the foreign-key edges the grain analysis reads.
 
-Resolution runs after the whole registry is populated, so a name that does not
-resolve becomes a :class:`ContractIssue` and the remaining contracts still
-ground their facts. The discoverers wrap this for the substrate's
-``FactDiscoverer`` protocol. See ``docs/design/propagation-soundness.md``.
+Resolution runs after every contract has registered, so a name that fails to
+resolve becomes a :class:`ContractIssue` while the rest still produce their
+facts. The discoverer classes below just adapt this resolution step to the
+interface the lineage engine uses to collect facts. See
+``docs/design/propagation-soundness.md``.
 """
 
 from __future__ import annotations
@@ -174,8 +176,8 @@ def _column_of(spec: DomainSpec, fname: str) -> str:
 def _build_tag(
     decl_name: str, spec: DomainSpec, src: SourceRef, known: frozenset[str] | None
 ) -> tuple[BoundTag | None, list[ContractIssue]]:
-    """Derive the bound tag for one domain-typed column, or the findings that
-    keep it from grounding.
+    """Build the domain tag for one domain-typed column, or explain why it
+    can't be built.
 
     Returns ``(None, [])`` when the type carries no magnitude (nothing to tag,
     and nothing wrong). Validation against a known column set runs only when one
@@ -418,9 +420,11 @@ def _resolve_methods(
     manifest: Manifest,
     out: _Accumulator,
 ) -> None:
-    """Lower each captured ``@contract`` method onto the substrate. A fact becomes
-    its matching ground fact (a dependency, a key, an edge); a predicate is set
-    aside for the execution loop. A body that failed at capture is a finding."""
+    """Turn each captured ``@contract`` method into what it declared: a fact
+    becomes the matching kind of fact on the resolved output (a dependency, a
+    key, an edge), while a predicate is set aside for the execution loop to
+    check later. A method whose body failed to parse at capture time surfaces
+    here as a finding."""
     for method in cspec.methods:
         if method.error is not None:
             out.issues.append(
@@ -550,11 +554,11 @@ def _own_columns(
 ) -> list[str] | None:
     """The column names of ``columns``, all of which must live on the contract's
     own model and (when ``known`` is supplied) name a real column. A reference into
-    another model is a finding, since the dependency and key facts the substrate
-    carries are single-relation; a column absent from ``known`` is an unknown-column
-    finding, matching the declaration path. ``fold`` case-folds the returned names
-    to the dependency property's lowercased column universe; key and grain facts
-    keep the authored case, which is why they pass ``fold=False``."""
+    another model is a finding, since dependency and key facts here only range over
+    a single relation; a column absent from ``known`` is an unknown-column
+    finding, matching the declaration path. ``fold`` lowercases the returned names
+    to match the functional-dependency property's column casing; key and grain
+    facts keep the name as written, which is why they pass ``fold=False``."""
     names: list[str] = []
     for col in columns:
         if col.model is not None:
@@ -680,8 +684,7 @@ def foreign_key_edges(
 ) -> tuple[ForeignKeyEdge, ...]:
     """Every foreign-key edge the project declares: contract ``ForeignKey``
     markers merged with dbt ``relationships`` tests, de-duplicated so an edge
-    stated both ways appears once. The merge point a future fan-out finding or
-    fixture generator reads from."""
+    stated both ways appears once."""
     contract_edges = resolve_contracts(manifest, registry=registry).foreign_keys
     return tuple(dict.fromkeys((*contract_edges, *dbt_relationship_edges(manifest))))
 
@@ -712,7 +715,8 @@ class _KeyDiscoverer:
 
 class _FdDiscoverer:
     """Yields the contract-sourced functional-dependency facts (from
-    ``self.a.determines(self.b)`` methods) that ground the FD property."""
+    ``self.a.determines(self.b)`` methods) that feed the functional-dependency
+    property."""
 
     def discover(
         self, manifest: Manifest, *, name_to_source: Mapping[str, SourceRef]

--- a/src/dblect/types/contract.py
+++ b/src/dblect/types/contract.py
@@ -60,9 +60,10 @@ _CONSTRAINT_ALIASES: Mapping[str, tuple[str, float]] = {
 
 @dataclass(frozen=True, slots=True)
 class _FieldSpec:
-    """What a ``Field(...)`` call captured: checkable constraints and inline
-    fixings (the vouched-meaning half, applied as a refinement of the column's
-    declared type)."""
+    """What a ``Field(...)`` call captured: constraints checked against real
+    data, and inline fixings (a meaning the caller asserts and dblect trusts
+    rather than verifies), applied as a refinement of the column's declared
+    type."""
 
     constraints: Constraints | None
     fixings: Mapping[str, object]

--- a/src/dblect/types/domain.py
+++ b/src/dblect/types/domain.py
@@ -9,9 +9,9 @@ narrows a type all land in the same spec, so they mean the same thing:
 * ``T.columns(field="col")`` maps fields to warehouse columns;
 * the call form ``T(field=value, amount="col")`` is sugar for both, splitting a
   magnitude's string into a column map and everything else into a fixing;
-* subclassing extends (adds fields) and fixes (a class-level default), with
-  multiple inheritance taking the union of facets and requiring agreement where
-  two bases fix the same field.
+* subclassing extends (adds fields) and fixes (a class-level default); with
+  multiple inheritance, the result has every field and fixing either base has,
+  and two bases that fix the same field must agree.
 
 This mirrors Pydantic's class-as-declaration shape without its runtime: the
 class is never instantiated to validate a row. Calling it returns a *narrowed

--- a/src/dblect/types/enums.py
+++ b/src/dblect/types/enums.py
@@ -1,14 +1,14 @@
-"""Marker bases that classify a domain type's enum fields by how the substrate
-carries them.
+"""Marker base classes that tell dblect how to treat a domain type's enum
+fields: as a unit of measure, or as a plain category.
 
-A :class:`UnitEnum` is a *dimensional* unit (a currency is the worked example),
-so it rides in a tag's dimensional monomial and does exponent arithmetic under
-``*`` and ``/``. A :class:`NominalEnum` is a *nominal* category (a country
-code), carried by equality only. Both subclass :class:`enum.StrEnum`, so a
-member equals its string code and ``MyUnit("USD")`` round-trips a literal, which
-is what lets a contract accept ``currency="USD"`` and ``currency=MyUnit.USD``
-alike (an out-of-domain literal is a finding, raised by neither the enum nor
-here).
+A :class:`UnitEnum` is a unit, like a currency: multiplying or dividing two
+magnitudes combines or cancels their units the way exponents do (dividing two
+dollar amounts by each other cancels the currency). A :class:`NominalEnum` is a
+plain category, like a country code, compared only for equality. Both subclass
+:class:`enum.StrEnum`, so a member equals its string code and ``MyUnit("USD")``
+round-trips a literal, which is what lets a contract accept ``currency="USD"``
+and ``currency=MyUnit.USD`` alike (an out-of-domain literal is a finding,
+raised by neither the enum nor here).
 
 A project declares its own vocabularies by subclassing these. The
 ``dblect.demo`` package ships partial ISO 4217 / 3166-1 slices to drive the
@@ -21,8 +21,8 @@ from enum import StrEnum
 
 
 class UnitEnum(StrEnum):
-    """A dimensional unit: a category that multiplies and divides (a currency)."""
+    """A unit of measure that multiplies and divides, like a currency."""
 
 
 class NominalEnum(StrEnum):
-    """A nominal category carried by equality (a country, a region code)."""
+    """A category compared only by equality, like a country or region code."""

--- a/src/dblect/types/errors.py
+++ b/src/dblect/types/errors.py
@@ -1,11 +1,11 @@
 """The one error the authoring layer raises while reading declarations.
 
 A misuse the framework catches at *authoring* time (refining a field that does
-not exist, fixing a magnitude to a literal, combining two facets that disagree)
-raises this. A mismatch the framework catches at *resolution* time (a dbt model
-that does not exist, an out-of-domain currency literal) is a finding instead, so
-one broken declaration does not blind the audit to the rest. See
-``docs/design/declaration-dsl.md``.
+not exist, fixing a magnitude to a literal, combining two base types that
+disagree about the same field) raises this. A mismatch the framework catches at
+*resolution* time (a dbt model that does not exist, an out-of-domain currency
+literal) is a finding instead, so one broken declaration does not blind the
+audit to the rest. See ``docs/design/declaration-dsl.md``.
 """
 
 from __future__ import annotations

--- a/src/dblect/types/scalars.py
+++ b/src/dblect/types/scalars.py
@@ -1,14 +1,14 @@
 """Scalar field types and the rule that classifies a field by its meaning.
 
-A domain type's field is read by what it *is*, not annotated by hand. The
-classification is the seam between the author's ordinary Python annotations and
-the substrate's tag algebra (``docs/design/domain-type-algebra.md``):
+A domain type's field is read by what it *is*, not annotated by hand. This
+classification connects the author's ordinary Python annotations to dblect's
+tag algebra (``docs/design/domain-type-algebra.md``):
 
 * a numeric :class:`Decimal` (or ``Decimal(p, s)``), a :class:`Count`, or a
   floating-point ``float`` / :class:`Float` is a **magnitude**, the field a tag
   rides on;
 * a :class:`~dblect.types.enums.UnitEnum` (a currency) is a **unit**, the
-  dimensional companion of the magnitude;
+  companion that the magnitude is measured in;
 * a :class:`~dblect.types.enums.NominalEnum`, a ``bool``, a ``str``, or a
   :class:`Varchar` is a **nominal** category, carried by equality;
 * a :class:`Date`, a :class:`Timestamp` / ``datetime``, and a bare integer
@@ -17,7 +17,7 @@ the substrate's tag algebra (``docs/design/domain-type-algebra.md``):
 A bare integer is the one scalar whose role its algebra does not settle: an
 integer is algebraically a perfect quantity, yet by role it is as often an
 identifier or a calendar year, which are tags. The lenient default reads it as
-opaque (inert), making no claim either way; a measure is spelled ``Count`` /
+inert, making no claim either way; a measure is spelled ``Count`` /
 ``Decimal`` and an identifier or year carries its own domain type. A future
 strict mode rejects a bare integer instead, per the lenient/strict switch in
 ``docs/design/domain-type-algebra.md``.
@@ -41,7 +41,7 @@ class FieldKind(StrEnum):
     """How a field participates in a tag."""
 
     MAGNITUDE = auto()  # the numeric value a tag rides on (an amount, a count)
-    UNIT = auto()  # a dimensional companion (a currency)
+    UNIT = auto()  # the companion a magnitude is measured in (a currency)
     NOMINAL = auto()  # a categorical companion carried by equality
     INERT = auto()  # a scalar that carries no tag (a date)
 
@@ -66,9 +66,9 @@ class FieldDef:
 
 class Decimal:
     """A fixed-point magnitude type, usable bare (``Decimal``) or parameterized
-    (``Decimal(18, 2)``). The parameters annotate precision and scale; the
-    substrate does not yet reason over them, but the contract carries them so a
-    later width check has them to hand."""
+    (``Decimal(18, 2)``). The parameters annotate precision and scale; dblect
+    does not yet reason over them, but the contract carries them so a later
+    width check has them to hand."""
 
     __slots__ = ("precision", "scale")
 

--- a/src/dblect/uniqueness/__init__.py
+++ b/src/dblect/uniqueness/__init__.py
@@ -1,7 +1,7 @@
 """Fact-grounded audit detectors for uniqueness hazards.
 
-The uniqueness *facts* (candidate keys per relation, declared and propagated)
-live on the lineage.facts substrate as ``dblect.lineage.properties.uniqueness``.
+The uniqueness *facts* (candidate keys per relation, declared or propagated
+across the model graph) are implemented in ``dblect.lineage.properties.uniqueness``.
 This package is the audit-facing consumer: detectors that read those keys and
 flag window order-key, join-fanout, and non-deterministic ``LIMIT`` hazards on a
 project's SQL.

--- a/src/dblect/uniqueness/detector.py
+++ b/src/dblect/uniqueness/detector.py
@@ -16,12 +16,12 @@ to make a claim, and stay silent otherwise):
   ``LIMIT`` has no ``ORDER BY``, or one whose order keys are not covered by a known
   uniqueness key, so a re-run materializes a different slice of rows.
 * ``detect_cross_model_fanout``: a duplicate-sensitive aggregate that folds a
-  magnitude an upstream fan-out replicated, over a relation no longer keyed at the
-  magnitude's grain. This one also reads ``where_provenance`` to find the origin a
-  magnitude traces to, the grain ``grain_preserved`` is asked about. A COUNT fold
-  (``COUNT(*)``, ``COUNT(col)``) yields a cardinality, not a magnitude: it counts the
-  relation's rows, whose grain the relation preserves, so it stays silent (the ``SUM(qty)``
-  analog), unlike ``SUM(amount)``.
+  magnitude (a summed value, say) an upstream fan-out replicated, over a relation no
+  longer keyed at the magnitude's grain. It traces the magnitude back to its origin via
+  ``where_provenance``, then asks ``grain_preserved`` whether that origin's grain still
+  holds. A COUNT fold (``COUNT(*)``, ``COUNT(col)``) yields a cardinality, not a
+  magnitude: it counts the relation's rows, whose grain the relation preserves, so it
+  stays silent (the ``SUM(qty)`` analog), unlike ``SUM(amount)``.
 
 The first two read keys from the lineage.facts uniqueness substrate: per-model keys
 come from cross-model propagation (``uniqueness_property`` over the relation graph),

--- a/src/dblect/varinf/__init__.py
+++ b/src/dblect/varinf/__init__.py
@@ -1,10 +1,12 @@
-"""Var inference: discover every ``var()`` / ``env_var()`` reference in a dbt
-project and infer enough about each to enumerate worlds.
+"""Var inference: find every ``var()`` / ``env_var()`` reference in a dbt
+project and work out enough about each one to check the project under every
+value it could take.
 
-This package is the discovery half of the flag system. The Jinja front end
+This package is the discovery half of dblect's flag system, which turns dbt
+vars and env vars into typed configuration. The Jinja front end
 (:mod:`dblect.templating`, :mod:`dblect.varinf.walker`) turns a node's source
-Jinja into :class:`~dblect.varinf.usage.VarUsage` records; later streams fold
-those into typed, domain-bearing flags.
+Jinja into :class:`~dblect.varinf.usage.VarUsage` records; later stages turn
+those into flags with a declared type and a known set of values.
 """
 
 from dblect.varinf.usage import (

--- a/src/dblect/varinf/usage.py
+++ b/src/dblect/varinf/usage.py
@@ -3,9 +3,10 @@
 
 These are the contract between the source-Jinja walker and the inference layer
 that folds usages into a type and a domain. The walker produces them; nothing
-here interprets them. The position is carried as a :data:`UsageContext`, a sum
-of small frozen records (one per syntactic shape) rather than a string tag, so a
-consumer matches over real variants and the type checker enforces exhaustiveness.
+here interprets them. The position is carried as a :data:`UsageContext`, a
+closed set of small frozen records (one per syntactic shape) rather than a
+string tag, so a consumer matches over real variants and the type checker
+enforces exhaustiveness.
 
 The control-flow versus value-substitution distinction the world enumerator
 hinges on is read off the variant: :class:`TruthyTest`, :class:`Comparison`,
@@ -187,9 +188,10 @@ class SourceLocation:
 class VarUsage:
     """One ``var()`` / ``env_var()`` reference, with the position it was found in.
 
-    ``macro_trail`` is empty for a direct reference; the macro-following stream
-    fills it with the macros traversed to reach a usage. ``confidence`` carries
-    the walker's certainty (see :class:`Confidence`).
+    ``macro_trail`` is empty for a direct reference; a later pass that follows
+    ``var`` calls through macro bodies fills it with the macros traversed to
+    reach a usage. ``confidence`` carries the walker's certainty (see
+    :class:`Confidence`).
     """
 
     var_name: str

--- a/src/dblect/varinf/walker.py
+++ b/src/dblect/varinf/walker.py
@@ -1,18 +1,19 @@
 """Walk a node's source Jinja and emit a :class:`VarUsage` per ``var()`` /
 ``env_var()`` reference, tagged with the syntactic position it sits in.
 
-The walk is context-carrying: each recursive step knows what context to assign a
-bare ``var`` call found directly at that position (the ``default`` argument),
-while the operator nodes that define a richer context (``If`` tests, ``Compare``,
-arithmetic, other calls) classify their ``var`` operands themselves. The
-control-flow versus value-substitution signal the world enumerator depends on is
-read straight off the resulting :data:`UsageContext` variant, with no text
-heuristics.
+The walk carries context as it recurses: a bare ``var`` call keeps the context
+its enclosing node set (the ``default`` argument), while a node that gives its
+children a more specific meaning (an ``if`` test, a comparison, an arithmetic
+expression, another call) classifies its own ``var`` operands. That is how a
+var that picks which branch runs (``{% if var('flag') %}``) is told apart from
+one that is just substituted into the rendered SQL (``{{ var('limit') }}``):
+the answer comes straight from which :data:`UsageContext` variant the var
+landed in, never from inspecting the surrounding text.
 
-Direct usage only. A ``var`` reached through a macro is the macro-following
-stream's concern, so a ``var`` passed to another call is recorded as a
-:class:`MacroArg` here and followed there. A body the environment cannot parse
-degrades to one :class:`OpaqueNode` diagnostic rather than raising.
+Direct usage only. A ``var`` reached through a macro call is left for a later
+pass that follows macros; here it is only recorded as a :class:`MacroArg`. A
+body the environment cannot parse degrades to one :class:`OpaqueNode`
+diagnostic rather than raising.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## What this does

Follows on from #232 (already merged): extends the same plain-language
docstring/comment pass to the ten remaining package areas in `src/dblect/`:
its own top level, `sql/`, `types/`, `contracts/`, `adapters/` (+`builtin/`,
no changes needed), `manifest/`, `execution/`, `audit/`, `varinf/`, `demo/`,
`uniqueness/`, `snapshot/` (no changes needed), `nullability/`, `flatten/`,
and `cli/`. No logic changed.

## How

Same approach as #232: one pass per package, reading every docstring and
comment directly rather than matching against a term list, and rewriting
only what didn't hold up for a reader who knows dblect but hasn't read the
design docs. `substrate`, `grounds`/`grounded`, and `opaque` (colliding with
the unrelated `Opacity` enum) turned out to be the most repeated offenders
across packages.

## A few of these were more than wording

- `contracts/decorator.py` called something "the model contract's
  metaclass"; it's actually `__init_subclass__`, verified against
  `types/contract.py`.
- `contracts/decorator.py` also described a "materialized escape hatch" as
  already returning multiple shapes; `capture()`'s real code only accepts
  fact/predicate proxies today and raises on anything else, so that was an
  unbuilt feature described as live.
- `audit/__init__.py`'s module docstring named "replay-determinism" and
  "heuristic invariants" as package components; neither is built.
- Two more grammatically broken sentences (`templating.py`,
  `uniqueness/detector.py`) needed a rewrite regardless of jargon.

## Test plan

- [x] `ruff check`
- [x] `ruff format --check`
- [x] `pyright`
- [x] `pytest` (full suite, 1584 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAE4C5m7unT2uPjd1XthjN