### PR TITLE
feat(lineage): declared dependencies survive UNION merges via grounding identity

### DIFF
--- a/docs/design/refutation-and-verdicts.md
+++ b/docs/design/refutation-and-verdicts.md
@@ -110,14 +110,15 @@ UNKNOWN, because `consistent` passes top (`facts/lattice.py`).
 |---|---|---|---|
 | `domain_type` | yes (`consistent`) | yes (`provisional`) | yes (`DOMAIN_TYPE_CONTRADICTION`, `check/run.py`) |
 | `nullability` | yes (`consistent`) | yes (`provisional`) | no |
-| `uniqueness` | **never consulted** | no | no |
-| `functional_dependency` | **never consulted** | no | no |
+| `uniqueness` | yes (the pre-reconcile record) | yes (`inferred_sink`) | yes (`GRAIN_NOT_ESTABLISHED`, `check/grain.py`) |
+| `functional_dependency` | yes (the pre-reconcile record) | yes (`inferred_sink`) | yes (`DEPENDENCY_NOT_ESTABLISHED`, `check/dependency.py`) |
 | `referential` | no property yet | — | — |
 
 The nullability row is the near-free win: the conflict is already computed, and
 what surfacing it yields is a not-established finding, never a refutation.
 
-The uniqueness and FD rows are blind for a mechanical reason. Both reconcile by meet (`reconcile_by_meet`,
+The uniqueness and FD rows were blind for a mechanical reason, and the record
+described below is what opened them. Both reconcile by meet (`reconcile_by_meet`,
 `lineage/property.py`): declared and inferred keys are same-polarity lower
 bounds, so the flow value is their union and `consistent` is never consulted.
 The consequence bites the contract layer directly: after reconcile, the stored
@@ -243,11 +244,16 @@ defeater tells it exactly which hop to test.
 - **The contract-layer notes are not blocked.** Their emitters are
   not-established emitters, and nothing they propose consumes machinery that
   does not exist.
-- **The two-channel record lands with its first consumer**, the #202 grain
-  emitter, since that is the reader the record exists for.
+- **The two-channel record landed with its first consumer**, the #202 grain
+  emitter (`check/grain.py`), since that is the reader the record exists for.
+- **The FD reader** (`check/dependency.py`) reuses it. Its witness lives in the
+  dependency walk: a union records what each arm carried into it, renamed
+  through later projections beside the dependency set, so the reader can name
+  the union that dropped a declaration every arm held. The policy both readers
+  share, which declarations are claims about the SELECT and which models have
+  a derived record to compare against, sits in `check/declared.py`.
 - **The nullability not-established finding** follows, reusing the shared
   reader with site-localized reporting.
-- **The FD reader** reuses the uniqueness machinery.
 - **Proven negatives wait** on cardinality and non-emptiness facts (#38 and
   relatives) and re-enter, when they do, as an evidence grade on hazards.
 - **Referential** waits on the property.
@@ -258,9 +264,12 @@ defeater tells it exactly which hop to test.
   soften from a run-stopping error to a Refuted finding, now that a finding
   grade exists for it to land in?
 - Where does the witnessed defeater live structurally? The nullability taint
-  carries it in the graph; the uniqueness walk would need to return the
-  surviving finer key alongside the key set, a small widening of the reducer's
-  return channel.
+  carries it in the graph; the uniqueness witness is a member of the derived
+  key set itself; the dependency walk carries its union witness beside the
+  dependency set and exposes it through a second walk over the tree
+  (`union_merges`) rather than through the reducer's return value. Whether
+  that second walk should become a recorded channel of the one propagation is
+  open.
 - Does Established deserve surfacing (a proven count beside the caveat), or
   does counting proofs invite the same false comfort the finding-count
   discipline avoids?

--- a/src/dblect/check/declared.py
+++ b/src/dblect/check/declared.py
@@ -1,0 +1,66 @@
+"""The judging policy the declared-versus-derived checks share: which declarations
+are claims about the SELECT at all, and which models have a derived record worth
+comparing against. The record is what the SQL derived before the declaration was
+folded in, since the combined value contains the declaration and would vouch for
+itself. Each check supplies its own notion of established and its own witnessed
+defeater."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from typing import Protocol, TypeVar, assert_never
+
+from dblect.lineage.facts.model import (
+    Annotation,
+    CompileValue,
+    Declared,
+    Fact,
+    NativeConstraint,
+    Provenance,
+)
+from dblect.lineage.graph import SourceRef
+
+
+class _Bounded(Protocol):
+    """A lattice value that knows when it is the formal bottom."""
+
+    @property
+    def is_bottom(self) -> bool: ...
+
+
+V = TypeVar("V", bound=_Bounded)
+
+
+def judged_provenance(provenance: Provenance) -> bool:
+    """Whether this provenance is a person's claim about what the SELECT produces,
+    the only kind worth judging. A native constraint is enforced by the warehouse's
+    write path, not the query (#48 asks whether that enforcement is real). A compile
+    value is minted by the toolchain, not asserted by a person: a deduplicating
+    incremental's ``unique_key`` is enforced by the merge on write, so its SELECT is
+    expected to produce finer rows, and flagging it would be wrong (#7)."""
+    match provenance:
+        case Declared():
+            return True
+        case NativeConstraint() | CompileValue():
+            return False
+    assert_never(provenance)
+
+
+def judged_declarations(
+    facts: Mapping[SourceRef, tuple[Fact[V, SourceRef], ...]],
+    derived: Mapping[SourceRef, Annotation[V]],
+) -> Iterator[tuple[SourceRef, Fact[V, SourceRef], V]]:
+    """Each declaration worth judging, with what its model's SQL derived on its
+    own, in a stable order. Passed over: a model absent from ``derived`` (no SQL of
+    its own to judge; coverage surfaces build failures), a provisional value
+    (evidence resting on a known upstream contradiction), the formal bottom (it
+    carries every claim), and conditional facts (claims over a row filter, which
+    activation owns)."""
+    for scope, bucket in sorted(facts.items(), key=lambda kv: kv[0].unique_id):
+        ann = derived.get(scope)
+        if ann is None or ann.provisional or ann.value.is_bottom:
+            continue
+        for fact in bucket:
+            if fact.condition is not None or not judged_provenance(fact.provenance):
+                continue
+            yield scope, fact, ann.value

--- a/src/dblect/check/dependency.py
+++ b/src/dblect/check/dependency.py
@@ -1,0 +1,116 @@
+"""Checking a declared dependency against the SQL that is supposed to keep it.
+
+The dependency twin of the grain check: a declared ``zip determines city`` is
+judged against what the model's SQL derives on its own, before the declaration is
+folded in. SQL that re-derives it (a GROUP BY on zip, a source that carries it)
+establishes it, and failing to re-derive it is not evidence by itself, since the
+walk prefers silence to guessing. What counts as evidence is a UNION whose every
+arm carries the dependency, because two arms may map one zip to different cities:
+the merge is where the guarantee stops. A union with an arm the walk knows nothing
+about is no evidence, since that arm may have lost the dependency earlier. Even then
+the data may agree on every shared zip, so the finding says not established rather
+than violated, and warns rather than errors, the grade
+``docs/design/refutation-and-verdicts.md`` assigns the grain finding too.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+
+from dblect.audit.sourcemap import LineMap
+from dblect.check.declared import judged_declarations
+from dblect.check.findings import CheckFinding, CheckFindingKind
+from dblect.check.locate import file_of, source_span, span_of
+from dblect.lineage.facts.model import Annotation, Fact
+from dblect.lineage.graph import RelationLineageGraph, SourceRef
+from dblect.lineage.properties.functional_dependency import (
+    FD,
+    FDSet,
+    UnionMerge,
+    determines,
+    union_merges,
+)
+from dblect.manifest import Manifest
+from dblect.sql import _sqlglot as sg
+
+
+def dependency_witness(declared: FD, merges: Iterable[UnionMerge]) -> UnionMerge | None:
+    """The union a declared dependency is dropped at, if there is one: every arm
+    entails it, so an arm carrying ``zip -> region`` and ``region -> city`` counts.
+    Ties go to the earliest in the SQL, so the finding reads the same every run."""
+    witnesses = [
+        merge
+        for merge in merges
+        if all(
+            determines(FDSet(arm), declared.determinant, declared.dependent) for arm in merge.arms
+        )
+    ]
+    if not witnesses:
+        return None
+    return min(witnesses, key=lambda merge: sg.line_range(merge.union) or (0, 0))
+
+
+def declared_dependency_findings(
+    manifest: Manifest,
+    fd_facts: Mapping[SourceRef, tuple[Fact[FDSet, SourceRef], ...]],
+    inferred: Mapping[SourceRef, Annotation[FDSet]],
+    flow: Mapping[SourceRef, Annotation[FDSet]],
+    relations: RelationLineageGraph,
+    line_maps: dict[str, LineMap],
+) -> list[CheckFinding]:
+    """One finding per declared dependency this model's SQL drops at a union.
+
+    Declarations are judged against ``inferred``, what each model's SQL derived on
+    its own. The union walk reads this model's sources at ``flow`` instead, which
+    folds in their declarations: upstream claims are trusted, and the only claim
+    under test is this model's own."""
+    model_fds = {ref: ann.value for ref, ann in flow.items()}
+    out: list[CheckFinding] = []
+    judged: set[tuple[SourceRef, FD]] = set()
+    merges_of: dict[SourceRef, frozenset[UnionMerge]] = {}
+    for scope, fact, derived in judged_declarations(fd_facts, inferred):
+        for declared in fact.value.fds:
+            if (scope, declared) in judged:
+                continue
+            judged.add((scope, declared))
+            if determines(derived, declared.determinant, declared.dependent):
+                continue
+            if scope not in merges_of:
+                tree = relations.derivation(scope)
+                merges_of[scope] = (
+                    union_merges(tree, model_fds) if tree is not None else frozenset()
+                )
+            witness = dependency_witness(declared, merges_of[scope])
+            if witness is None:
+                continue
+            out.append(_finding(manifest, scope, fact, declared, witness, line_maps))
+    return out
+
+
+def _finding(
+    manifest: Manifest,
+    scope: SourceRef,
+    fact: Fact[FDSet, SourceRef],
+    declared: FD,
+    witness: UnionMerge,
+    line_maps: dict[str, LineMap],
+) -> CheckFinding:
+    determinant = ", ".join(sorted(declared.determinant))
+    attribution = f" (declared by {fact.detail})" if fact.detail else ""
+    line_start, line_end = span_of(witness.union)
+    return CheckFinding(
+        kind=CheckFindingKind.DEPENDENCY_NOT_ESTABLISHED,
+        message=(
+            f"declared dependency ({determinant} -> {declared.dependent}){attribution} is "
+            "not established: every arm of the UNION carries it, but the merge does "
+            f"not, since two arms may map one value of ({determinant}) to different "
+            f"values of {declared.dependent}. Settle the mapping from one source "
+            "before the union, or correct the declaration to what the SQL produces."
+        ),
+        model_unique_id=scope.unique_id,
+        file_path=file_of(manifest, scope),
+        column=declared.dependent,
+        line_start=line_start,
+        line_end=line_end,
+        source_span=source_span(manifest, scope.unique_id, line_start, line_end, line_maps),
+    )

--- a/src/dblect/check/findings.py
+++ b/src/dblect/check/findings.py
@@ -48,6 +48,12 @@ class CheckFindingKind(StrEnum):
     established rather than that it is violated. See
     ``docs/design/refutation-and-verdicts.md``."""
 
+    DEPENDENCY_NOT_ESTABLISHED = auto()
+    """A model's SQL drops a declared dependency at a UNION whose every arm carried
+    it (each arm can honour ``zip -> city`` alone while mapping one zip differently).
+    The arms may still agree on every shared zip, so this too says not established
+    rather than violated."""
+
     RESOLUTION_BELOW_FLOOR = auto()
     """Lineage resolution across the project sits below the configured floor, so
     the analysis covers only a fraction of columns and a clean report would

--- a/src/dblect/check/grain.py
+++ b/src/dblect/check/grain.py
@@ -35,17 +35,11 @@ for claims about rows.
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import assert_never
 
+from dblect.check.declared import judged_declarations
 from dblect.check.findings import CheckFinding, CheckFindingKind
-from dblect.lineage.facts.model import (
-    Annotation,
-    CompileValue,
-    Declared,
-    Fact,
-    NativeConstraint,
-    Provenance,
-)
+from dblect.check.locate import file_of
+from dblect.lineage.facts.model import Annotation, Fact
 from dblect.lineage.graph import SourceRef
 from dblect.lineage.properties.functional_dependency import NO_FDS, FDSet, determines
 from dblect.lineage.properties.uniqueness import CandidateKeySet, Key
@@ -90,60 +84,27 @@ def declared_grain_findings(
     ``key_facts`` holds every key a user declared, read from the same place the
     propagation reads them so the two cannot disagree about what was claimed.
     ``inferred`` holds the keys each model's SQL implies on its own, recorded before
-    declared keys were merged in.
-
-    A model missing from ``inferred`` has no SQL of its own to judge, a source or a
-    model that failed to build, and is passed over; the coverage report is what
-    surfaces the ones that failed to build. We also stay quiet when the keys we
-    derived rest on contradictory upstream declarations, since evidence drawn from a
-    known contradiction is not worth reporting.
+    declared keys were merged in. Which declarations are judged at all, and against
+    which models, is :func:`judged_declarations`' policy, shared with the dependency
+    check.
     """
     out: list[CheckFinding] = []
     judged: set[tuple[SourceRef, Key]] = set()
-    for scope, bucket in sorted(key_facts.items(), key=lambda kv: kv[0].unique_id):
-        inferred_ann = inferred.get(scope)
-        if inferred_ann is None or inferred_ann.provisional:
-            continue
-        derived = inferred_ann.value
-        if derived.is_bottom:
-            continue  # the formal universal element already carries every key
+    for scope, fact, derived in judged_declarations(key_facts, inferred):
         fd_ann = fd.get(scope)
         fds = fd_ann.value if fd_ann is not None else NO_FDS
-        for fact in bucket:
-            if not _judged_provenance(fact.provenance):
+        for authored in fact.value.keys:
+            declared = frozenset(col.lower() for col in authored)
+            if (scope, declared) in judged:
                 continue
-            if fact.condition is not None:
-                continue  # a conditional key holds only over a row filter; activation owns it
-            for authored in fact.value.keys:
-                declared = frozenset(col.lower() for col in authored)
-                if (scope, declared) in judged:
-                    continue
-                judged.add((scope, declared))
-                if grain_established(declared, derived.keys, fds):
-                    continue
-                witness = grain_witness(declared, derived.keys)
-                if witness is None:
-                    continue
-                out.append(_finding(manifest, scope, fact, authored, witness))
+            judged.add((scope, declared))
+            if grain_established(declared, derived.keys, fds):
+                continue
+            witness = grain_witness(declared, derived.keys)
+            if witness is None:
+                continue
+            out.append(_finding(manifest, scope, fact, authored, witness))
     return out
-
-
-def _judged_provenance(provenance: Provenance) -> bool:
-    """Whether a key from this source is a claim about what the SELECT itself
-    produces, deciding every kind we can receive.
-
-    A key someone wrote down, in a contract or a dbt test, is such a claim, so we
-    check it. A native warehouse constraint is enforced when the table is written
-    rather than by the query, and whether the warehouse really enforces it is #48's
-    question. An incremental model's ``unique_key`` under a merge strategy is the
-    same story: the merge collapses duplicates on write, so its SELECT is expected to
-    produce finer rows and flagging that would be wrong (#7 covers the write path)."""
-    match provenance:
-        case Declared():
-            return True
-        case NativeConstraint() | CompileValue():
-            return False
-    assert_never(provenance)
 
 
 def _finding(
@@ -156,7 +117,6 @@ def _finding(
     declared_cols = ", ".join(sorted(declared))
     witness_cols = ", ".join(sorted(witness))
     attribution = f" (declared by {fact.detail})" if fact.detail else ""
-    node = manifest.nodes.get(scope.unique_id)
     single = next(iter(declared)) if len(declared) == 1 else None
     return CheckFinding(
         kind=CheckFindingKind.GRAIN_NOT_ESTABLISHED,
@@ -168,6 +128,6 @@ def _finding(
             "produces."
         ),
         model_unique_id=scope.unique_id,
-        file_path=node.original_file_path if node is not None else None,
+        file_path=file_of(manifest, scope),
         column=single,
     )

--- a/src/dblect/check/locate.py
+++ b/src/dblect/check/locate.py
@@ -1,0 +1,55 @@
+"""Where a finding points: the file a model lives in, the compiled-SQL span of the
+construct being reported, and that span back-mapped onto the source template the
+developer wrote."""
+
+from __future__ import annotations
+
+from sqlglot import Expr
+
+from dblect.audit.sourcemap import LineMap, SourceSpan, build_line_map
+from dblect.lineage.graph import Derivation, SourceRef
+from dblect.manifest import Manifest
+from dblect.sql import _sqlglot as sg
+
+
+def file_of(manifest: Manifest, source: SourceRef) -> str | None:
+    node = manifest.nodes.get(source.unique_id)
+    return node.original_file_path if node is not None else None
+
+
+def source_span(
+    manifest: Manifest,
+    uid: str,
+    line_start: int,
+    line_end: int,
+    cache: dict[str, LineMap],
+) -> SourceSpan:
+    """Back-map a compiled span onto the model's source template (see
+    :mod:`dblect.audit.sourcemap`), reusing one line map per model across the world's
+    findings. The "no line" sentinel has no source position, so no map is built
+    for a model whose findings are all unlocated."""
+    if line_start == 0:
+        return SourceSpan.compiled(line_start, line_end)
+    line_map = cache.get(uid)
+    if line_map is None:
+        node = manifest.nodes.get(uid)
+        compiled = node.analysis_sql if node is not None else None
+        raw = node.raw_code if node is not None else None
+        line_map = build_line_map(compiled, raw)
+        cache[uid] = line_map
+    return line_map.map_span(line_start, line_end)
+
+
+def span_of(*nodes: Derivation | None) -> tuple[int, int]:
+    """The 1-indexed compiled-SQL line span of the first ``nodes`` entry sqlglot
+    stamped with a usable line, falling back through the rest; ``(0, 0)`` when none
+    carry one (an unlocated finding, never line-suppressible). A non-``Expr``
+    derivation (a ``UnionConfluence``) carries no line, so it is skipped like
+    ``None``."""
+    for node in nodes:
+        if not isinstance(node, Expr):
+            continue
+        span = sg.line_range(node)
+        if span is not None:
+            return span
+    return (0, 0)

--- a/src/dblect/check/run.py
+++ b/src/dblect/check/run.py
@@ -29,6 +29,7 @@ from dblect.adapters import AdapterProfile
 from dblect.audit.sourcemap import LineMap
 from dblect.audit.suppress import FramedDirectives, apply
 from dblect.check.coverage import GroundingCoverage, PropertyGrounding, ResolutionCoverage
+from dblect.check.dependency import declared_dependency_findings
 from dblect.check.findings import (
     CheckFinding,
     CheckFindingKind,
@@ -155,7 +156,14 @@ class WorldAnnotations:
     )
     """What each relation's functional dependencies came out as, kept so a consumer
     that needs them (the grain check reads them to widen what a declared grain
-    covers) does not propagate the property a second time."""
+    covers; the dependency check reads a model's sources at them) does not
+    propagate the property a second time."""
+    functional_dependency_inferred: Mapping[SourceRef, Annotation[FDSet]] = field(
+        default_factory=_no_fd_annotations
+    )
+    """The dependencies each relation's SQL implies on its own, recorded before the
+    declared ones were folded in: the dependency check's counterpart of
+    ``uniqueness_inferred``."""
     uniqueness_inferred: Mapping[SourceRef, Annotation[CandidateKeySet]] = field(
         default_factory=_no_key_annotations
     )
@@ -222,7 +230,8 @@ def propagate_world(graphs: CheckGraphs, facts: WorldFacts) -> WorldAnnotations:
         functional_dependency_grounding(by_scope(facts.fd_facts))
     )
     store = AnnotationStore()
-    fd_anns = dict(propagate(graphs.relation_build.graph, fd_prop))
+    fd_inferred: dict[SourceRef, Annotation[FDSet]] = {}
+    fd_anns = dict(propagate(graphs.relation_build.graph, fd_prop, inferred_sink=fd_inferred))
     for scope, ann in fd_anns.items():
         store.record(fd_prop.name, scope, ann)
 
@@ -242,6 +251,7 @@ def propagate_world(graphs: CheckGraphs, facts: WorldFacts) -> WorldAnnotations:
         domain_type=domain_type,
         coherence_clears=tuple(clears),
         functional_dependency=fd_anns,
+        functional_dependency_inferred=fd_inferred,
         uniqueness_inferred=uniqueness_inferred,
     )
 
@@ -373,6 +383,16 @@ def world_findings(graphs: CheckGraphs, world: WorldAnnotations) -> list[CheckFi
             graphs.uniqueness_facts,
             world.uniqueness_inferred,
             world.functional_dependency,
+        )
+    )
+    findings.extend(
+        declared_dependency_findings(
+            graphs.manifest,
+            by_scope(graphs.resolved.fd_facts),
+            world.functional_dependency_inferred,
+            world.functional_dependency,
+            graphs.relation_build.graph,
+            line_maps,
         )
     )
     return findings

--- a/src/dblect/check/run.py
+++ b/src/dblect/check/run.py
@@ -26,7 +26,7 @@ import sqlglot.expressions as exp
 from sqlglot import Expr
 
 from dblect.adapters import AdapterProfile
-from dblect.audit.sourcemap import LineMap, SourceSpan, build_line_map
+from dblect.audit.sourcemap import LineMap
 from dblect.audit.suppress import FramedDirectives, apply
 from dblect.check.coverage import GroundingCoverage, PropertyGrounding, ResolutionCoverage
 from dblect.check.findings import (
@@ -37,6 +37,7 @@ from dblect.check.findings import (
     UnbuiltModel,
 )
 from dblect.check.grain import declared_grain_findings
+from dblect.check.locate import file_of, source_span, span_of
 from dblect.lineage.builder import (
     BuildIssue,
     BuildResult,
@@ -50,7 +51,6 @@ from dblect.lineage.facts.registry import AnnotationStore, PropertyRegistry
 from dblect.lineage.graph import (
     ColumnLineageGraph,
     ColumnRef,
-    Derivation,
     SourceKind,
     SourceRef,
 )
@@ -507,7 +507,7 @@ def _contradiction_findings(
     for ref, ann in _sorted(annotations):
         if not ann.provisional or ann.value == NAKED:
             continue
-        line_start, line_end = _span_of(column_graph.derivation(ref))
+        line_start, line_end = span_of(column_graph.derivation(ref))
         uid = ref.source.unique_id
         out.append(
             CheckFinding(
@@ -517,11 +517,11 @@ def _contradiction_findings(
                     "that flows in from upstream"
                 ),
                 model_unique_id=uid,
-                file_path=_file_of(manifest, ref.source),
+                file_path=file_of(manifest, ref.source),
                 column=ref.column,
                 line_start=line_start,
                 line_end=line_end,
-                source_span=_source_span(manifest, uid, line_start, line_end, line_maps),
+                source_span=source_span(manifest, uid, line_start, line_end, line_maps),
             )
         )
     return out
@@ -562,18 +562,18 @@ def _aggregation_findings(
         # The aggregate node pins the line; the projection derivation is the fallback so
         # the finding still lands near the right place when the aggregate carries no
         # stamped line (a literal-only shape).
-        line_start, line_end = _span_of(agg, column_graph.derivation(owner))
+        line_start, line_end = span_of(agg, column_graph.derivation(owner))
         uid = owner.source.unique_id
         out.append(
             CheckFinding(
                 kind=CheckFindingKind.AGGREGATION_NOT_WELL_TYPED,
                 message=_aggregation_message(owner, clear),
                 model_unique_id=uid,
-                file_path=_file_of(manifest, owner.source),
+                file_path=file_of(manifest, owner.source),
                 column=owner.column,
                 line_start=line_start,
                 line_end=line_end,
-                source_span=_source_span(manifest, uid, line_start, line_end, line_maps),
+                source_span=source_span(manifest, uid, line_start, line_end, line_maps),
             )
         )
     # The clear order follows the propagation walk; sort so the report is deterministic.
@@ -669,17 +669,17 @@ def _join_key_findings(
             if not isinstance(on, Expr):
                 continue
             for left, right, left_tag, right_tag in join_key_conflicts(on, tag_of):
-                line_start, line_end = _span_of(left, right, on)
+                line_start, line_end = span_of(left, right, on)
                 out.append(
                     CheckFinding(
                         kind=CheckFindingKind.JOIN_KEY_TYPE_MISMATCH,
                         message=_join_key_message(left, right, left_tag, right_tag),
                         model_unique_id=uid,
-                        file_path=_file_of(manifest, source),
+                        file_path=file_of(manifest, source),
                         column=left.name or None,
                         line_start=line_start,
                         line_end=line_end,
-                        source_span=_source_span(manifest, uid, line_start, line_end, line_maps),
+                        source_span=source_span(manifest, uid, line_start, line_end, line_maps),
                     )
                 )
     out.sort(key=lambda f: (f.model_unique_id or "", f.line_start, f.column or ""))
@@ -719,51 +719,3 @@ def _sorted(
     """Annotations in a stable order (by model then column) so the report is
     deterministic."""
     return sorted(annotations.items(), key=lambda kv: (kv[0].source.unique_id, kv[0].column))
-
-
-def _file_of(manifest: Manifest, source: SourceRef) -> str | None:
-    node = manifest.nodes.get(source.unique_id)
-    return node.original_file_path if node is not None else None
-
-
-def _source_span(
-    manifest: Manifest,
-    uid: str,
-    line_start: int,
-    line_end: int,
-    cache: dict[str, LineMap],
-) -> SourceSpan:
-    """Back-map a compiled span onto the model's source template (see
-    :mod:`dblect.audit.sourcemap`), reusing one line map per model across the world's
-    findings."""
-    # The "no line" sentinel has no source position; skip building the map for a model
-    # whose findings are all unlocated.
-    if line_start == 0:
-        return SourceSpan.compiled(line_start, line_end)
-    line_map = cache.get(uid)
-    if line_map is None:
-        node = manifest.nodes.get(uid)
-        compiled = node.analysis_sql if node is not None else None
-        raw = node.raw_code if node is not None else None
-        line_map = build_line_map(compiled, raw)
-        cache[uid] = line_map
-    return line_map.map_span(line_start, line_end)
-
-
-def _span_of(*nodes: Derivation | None) -> tuple[int, int]:
-    """The 1-indexed source-line span of the first ``nodes`` entry sqlglot stamped with
-    a usable line, falling back through the rest. ``(0, 0)`` when none carry one, the
-    convention a finding with no locatable line uses (never line-suppressible).
-
-    The span is in the compiled SQL's line space. The located finding kinds carry it
-    on ``line_start``/``line_end`` and additionally back-map it onto ``raw_code`` via
-    :func:`_source_span`, so the report can point at the source line the developer
-    wrote when the construct passes through verbatim. A non-``Expr`` derivation (a
-    ``UnionConfluence``) carries no line and is skipped like ``None``."""
-    for node in nodes:
-        if not isinstance(node, Expr):
-            continue
-        span = sg.line_range(node)
-        if span is not None:
-            return span
-    return (0, 0)

--- a/src/dblect/lineage/properties/functional_dependency.py
+++ b/src/dblect/lineage/properties/functional_dependency.py
@@ -25,6 +25,11 @@ by source alias) plus an inner join's ``ON`` equalities as mutual determinations
 Posture elsewhere is silent-when-unproven: an outer join's NULL-padded side and
 two UNION arms that can each satisfy a dependency their union violates both prove
 nothing.
+
+A union is silent but not blind: what each arm carried into it is kept beside
+the (empty) result as a :class:`UnionMerge`, renamed through later projections
+exactly as dependencies are, so the declared-dependency check can name the union
+that dropped a dependency every arm held. It never enters the property's value.
 """
 
 from __future__ import annotations
@@ -182,14 +187,40 @@ def functional_dependency_grounded_scopes(
 # outside the modelled fragment drops to the empty set rather than over-claiming.
 
 
+@dataclass(frozen=True, slots=True, eq=False)
+class UnionMerge:
+    """A union and what each of its arms carried into it, in the output column
+    names of the scope holding the record (renamed as the walk climbs). The union
+    proves nothing on its own; the arms let a reader ask whether every arm entailed
+    a dependency the merge then dropped. Compared by identity, since it is minted
+    once per union per scope and holds a live tree node."""
+
+    union: exp.Union
+    arms: tuple[frozenset[FD], ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _Carried:
+    """What a scope carries to its output: its dependencies, and the union merges
+    below it whose arms' dependencies still name columns this scope exposes."""
+
+    fds: frozenset[FD]
+    merges: frozenset[UnionMerge] = frozenset()
+
+
+_EMPTY: _Carried = _Carried(frozenset())
+
+
 @dataclass(frozen=True, slots=True)
 class _Base:
     """What a resolved FROM source contributes: its dependencies (in its output
-    column names) and, for a base table with the uniqueness edge live, its
-    candidate keys (each of which determines the columns read alongside it)."""
+    column names), any union merges it carries, and, for a base table with the
+    uniqueness edge live, its candidate keys (each of which determines the columns
+    read alongside it)."""
 
     fds: frozenset[FD]
     keys: frozenset[Key] = frozenset()
+    merges: frozenset[UnionMerge] = frozenset()
 
 
 _NOTHING: _Base = _Base(frozenset())
@@ -206,36 +237,69 @@ class _FdWalk:
     ``base_resolve`` resolves a base table; CTEs and inline subqueries are
     resolved structurally within the walk. Single-source scopes carry fully; a
     join carries its kept sides (see :meth:`_join_select`); a UNION proves
-    nothing, and an unmodellable group shape (positional or computed group keys)
-    drops the scope's dependencies entirely.
+    nothing but records what its arms brought (see :meth:`_union`), and an
+    unmodellable group shape (positional or computed group keys) drops the
+    scope's dependencies entirely.
     """
 
     def __init__(self, base_resolve: _BaseResolve) -> None:
         self._base_resolve = base_resolve
 
-    def scope_fds(self, node: Expr, *, cte_scope: Mapping[str, frozenset[FD]]) -> frozenset[FD]:
+    def scope_fds(self, node: Expr, *, cte_scope: Mapping[str, _Carried]) -> _Carried:
         if isinstance(node, exp.Select):
             return self._select(node, cte_scope=cte_scope)
-        return frozenset()
+        if isinstance(node, exp.Union):
+            return self._union(node, cte_scope=cte_scope)
+        # INTERSECT and EXCEPT keep a subset of the left arm's rows, and a dependency
+        # that holds on a relation holds on any subset of it, so neither can break
+        # one; they claim nothing (left as is) and are no witness either.
+        return _EMPTY
 
-    def _select(self, sel: exp.Select, *, cte_scope: Mapping[str, frozenset[FD]]) -> frozenset[FD]:
+    def _with_scope(self, node: Expr, cte_scope: Mapping[str, _Carried]) -> dict[str, _Carried]:
+        """``cte_scope`` extended with the CTEs ``node`` declares, each resolved in
+        the scope the ones before it built."""
         local = dict(cte_scope)
-        with_ = sel.args.get("with_")
+        with_ = node.args.get("with_")
         if isinstance(with_, exp.With):
             for cte in with_.expressions:
                 if isinstance(cte, exp.CTE) and isinstance(cte.this, Expr):
                     local[cte.alias_or_name] = self.scope_fds(cte.this, cte_scope=local)
+        return local
+
+    def _union(self, u: exp.Union, *, cte_scope: Mapping[str, _Carried]) -> _Carried:
+        """A union proves nothing: the same determinant value can map to different
+        dependents per arm. What each arm carried is recorded instead, translated to
+        the union's output names (the first arm's, the rest lined up by position, as
+        SQL does). An arm without positionally nameable outputs (a star, a duplicated
+        name, not a plain SELECT) leaves nothing to line up."""
+        local = self._with_scope(u, cte_scope)
+        arms = _union_arms(u)
+        carried = [self.scope_fds(arm, cte_scope=local) for arm in arms]
+        names = [_positional_outputs(arm) for arm in arms]
+        first = names[0] if names else None
+        if first is None or any(n is None or len(n) != len(first) for n in names):
+            return _EMPTY
+        aligned: list[frozenset[FD]] = []
+        for arm_names, arm_carried in zip(names, carried, strict=True):
+            assert arm_names is not None
+            rename = {src: (dst,) for src, dst in zip(arm_names, first, strict=True)}
+            aligned.append(_remap(arm_carried.fds, rename))
+        return _Carried(frozenset(), frozenset({UnionMerge(u, tuple(aligned))}))
+
+    def _select(self, sel: exp.Select, *, cte_scope: Mapping[str, _Carried]) -> _Carried:
+        local = self._with_scope(sel, cte_scope)
 
         from_ = sg.from_of(sel)
         if from_ is None or not isinstance(from_.this, Expr):
-            return frozenset()
+            return _EMPTY
         joins = sg.joins_of(sel)
         if joins:
             return self._join_select(sel, from_.this, joins, cte_scope=local)
         base = self._resolve_source(from_.this, cte_scope=local)
         if base is None:
-            return frozenset()
+            return _EMPTY
         carried = base.fds
+        merges = base.merges
 
         # A dependency is universally quantified over row pairs, and a WHERE only
         # removes pairs, so everything carries; an equality filter additionally pins
@@ -261,14 +325,22 @@ class _FdWalk:
         if group is not None and group.expressions:
             group_names = _group_columns(sel)
             if group_names is None:
-                return frozenset()  # unmodellable group shape: prove nothing
+                return _EMPTY  # unmodellable group shape: prove nothing
             # Grouping aggregates everything outside the group key away, so only a
             # dependency lying entirely within it still describes the output rows.
-            carried = frozenset(
-                fd for fd in carried if fd.determinant | {fd.dependent} <= group_names
+            # A merge's arm sets are cut the same way: two groups that disagree on
+            # a dependent inside the key are still two rows of the output.
+            carried = _within(carried, group_names)
+            merges = frozenset(
+                UnionMerge(m.union, tuple(_within(arm, group_names) for arm in m.arms))
+                for m in merges
             )
 
         out = carried if star else _remap(carried, rename)
+        if not star:
+            merges = frozenset(
+                UnionMerge(m.union, tuple(_remap(arm, rename) for arm in m.arms)) for m in merges
+            )
         if group_names is not None:
             group_out = group_names if star else _remap_columns(group_names, rename)
             if group_out is not None:
@@ -277,20 +349,20 @@ class _FdWalk:
                 out = out | {
                     FD(group_out, name) for name in _named_outputs(sel) if name not in group_out
                 }
-        return out
+        return _Carried(out, merges)
 
-    def _resolve_source(
-        self, node: Expr, *, cte_scope: Mapping[str, frozenset[FD]]
-    ) -> _Base | None:
+    def _resolve_source(self, node: Expr, *, cte_scope: Mapping[str, _Carried]) -> _Base | None:
         if isinstance(node, exp.Table):
             if node.name in cte_scope:
-                return _Base(cte_scope[node.name])
+                cte = cte_scope[node.name]
+                return _Base(cte.fds, merges=cte.merges)
             return self._base_resolve(node)
         if isinstance(node, exp.Subquery):
             inner = node.this
             if not isinstance(inner, Expr):
                 return None
-            return _Base(self.scope_fds(inner, cte_scope=cte_scope))
+            sub = self.scope_fds(inner, cte_scope=cte_scope)
+            return _Base(sub.fds, merges=sub.merges)
         return None
 
     def _join_select(
@@ -299,8 +371,8 @@ class _FdWalk:
         from_node: Expr,
         joins: list[exp.Join],
         *,
-        cte_scope: Mapping[str, frozenset[FD]],
-    ) -> frozenset[FD]:
+        cte_scope: Mapping[str, _Carried],
+    ) -> _Carried:
         """Dependencies a join carries to the projection.
 
         An FD that holds on a joined relation holds on the join wherever that side's
@@ -320,18 +392,19 @@ class _FdWalk:
         INNER and CROSS pad nothing (a cross join only duplicates rows). Aggregation
         over a join is deferred (the FD scope a downstream guard would read is not a
         single source), and a candidate-key-derived dependency is not minted across a
-        join (sound to omit; the key path stays single-source for now)."""
+        join (sound to omit; the key path stays single-source for now), and neither
+        is a union merge, so a union feeding a join is not offered as a witness."""
         group = sg.group_of(sel)
         if group is not None and group.expressions:
-            return frozenset()
+            return _EMPTY
 
         sources: list[tuple[str, _Base]] = []
         for node in (from_node, *(j.this for j in joins)):
             if not isinstance(node, Expr):
-                return frozenset()
+                return _EMPTY
             base = self._resolve_source(node, cte_scope=cte_scope)
             if base is None:
-                return frozenset()
+                return _EMPTY
             sources.append((node.alias_or_name.lower(), base))
 
         aliases = [alias for alias, _ in sources]
@@ -373,8 +446,8 @@ class _FdWalk:
 
         qrename, star = _qualified_rename(sel)
         if star:
-            return frozenset()  # a star over a join leaves the output universe ambiguous
-        return _project_qualified(qfds, qrename)
+            return _EMPTY  # a star over a join leaves the output universe ambiguous
+        return _Carried(_project_qualified(qfds, qrename))
 
 
 def _group_columns(sel: exp.Select) -> frozenset[str] | None:
@@ -393,6 +466,41 @@ def _group_columns(sel: exp.Select) -> frozenset[str] | None:
             return None
         out.add(sg.column_name(g).lower())
     return frozenset(out)
+
+
+def _union_arms(u: exp.Union) -> list[Expr]:
+    """The arms of ``u`` in order, a chain of unions (left-nested by the parser)
+    flattened so a dependency every arm carries is reported against one union."""
+    arms: list[Expr] = []
+    for side in (u.this, u.expression):
+        if isinstance(side, exp.Union):
+            arms.extend(_union_arms(side))
+        elif isinstance(side, Expr):
+            arms.append(side)
+    return arms
+
+
+def _positional_outputs(arm: Expr) -> tuple[str, ...] | None:
+    """An arm's output column names in projection order, or ``None`` when they
+    cannot be lined up positionally (a star, a duplicated name, not a SELECT)."""
+    if not isinstance(arm, exp.Select):
+        return None
+    names: list[str] = []
+    for proj in arm.expressions:
+        if isinstance(proj, exp.Star):
+            return None
+        inner = proj.this if isinstance(proj, exp.Alias) else proj
+        if isinstance(inner, exp.Column) and isinstance(inner.this, exp.Star):
+            return None
+        names.append(proj.alias_or_name.lower())
+    if len(set(names)) != len(names):
+        return None
+    return tuple(names)
+
+
+def _within(fds: frozenset[FD], columns: frozenset[str]) -> frozenset[FD]:
+    """The dependencies mentioning only ``columns``."""
+    return frozenset(fd for fd in fds if fd.determinant | {fd.dependent} <= columns)
 
 
 def _remap(fds: frozenset[FD], rename: Mapping[str, tuple[str, ...]]) -> frozenset[FD]:
@@ -492,6 +600,23 @@ def _project_qualified(
     return frozenset(out)
 
 
+def union_merges(tree: Expr, model_fds: Mapping[SourceRef, FDSet]) -> frozenset[UnionMerge]:
+    """The unions in ``tree`` whose arms' dependencies reach its output, each with
+    what its arms carried, in the output's column names: the same walk the reducer
+    runs, with base tables resolved by stamped :class:`SourceRef` against
+    ``model_fds`` (the per-model values propagation produced). The declared-dependency
+    check reads this, since the reducer keeps only the dependency set. Valid only
+    for the lifetime of ``tree``."""
+
+    def base_resolve(table: exp.Table) -> _Base:
+        ref = source_ref_meta(table)
+        if ref is None or ref not in model_fds:
+            return _NOTHING
+        return _Base(model_fds[ref].fds)
+
+    return _FdWalk(base_resolve).scope_fds(tree, cte_scope={}).merges
+
+
 # --- the property ------------------------------------------------------------
 
 
@@ -531,7 +656,7 @@ def functional_dependency_property(
                     keys = key_ann.value.keys
             return _Base(ann.value.fds, keys)
 
-        fds = _FdWalk(base_resolve).scope_fds(deriv, cte_scope={})
+        fds = _FdWalk(base_resolve).scope_fds(deriv, cte_scope={}).fds
         opacity = Opacity.CONCRETE if fds else Opacity.IMPLICIT
         return Annotation(FDSet(fds), opacity, provisional=provisional)
 

--- a/src/dblect/severity.py
+++ b/src/dblect/severity.py
@@ -132,7 +132,7 @@ def _check_severity(kind: CheckFindingKind) -> Severity:
             return Severity.WARN
         # One grade below a contradiction: the SQL does not guarantee the declared
         # grain, but the data may still hold it, so this warns rather than errors.
-        case CheckFindingKind.GRAIN_NOT_ESTABLISHED:
+        case CheckFindingKind.GRAIN_NOT_ESTABLISHED | CheckFindingKind.DEPENDENCY_NOT_ESTABLISHED:
             return Severity.WARN
     assert_never(kind)
 

--- a/tests/check/test_dependency_not_established.py
+++ b/tests/check/test_dependency_not_established.py
@@ -1,0 +1,229 @@
+# pyright: reportInvalidTypeForm=false, reportUnusedClass=false, reportGeneralTypeIssues=false
+# A contract method's ``self`` is a ContractSelf proxy at capture, not a real
+# instance; annotating it that way trips pyright's self-supertype rule while keeping
+# the proxy usage checked. Typed ``self`` in authored contracts is the stubs concern.
+"""A declared ``zip determines city`` through the real check, from contract to
+finding. The witness is a UNION whose every arm carries the dependency: each arm can
+honour it alone while the two disagree on some zip, so the merge is the one operator
+we can point at, and the finding says not established, never violated."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import pytest
+
+from dblect.adapters import profile_for_adapter
+from dblect.check import CheckFinding, CheckFindingKind, run_check
+from dblect.contracts import ContractSelf, contract
+from dblect.manifest import Column, Node
+from dblect.types import ModelContract
+from tests._manifest_builders import cols as _cols
+from tests._manifest_builders import manifest as _manifest
+from tests._manifest_builders import node as _node
+
+_DUCKDB = profile_for_adapter("duckdb")
+_ADDRESS_COLS = _cols(zip="TEXT", city="TEXT")
+_AT_DIM = ["model.shop.dim_addresses"]
+
+# Leaf staging models: no FROM, so the walk infers nothing and only a declaration
+# can give them a dependency.
+_STG_US = _node(
+    "model.shop.stg_us_addresses",
+    sql="select '1' as zip, 'austin' as city",
+    columns=_ADDRESS_COLS,
+)
+_STG_INTL = _node(
+    "model.shop.stg_intl_addresses",
+    sql="select '1' as zip, 'oslo' as city",
+    columns=_ADDRESS_COLS,
+)
+
+_UNIONED_CTE = (
+    "with unioned as (\n"
+    "  select zip, city from stg_us_addresses\n"
+    "  union all\n"
+    "  select zip, city from stg_intl_addresses\n"
+    ")\n"
+)
+
+
+def _declare_zip_determines_city(model: str) -> None:
+    class Declares(ModelContract):
+        dbt_model = model
+
+        @contract
+        def zip_determines_city(self: ContractSelf) -> object:
+            return self.zip.determines(self.city)
+
+
+def _declare_all(*models: str) -> None:
+    for model in models:
+        _declare_zip_determines_city(model)
+
+
+def _dim(sql: str, columns: Mapping[str, Column] = _ADDRESS_COLS) -> Node:
+    return _node("model.shop.dim_addresses", sql=sql, columns=columns)
+
+
+def _findings(*nodes: Node) -> list[CheckFinding]:
+    report = run_check(_manifest(*nodes), _DUCKDB)
+    return [f for f in report.findings if f.kind is CheckFindingKind.DEPENDENCY_NOT_ESTABLISHED]
+
+
+def test_the_finding_lands_at_the_model_and_points_at_the_union() -> None:
+    _declare_all("stg_us_addresses", "stg_intl_addresses", "dim_addresses")
+    dim = _dim(
+        "select zip, city from stg_us_addresses\nunion all\nselect zip, city from stg_intl_addresses"
+    )
+    findings = _findings(_STG_US, _STG_INTL, dim)
+
+    assert [f.model_unique_id for f in findings] == _AT_DIM
+    finding = findings[0]
+    assert "not established" in finding.message
+    assert "zip" in finding.message
+    assert "city" in finding.message
+    assert "union" in finding.message.lower()
+    # The data may still satisfy the dependency, so no claim of violation.
+    assert "violat" not in finding.message.lower()
+    assert (finding.line_start, finding.line_end) == (1, 3)
+    assert finding.column == "city"
+
+
+@pytest.mark.parametrize(
+    "dim_sql",
+    [
+        pytest.param(_UNIONED_CTE + "select * from unioned", id="passthrough_cte"),
+        pytest.param(
+            "select zip, city from stg_us_addresses "
+            "union all select zip, city from stg_intl_addresses "
+            "union all select zip, city from stg_us_addresses",
+            id="three_arms_one_witness",
+        ),
+    ],
+)
+def test_the_witness_reaches_the_output_through_common_shapes(dim_sql: str) -> None:
+    _declare_all("stg_us_addresses", "stg_intl_addresses", "dim_addresses")
+    findings = _findings(_STG_US, _STG_INTL, _dim(dim_sql))
+    assert [f.model_unique_id for f in findings] == _AT_DIM
+
+
+def test_the_witness_follows_a_rename_after_the_union() -> None:
+    # The declaration is in the model's output names, not the arms'.
+    _declare_all("stg_us_addresses", "stg_intl_addresses")
+
+    class DimAddresses(ModelContract):
+        dbt_model = "dim_addresses"
+
+        @contract
+        def postal_code_determines_city(self: ContractSelf) -> object:
+            return self.postal_code.determines(self.city)
+
+    dim = _dim(
+        _UNIONED_CTE + "select zip as postal_code, city from unioned",
+        columns=_cols(postal_code="TEXT", city="TEXT"),
+    )
+    assert [f.model_unique_id for f in _findings(_STG_US, _STG_INTL, dim)] == _AT_DIM
+
+
+def test_arms_align_by_position_not_by_name() -> None:
+    # SQL names a union after its first arm; the second arm spells the columns
+    # differently and still carries the dependency into the union.
+    _declare_all("stg_us_addresses", "dim_addresses")
+
+    class Intl(ModelContract):
+        dbt_model = "stg_intl_addresses"
+
+        @contract
+        def postal_determines_town(self: ContractSelf) -> object:
+            return self.postal.determines(self.town)
+
+    intl = _node(
+        "model.shop.stg_intl_addresses",
+        sql="select '1' as postal, 'oslo' as town",
+        columns=_cols(postal="TEXT", town="TEXT"),
+    )
+    dim = _dim(
+        "select zip, city from stg_us_addresses union all select postal, town from stg_intl_addresses"
+    )
+    assert [f.model_unique_id for f in _findings(_STG_US, intl, dim)] == _AT_DIM
+
+
+def test_an_arm_carries_the_dependency_through_a_chain() -> None:
+    # The US arm states zip -> region and region -> city, never zip -> city: an arm
+    # is judged by what it entails. (Both arms keep region in the projection; the
+    # walk carries spelled-out dependencies, so dropping the middle drops the chain.)
+    class Us(ModelContract):
+        dbt_model = "stg_us_addresses"
+
+        @contract
+        def zip_determines_region(self: ContractSelf) -> object:
+            return self.zip.determines(self.region)
+
+        @contract
+        def region_determines_city(self: ContractSelf) -> object:
+            return self.region.determines(self.city)
+
+    _declare_all("stg_intl_addresses", "dim_addresses")
+    regional = _cols(zip="TEXT", region="TEXT", city="TEXT")
+    us = _node(
+        "model.shop.stg_us_addresses",
+        sql="select '1' as zip, 'tx' as region, 'austin' as city",
+        columns=regional,
+    )
+    intl = _node(
+        "model.shop.stg_intl_addresses",
+        sql="select '1' as zip, 'no' as region, 'oslo' as city",
+        columns=regional,
+    )
+    dim = _dim(
+        "select zip, region, city from stg_us_addresses "
+        "union all select zip, region, city from stg_intl_addresses",
+        columns=regional,
+    )
+    assert [f.model_unique_id for f in _findings(us, intl, dim)] == _AT_DIM
+
+
+def test_a_single_carrying_source_establishes_it() -> None:
+    _declare_all("stg_us_addresses", "dim_addresses")
+    assert _findings(_STG_US, _dim("select zip, city from stg_us_addresses")) == []
+
+
+def test_a_group_by_on_the_determinant_re_establishes_it() -> None:
+    # Both arms carry the dependency, so the union is a witness; the GROUP BY
+    # collapses to one row per zip, and established wins over witnessed.
+    _declare_all("stg_us_addresses", "stg_intl_addresses", "dim_addresses")
+    dim = _dim(_UNIONED_CTE + "select zip, max(city) as city from unioned group by zip")
+    assert _findings(_STG_US, _STG_INTL, dim) == []
+
+
+def test_an_arm_that_carries_nothing_is_not_a_witness() -> None:
+    # The intl arm declares nothing: the dependency may have broken earlier, so
+    # the union cannot be named as the operator that broke it.
+    _declare_all("stg_us_addresses", "dim_addresses")
+    dim = _dim(
+        "select zip, city from stg_us_addresses union all select zip, city from stg_intl_addresses"
+    )
+    assert _findings(_STG_US, _STG_INTL, dim) == []
+
+
+def test_a_declaration_with_no_dependency_anywhere_is_not_a_witness() -> None:
+    _declare_zip_determines_city("dim_addresses")
+    assert _findings(_STG_US, _dim("select zip, city from stg_us_addresses")) == []
+
+
+# A UNION, distinct or not, merges rows from both arms, so the arms can disagree.
+# INTERSECT and EXCEPT keep a subset of the left arm's rows, and a dependency that
+# holds on a relation holds on any subset of it; they are no witness.
+@pytest.mark.parametrize(
+    ("operator", "fires"),
+    [("union all", True), ("union", True), ("intersect", False), ("except", False)],
+)
+def test_set_operations_decide_whether_a_merge_is_a_witness(operator: str, fires: bool) -> None:
+    _declare_all("stg_us_addresses", "stg_intl_addresses", "dim_addresses")
+    dim = _dim(
+        f"select zip, city from stg_us_addresses {operator} "
+        "select zip, city from stg_intl_addresses"
+    )
+    findings = _findings(_STG_US, _STG_INTL, dim)
+    assert [f.model_unique_id for f in findings] == (_AT_DIM if fires else [])


### PR DESCRIPTION
Reframes and replaces the earlier draft, which proposed `DEPENDENCY_NOT_ESTABLISHED`, the dependency twin of #230's grain check. That transfer turns out to be unsound: the case it fired on is a case the walk should be proving. What lands instead is a lineage change that makes the union merge agree with what a declaration means, and no emitter. The PR is standalone on `main` (no longer stacked on #230).

## What a declared dependency means

`a determines b` is an axiom about the world, asserting determinism of the entity: `order_id determines user_id` because one order cannot belong to two users. It is quantified over every pair of rows that describe the world, not over the rows of one relation. Users declare it precisely because SQL structure cannot derive it, and dblect consumes it on trust (to prove a `GROUP BY order_id` that selects `user_id` well typed, to fold join keys covered by a chain).

Along the way, `zip -> city` retires as the running example. It is false in the world (ZIP codes cross city lines), and its falseness is what made a union warning look plausible. `order_id -> user_id` is the honest canonical example.

## Why UNION treats derived and declared dependencies differently

A dependency is universally quantified over row pairs, and what a union adds is exactly the cross pairs, one row from each arm. Survival at the merge depends on whether the dependency's witness covers those cross pairs.

- **Derived dependencies are relation-local and genuinely die.** One arm has `WHERE currency = 'usd'` and carries the constant dependency `{} -> currency`; the other has `WHERE currency = 'eur'` and carries the same syntactic dependency. Both arms carry it and the union violates it. Key-derived and GROUP BY-derived dependencies fail the same way. The walk's drop for these stays.
- **Declared dependencies survive when the arms share the axiom.** When every arm's `(order_id, user_id)` pairs are the declared world's pairs, which is what it means for each arm's instance to trace to the same grounding declaration, every cross pair is covered too and the merge carries the dependency. The merged data can only violate it if the axiom is false in the data, a data-quality failure the declaration asserts away and one no SQL structure can create.

This is also why #230 stands while its dependency analogue does not transfer. Uniqueness is not a pair property over a world: a union of a relation with itself breaks uniqueness while no data is wrong anywhere, so "arms each unique on k, merge maybe not" is a real structural hazard. That same union breaks no dependency.

## The change

Each declared dependency now travels as a grounded instance, `DeclaredFD(origin, declared, fd)`: the relation it was declared about, the dependency in that relation's names, and the dependency under the current relation's output names, renamed as the walk climbs. `FDSet` carries these instances beside the plain set (every instance's current dependency is also in `fds`, enforced at construction, so consumers reading `fds` alone are unchanged). Grounding lifts instances from `Declared`-provenance facts only, decided explicitly across the closed provenance space: a native constraint holds by the warehouse's write path and a compile value is minted by the toolchain, so neither claims a world.

The union merge keeps exactly the instances every arm shares, whole, once arms are lined up by position under the first arm's names as SQL merges them. All three fields key the match: origin alone is not enough (one relation can declare `a -> b` and `c -> d`, and arms can rename both onto the same output columns), and the axiom alone is not either (an arm can cross the declared columns, running the instance the other way). Mixed provenance drops too: declared in one arm and derived in the other, or the same syntactic dependency grounded in two different declarations (two order systems whose id spaces may collide are exactly where the axiom's coverage ends). Instances ride the same renames and cuts as plain dependencies everywhere else (projections, WHERE, GROUP BY within the key, a join's kept sides), so the two can never drift.

This closes a real false negative: downstream of a union over `us_orders` and `ca_orders`, `GROUP BY order_id` selecting `user_id` was unprovable even though the axiom guarantees it.

## No emitter

`DEPENDENCY_NOT_ESTABLISHED` is dropped, not narrowed. Its central fire case, a union whose every arm carries the declared dependency, is the case this change proves quiet. Structural SQL can neither establish nor refute an axiom; the honest check for a declaration is a data test at the declaring model (no determinant value maps to two dependent values). That is a small separate feature if we want it, and #202's "FD violation" half should be re-scoped the same way.

## Tests

Written before the implementation, then verified to bite by breaking the code four ways and confirming a test fails for each: witnessing on some arm instead of every arm, matching instances without their current columns (the swapped-columns case fails), keeping derived dependencies across the merge (the two-worlds cases and the data-judge PBT fail), and lifting every provenance into instances (the native-constraint and compile-value cases fail).

- Propagation shapes: one world's slices carry (top-level, via CTE, renamed after the union, aligned by position, three arms, UNION and UNION ALL alike, chain kept whole and entailing through the closure, GROUP BY below the union); the drops (two declared worlds, declared meets unknown, two declarations of one world on the same columns, swapped columns, a star arm); derived dependencies still prove nothing; INTERSECT and EXCEPT still claim nothing, one test per operator.
- Lattice laws over instance-carrying values, plus the construction invariant (an instance outside `fds` is rejected) and the join rule that an instance survives only whole.
- A data-as-judge PBT alongside the existing ones: two base tables with independently drawn `g -> x` mappings, arms drawn from one world or two, every claimed dependency checked against the materialized union, with an anti-vacuity arm (same world, same projection: the merge must keep the dependency, silence cannot pass).

## Not in this PR

- The aggregate coherence guard does not yet discharge through an intermediate model or a union, because the companion column's ref stays bound to its source relation; that is the cross-relation companion rebinding follow-up (#76), and the FD value it will read below unions is now correct.
- INTERSECT and EXCEPT could carry their covering arm (a subset cannot break a dependency); they stay silent, recorded in the walk as a possible refinement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAE4C5m7unT2uPjd1XthjN
