### PR TITLE
docs: trim lineage/check prose to plain AND short, not just plain

### DIFF
--- a/src/dblect/check/findings.py
+++ b/src/dblect/check/findings.py
@@ -1,8 +1,8 @@
 """The findings ``dblect check`` reports, and the report that carries them.
 
 These are declaration-level findings: a contract that does not line up with the
-manifest, a declared domain type contradicted by what the substrate propagates, a
-sum the algebra cannot call well typed. They are distinct from the SQL-structural
+manifest, a declared domain type contradicted by what propagation infers, a sum
+the algebra cannot call well typed. They are distinct from the SQL-structural
 findings the ``audit`` walker emits, so they carry their own kinds and their own
 small report shape rather than borrowing the SQL ``Finding`` (which is a span in
 one statement). See ``docs/design/declaration-dsl.md`` and
@@ -28,8 +28,9 @@ class CheckFindingKind(StrEnum):
     field, out-of-domain value, malformed declaration)."""
 
     DOMAIN_TYPE_CONTRADICTION = auto()
-    """A declared domain type is contradicted by the type the substrate inferred
-    for the same column, and the contradiction rides the DAG (currency creep)."""
+    """A declared domain type is contradicted by the type propagation inferred for
+    the same column, and the contradiction shows up at every downstream column it
+    reaches (currency creep)."""
 
     AGGREGATION_NOT_WELL_TYPED = auto()
     """A reduction over one field of a multi-field type whose other fields are not

--- a/src/dblect/check/run.py
+++ b/src/dblect/check/run.py
@@ -1,17 +1,18 @@
 """Run the declaration check: resolve contracts, propagate, derive findings.
 
-The pipeline is the substrate-first story made user-facing. Contracts resolve into
-the facts the properties ground from, two properties propagate (the
-functional-dependency property over the relation graph, then the domain-type
-property over the column graph reading it), and the findings fall out of what the
-substrate concluded:
+Contracts resolve into the facts the properties ground from, two properties
+propagate (the functional-dependency property over the relation graph, then the
+domain-type property over the column graph reading it), and the findings fall out
+of what propagation concluded:
 
-* a contract that did not resolve is a finding directly off the bridge;
-* a column whose flow value is provisional carries a declared type the inferred
-  one contradicts, which is currency creep, and it lands wherever the taint
-  reached, declared model or not;
-* an aggregate whose tag cleared to naked while an operand it summed still carried
-  one is a reduction the algebra cannot call well typed, the mixed-currency sum.
+* a contract that fails to resolve is a finding on its own, straight out of
+  contract resolution;
+* a column carries a declared type the inferred one contradicts, which is
+  currency creep, and it lands on every downstream column the disagreement
+  flows to, declared model or not;
+* an aggregate whose tag cleared to naked while an operand it summed still
+  carried one is a reduction the algebra cannot call well typed, the
+  mixed-currency sum.
 
 Predicates are collected and counted, not run: executing them needs materialized
 data, which belongs to the fixture/PBT loop, so the static check stays static.
@@ -99,18 +100,18 @@ class CheckGraphs:
     A model the build skipped (a compilation miss, a build error) is absent, so the check
     never reads an unstamped tree as a clean one."""
     join_key_ground: Callable[[ColumnRef], Annotation[DomainTag]]
-    """The declared-grounding fallback the join-key check reads a never-projected key's
-    tag through. Folded once here, alongside the graph it is judged against, rather than
-    per world: it derives from the world-invariant declared facts, so colocating it with
-    the graph build keeps it in step with the graph instead of resting on the assumption
-    that successive worlds share one."""
+    """The fallback the join-key check uses to look up a never-projected key's declared
+    tag. Built once here, next to the graph it is checked against, rather than per world:
+    it comes from the facts that do not change across worlds, so keeping it with the
+    graph build keeps the two in sync instead of assuming every world reuses the same
+    graph."""
 
 
 @dataclass(frozen=True, slots=True)
 class WorldFacts:
     """The facts that ground one world's propagation. The declared facts are
-    world-invariant (shared across worlds); a world's ``CompileValue`` leaves are
-    appended by the enumerator. Keeping the two apart means the enumerator only
+    world-invariant (shared across worlds); the enumerator appends each world's own
+    ``CompileValue`` facts on top. Keeping the two apart means the enumerator only
     adds, never recomputes, the declared facts."""
 
     world: WorldRef
@@ -224,7 +225,7 @@ def run_check(
     the same sequence the enumerator runs per world.
 
     This is the declaration-level family alone. A consumer that needs every family's
-    findings over a manifest (any multi-world or finding-threading path) calls
+    findings over a manifest, such as a cross-world diff, calls
     :func:`dblect.analysis.analyze` instead, which carries both families so a family
     is never dropped by being forgotten.
 
@@ -355,7 +356,7 @@ def _grounding_coverage(
     the domain-type annotation map, which includes source leaves the lineage flows
     from (these are absent from ``graph.subjects()``, yet a contract on a source
     column is genuinely checkable). "Grounded" reads the property's own grounding
-    fold (``*_grounded_scopes``), the very fold ``_propagate`` grounds from, so the
+    fold (``*_grounded_scopes``), the very fold ``propagate`` grounds from, so the
     coverage number cannot drift from what was actually grounded. The per-property
     denominator keeps only model-kind columns, since the synthetic CTE and UNION
     scaffolding is internal, not a column a fact would ever ground."""
@@ -448,8 +449,8 @@ def _contradiction_findings(
     column_graph: ColumnLineageGraph,
     line_maps: dict[str, LineMap],
 ) -> list[CheckFinding]:
-    """One finding per column whose flow value is provisional: a declared type the
-    inferred one contradicts, reported wherever the taint reached."""
+    """One finding per column whose declared type the inferred one contradicts,
+    reported wherever the disagreement flows downstream."""
     out: list[CheckFinding] = []
     for ref, ann in _sorted(annotations):
         if not ann.provisional or ann.value == NAKED:
@@ -488,7 +489,7 @@ def _aggregation_findings(
     cannot tell a cleared live tag from an operand that was naked before the reduction).
     A ``SELECT`` clear (``min``/``max`` widening a tag-blind selection) is not this
     finding, so only the combining class is rendered. A clear whose site is unstamped
-    (a windowed aggregate) is the deferred windowed obligation, left for later; an opaque
+    (a windowed aggregate) is skipped for now, left as future work; an opaque
     group shape (a positional or computed GROUP BY, ``group_refs is None``) is surfaced,
     since the companion is no more held by a group the builder cannot enumerate than by a
     resolved one that omits it, and the guard recorded the clear rather than guessing."""
@@ -534,8 +535,8 @@ def _aggregate_owners(column_graph: ColumnLineageGraph) -> dict[int, ColumnRef]:
 
     The propagator walked these very derivations, so the ``AggFunc`` in a clear is the
     same object found here; keyed on ``id`` because two distinct calls can be equal by
-    value. The first owner wins, which is unambiguous since each projection subtree is a
-    distinct output column's own."""
+    value. The first owner wins, which is unambiguous since each projection subtree
+    belongs to exactly one output column."""
     owners: dict[int, ColumnRef] = {}
     for ref in column_graph.subjects():
         derivation = column_graph.derivation(ref)

--- a/src/dblect/lineage/builder.py
+++ b/src/dblect/lineage/builder.py
@@ -188,8 +188,8 @@ def build_manifest_graph(
     # reference resolves against an upstream model the project never documented.
     schema: dict[str, dict[str, str]] = {k: dict(v) for k, v in _build_schema(manifest).items()}
     # One persistent Schema, `add_table`-ing only the touched table per model, rather than a raw
-    # dict `qualify` re-normalizes whole every call. `schema` stays the merge accumulator (the
-    # documented-wins/UNKNOWN-for-new fold); the Schema mirrors it table by table.
+    # dict, which `qualify` re-normalizes in full on every call. `schema` stays the merge
+    # accumulator (the documented-wins/UNKNOWN-for-new fold); the Schema mirrors it table by table.
     mapping_schema: Schema = MappingSchema(
         cast("dict[str, object]", schema), dialect=dialect, normalize=True
     )
@@ -1021,9 +1021,9 @@ def index_by_name(manifest: Manifest, by_source: Mapping[SourceRef, _ByName]) ->
     """Re-key a per-relation map by the relation name as it appears in compiled SQL.
 
     A detector propagates a property to a ``Mapping[SourceRef, ...]`` but looks relations
-    up by the name in a parsed tree. Rather than re-encode the name convention (the
-    fragile-cooperation hazard), it composes the one resolver, :func:`build_name_to_source`,
-    with its own ``SourceRef``-keyed facts. A name whose relation has no entry in
+    up by the name in a parsed tree. Rather than re-encode the name convention, it composes
+    the one resolver, :func:`build_name_to_source`, with its own ``SourceRef``-keyed facts.
+    A name whose relation has no entry in
     ``by_source`` is omitted, so a lookup miss reads as "no fact" exactly as a per-relation
     absence would; on a model/source name collision the model wins, as in ``ref`` resolution.
     """

--- a/src/dblect/lineage/facts/grounding.py
+++ b/src/dblect/lineage/facts/grounding.py
@@ -66,7 +66,7 @@ class DiscovererError(Exception):
     """The one exception ``collect`` treats as expected: a discoverer that hits a
     manifest shape it cannot read raises this, drops all of its own facts, and
     leaves every other discoverer's facts untouched. Any other exception is a
-    substrate bug and propagates."""
+    bug in dblect itself and propagates."""
 
 
 def collect(
@@ -137,7 +137,7 @@ def grounding(
     opaque: Collection[S],
     lat: Lattice[K],
 ) -> Callable[[S], Annotation[K]]:
-    """Fold each scope's bucket into its grounded annotation and return the lookup.
+    """Fold each scope's bucket into its value and return the lookup.
 
     A scope absent from the fold grounds ``Annotation(top, IMPLICIT)``, the
     "nothing declared" default. See ``_ground`` for the grounding rule itself.

--- a/src/dblect/lineage/facts/lattice.py
+++ b/src/dblect/lineage/facts/lattice.py
@@ -21,8 +21,9 @@ K = TypeVar("K")
 @dataclass(frozen=True, slots=True)
 class Lattice(Generic[K]):
     """``meet`` is the greatest lower bound (the more precise value), ``join`` the
-    least upper bound (used at a confluence). ``top`` is 'no information'; ``bottom``
-    is 'contradiction', a value that no data can satisfy."""
+    least upper bound (used where two branches merge, e.g. a UNION). ``top`` is
+    'no information'; ``bottom`` is 'contradiction', a value that no data can
+    satisfy."""
 
     meet: Callable[[K, K], K]
     join: Callable[[K, K], K]

--- a/src/dblect/lineage/facts/model.py
+++ b/src/dblect/lineage/facts/model.py
@@ -1,4 +1,4 @@
-"""Value types for the facts substrate: facts, provenance, and annotations.
+"""Value types this package works with: facts, provenance, and annotations.
 
 A :class:`Fact` is a typed, provenance-carrying claim about one node of the
 lineage graph (a column when ``S`` is :class:`ColumnRef`, a relation when ``S``
@@ -29,9 +29,9 @@ S = TypeVar("S", ColumnRef, SourceRef)
 
 @dataclass(frozen=True, slots=True)
 class WorldRef:
-    """A world assignment chosen by the flag layer. Opaque to the substrate in
-    meaning; facts bucket by world, so its identity must be stable (hashable,
-    value equality)."""
+    """A world assignment chosen by the flag layer. Its meaning is opaque here;
+    facts bucket by world, so its identity must be stable (hashable, value
+    equality)."""
 
     assignments: frozenset[tuple[str, Hashable]]
 
@@ -122,9 +122,9 @@ class Fact(Generic[K, S]):
     A candidate key ``{customer_id, region}`` is a relation fact whose *value*
     names the columns: the address is the relation, never the column set.
 
-    ``condition`` scopes the claim to a row filter when present (a ``where``-
-    filtered dbt test). A conditional fact is captured and carried through
-    ``collect``, but grounding does not fold it into the unconditional annotation.
+    ``condition`` scopes the claim to a row filter when present; see
+    :class:`Predicate`. ``collect`` keeps such a fact, but grounding leaves it
+    out of the unconditional fold.
     """
 
     scope: S
@@ -147,7 +147,7 @@ def by_scope(facts: tuple[Fact[K, S], ...]) -> dict[S, tuple[Fact[K, S], ...]]:
 class Opacity(StrEnum):
     CONCRETE = "concrete"  # value carries information (value is not top)
     EXPLICIT = "explicit"  # value is top by a declared opt-out; flows silently
-    IMPLICIT = "implicit"  # value is top incidentally (nothing declared it); warns at a seam
+    IMPLICIT = "implicit"  # top incidentally (nothing declared); warns on meeting a concrete value
 
 
 @dataclass(frozen=True, slots=True)
@@ -157,7 +157,7 @@ class Annotation(Generic[K]):
     ``opacity`` carries information only when ``value`` is the lattice top:
     ``CONCRETE`` *is* "value is not top", and the choice that matters is
     ``EXPLICIT`` (a declared opt-out, flows silently) versus ``IMPLICIT``
-    (incidental top, warns at a refinement seam).
+    (incidental top, warns when it meets a concrete value).
 
     ``provisional`` is the one bit that is not about knowing or not knowing: an
     error-recovery taint set when a node's inferred value conflicts with its

--- a/src/dblect/lineage/facts/property.py
+++ b/src/dblect/lineage/facts/property.py
@@ -101,7 +101,7 @@ class CoherenceGuard(Generic[K, F]):
     aggregating scope's own WHERE, or an ``entails`` read of the ``fd`` dependency
     at the aggregation input (antecedent: the group columns, in the input
     relation's names). Where no path discharges a companion, the aggregate clears
-    to top and the seam rule reports it. See ``propagation-soundness.md``.
+    to top, which warns at ``combine``. See ``propagation-soundness.md``.
 
     ``fd`` must appear in the carrying property's ``depends_on``, so the registry
     orders the dependency first and the read is never silently unevaluated."""
@@ -157,7 +157,7 @@ class CoherenceClear(Generic[K]):
 
 # The channel a guard records a clear into during propagation. A plain list kept by the
 # caller of :func:`propagate`: the propagator appends, the consumer reads. ``None`` means
-# the caller is not collecting, so the guard clears silently (the substrate-only path).
+# the caller is not collecting, so the guard clears silently with no diagnostic recorded.
 CoherenceSink = list[CoherenceClear[K]]
 
 
@@ -173,7 +173,7 @@ class AggregateRule(Generic[K]):
 
 @dataclass(frozen=True, slots=True)
 class AxisDisplay:
-    """The human-facing names the seam diagnostic fills its template from. The
+    """The human-facing names the ``combine`` warning fills its template from. The
     types layer supplies it from a declaration, with fallback to the bare type and
     axis names."""
 
@@ -198,7 +198,7 @@ class Property(Generic[K, S]):
 
     Build one with :func:`column_property` or :func:`relation_property`, which
     mint ``ref`` and fix ``scope_kind`` to match the scope type. ``semiring`` is
-    set only for a property whose confluence or cross counts or accumulates; when
+    set only for a property whose UNION or JOIN counts or accumulates; when
     set, the relational operators derive from it and must not be redefined in
     ``operators``.
     """
@@ -243,7 +243,7 @@ class Property(Generic[K, S]):
     here rather than relying on a global registry."""
 
     def __post_init__(self) -> None:
-        # A semiring-carrying property derives its confluence and cross from
+        # A semiring-carrying property derives its UNION and JOIN behavior from
         # plus/times, so it must not also pin those operators by hand. The semiring
         # laws themselves are PBT obligations (see propagation-soundness.md), not
         # decidable here.

--- a/src/dblect/lineage/properties/aggregation_depth.py
+++ b/src/dblect/lineage/properties/aggregation_depth.py
@@ -27,8 +27,8 @@ from dblect.lineage.semiring import Semiring
 
 
 class MaxSemiring:
-    """Max-semiring on non-negative ints. Non-strict near-semiring; ``plus`` and
-    ``times`` both take the max, so the deepest path wins at confluence and cross."""
+    """Max-semiring on non-negative ints. Non-strict: ``plus`` and ``times`` both
+    take the max, so the deepest path always wins."""
 
     zero: int = 0
     one: int = 0

--- a/src/dblect/lineage/properties/domain_type.py
+++ b/src/dblect/lineage/properties/domain_type.py
@@ -21,8 +21,9 @@ summarizability story (Lenz & Shoshani, SSDBM 1997); see
 
 Naked-amount taint falls out of lineage: when ``amount`` flows to a model where
 its companion ``currency`` column was projected away, the binding rides as a
-reference that no longer agrees at a confluence and widens to ``NAKED``; the
-coherence guard then blocks a downstream sum until a dependency discharges it.
+reference that no longer agrees at a UNION's confluence and widens to
+``NAKED``; the coherence guard then blocks a downstream sum until a dependency
+discharges it.
 The guard is armed by :func:`domain_type_property` when the caller passes the
 functional-dependency property's ref.
 
@@ -157,11 +158,10 @@ class _Polymorphic:
     """The dimension of a bare numeric literal: no fixed unit, but not a no-claim
     unknown either. It adopts the other operand's unit under ``+``/``-`` (so
     ``amount + 5`` stays the amount's currency rather than conflicting on a scalar)
-    and acts as dimensionless under ``*``/``/`` (so ``amount * 0.9`` keeps it). This
-    is the "a literal sits at bottom, polymorphic, until context fixes it" reading of
-    the algebra doc, kept distinct from ``None`` (an unknown magnitude, which absorbs
-    under every operator) and from the empty monomial (a *certified* dimensionless
-    value, which conflicts when added to a unit). A singleton; carries no payload."""
+    and acts as dimensionless under ``*``/``/`` (so ``amount * 0.9`` keeps it).
+    Distinct from ``None`` (an unknown magnitude, which absorbs under every
+    operator) and from the empty monomial (a *certified* dimensionless value,
+    which conflicts when added to a unit). A singleton; carries no payload."""
 
 
 POLYMORPHIC: Final[_Polymorphic] = _Polymorphic()
@@ -538,9 +538,8 @@ def _aggregate_rules(
     companion is not held constant per group: for ``COMBINE`` that cleared result is the
     mixed-currency reduction the not-well-typed finding reports; for ``SELECT`` it is the
     widen-to-top of a tag-blind selection (``min`` over mixed currencies), caught later
-    where a definite tag is required. The produce rule is the same for both; the finding
-    tells them apart. The classification (:data:`AGGREGATE_BEHAVIORS`) is the single
-    source of truth, in :mod:`dblect.sql.aggregates`."""
+    where a definite tag is required. The classification (:data:`AGGREGATE_BEHAVIORS`)
+    is the single source of truth, in :mod:`dblect.sql.aggregates`."""
     rules: dict[type[exp.AggFunc], AggregateRule[DomainTag]] = {}
     for agg_type, behavior in AGGREGATE_BEHAVIORS.items():
         # COMBINE and SELECT deliberately share one produce rule (the finding tells them
@@ -619,7 +618,7 @@ def domain_type_display(tag: DomainTag) -> AxisDisplay:
     return AxisDisplay(name="a magnitude in " + ", ".join(pieces))
 
 
-# --- join-key type compatibility (substrate signal) -----------------------------
+# --- join-key type compatibility (a signal, not a finding) -----------------------
 
 
 def join_key_conflicts(

--- a/src/dblect/lineage/properties/nullability.py
+++ b/src/dblect/lineage/properties/nullability.py
@@ -366,10 +366,10 @@ def _conditional_notnull_carrier(
     carrying it needs (rename columns and predicates through each projection, drop on a
     join / group / computed projection) is property-agnostic; only the *meaning* of the
     payload differs, and a one-column key reads here as "this column is non-null under
-    the predicate". The borrow is the pragmatic reuse for the second axis. If a third
-    axis wants the same carrying, lift this into a generic
-    ``conditional_carrier(claims, lattice)`` rather than reaching further into
-    uniqueness, so the shared mechanism stops depending on one property's value type.
+    the predicate". If a third caller wants the same carrying, lift this into a
+    generic ``conditional_carrier(claims, lattice)`` rather than reaching further
+    into uniqueness, so the shared mechanism stops depending on one property's
+    value type.
     """
     facts = collect(
         manifest,
@@ -564,7 +564,7 @@ def _outer_join_output_columns(
 def outer_join_nullable_columns(
     manifest: Manifest, *, parsed: Mapping[str, Expr] | None = None
 ) -> Mapping[str, Mapping[str, JoinSide]]:
-    """Per model name, the output columns whose nullability the substrate attributes to an
+    """Per model name, the output columns whose nullability this analysis attributes to an
     outer join at that model's own top-level FROM/JOIN structure, each mapped to the join
     kind (LEFT/RIGHT/FULL) that padded it.
 

--- a/src/dblect/lineage/properties/predicate_flow.py
+++ b/src/dblect/lineage/properties/predicate_flow.py
@@ -7,10 +7,10 @@ to it, and a projection renames the filter's columns (``country = 'US'`` becomes
 ``region = 'US'`` after ``country AS region``). CTEs and inline subqueries
 accumulate for free, since the relation walk recurses through them.
 
-The property is the shared substrate a later activation step reads to decide when a
-captured conditional fact applies: a conditional ``unique`` / ``not_null`` holds at
-any scope whose accumulated filter *implies* the test's predicate. Type refinement
-and contract validation are further consumers of the same flow.
+A later activation step reads this property to decide when a captured conditional
+fact applies: a conditional ``unique`` / ``not_null`` holds at any scope whose
+accumulated filter *implies* the test's predicate. Type refinement and contract
+validation read the same flow too.
 
 The value reuses the predicate engine's typed atoms (:data:`Canon`), so the filter
 is rigorously shaped and feeds the engine directly. Posture is silent-when-unproven:

--- a/src/dblect/lineage/properties/uniqueness.py
+++ b/src/dblect/lineage/properties/uniqueness.py
@@ -16,10 +16,10 @@ contradicts (two key declarations always union cleanly), so it is unreachable in
 resolution and exists only so ``meet`` / ``join`` have their annihilator and
 identity.
 
-Confluence and the cross at a ``JOIN`` are not a plain semiring: the ``JOIN``
-combine reads which columns the ON predicate equates, so it is an operator rule
-over :class:`~sqlglot.expressions.Join` rather than a value-only ``times``. The
-transfer catalogs and the relation walk land with the propagator's
+Confluence and the times-combine at a ``JOIN`` are not a plain semiring: the
+``JOIN`` combine reads which columns the ON predicate equates, so it is an
+operator rule over :class:`~sqlglot.expressions.Join` rather than a value-only
+``times``. The transfer catalogs and the relation walk land with the propagator's
 relation-scoped dispatch; this module defines the value type, its lattice, and
 the discoverers that ground it.
 """
@@ -176,7 +176,7 @@ def grain_preserved(keys: CandidateKeySet, origin_key: Key) -> bool:
     keyed only on a different key (the fan trap, where a join to a many-side replicates the
     magnitude), or with no key known, is not provably single-counted: the fan-out signal a
     downstream ``sum`` rests on. The user-facing finding is the finding pipeline's job; this
-    is the substrate predicate."""
+    is the predicate underneath it."""
     if keys.is_bottom:
         return True
     return any(key <= origin_key for key in keys.keys)

--- a/src/dblect/lineage/property.py
+++ b/src/dblect/lineage/property.py
@@ -116,7 +116,7 @@ def propagate(
     when it clears a tag, so a caller (the check) reads *why* a tag went to top rather
     than re-inferring it from the output. It is per-call: the propagator never mutates
     the shared graph, so one ``sink`` belongs to one world's run. ``None`` clears
-    silently (the substrate-only path).
+    silently, for a caller that only wants the annotation values, not the reasons.
     """
     reduce = _reducer_for(prop)
     lat = prop.lattice
@@ -301,7 +301,7 @@ def _apply_aggregate(
     The guard is the one channel a dependency enters an aggregate through: where a
     per-row companion of the aggregated value is not provably constant per group,
     the result clears to the lattice top. The cleared top is IMPLICIT, so a
-    downstream seam warns on it rather than reading it as a declared opt-out. When the
+    downstream consumer warns on it rather than reading it as a declared opt-out. When the
     guard clears and a ``sink`` is collecting, the structured reason (the operand tag
     and the undischarged companions with the paths checked) is recorded there, so the
     consumer reads the event rather than re-inferring it from the cleared output.


### PR DESCRIPTION
## What this does

Follows on from #232 (merged): re-passes the same 4 package areas
(`lineage/`, `lineage/facts/`, `lineage/properties/`, `check/`) to fix a gap
in that pass and correct an overshoot found while fixing it.

`#232` fixed design-doc jargon by swapping in plainer words, but on review
some jargon nouns ("substrate", "seam") were still left in several
docstrings. An attempt to fix that went the other way: it added worked
examples, extra paragraphs, and reader-oriented headers, landing at +264 net
lines across these same 14 files — tight docstrings turned into small
essays. That attempt was discarded, not merged.

This PR targets the actual bar: plain language **and** short, everywhere.
Jargon gets replaced by what it means, inline, at the same length; no new
example gets added; no sentence survives that just restates what the code
already shows structurally. Net change across the 14 files: **+2 lines**
(84 insertions, 82 deletions) — versus +34 for #232 and +264 for the
discarded attempt.

## A real bug, not just prose

`check/run.py`'s `_grounding_coverage` docstring referenced a function
`_propagate`, which doesn't exist. The real function is `propagate`. Fixed
the stale reference.

## Test plan

- [x] `ruff check`
- [x] `ruff format --check`
- [x] `pyright`
- [x] `pytest` (full suite, 1584 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAE4C5m7unT2uPjd1XthjN