### PR TITLE
docs: plain-and-tight prose pass over the rest of src/dblect

### DIFF
--- a/src/dblect/adapters/__init__.py
+++ b/src/dblect/adapters/__init__.py
@@ -12,9 +12,9 @@ and calls :func:`register`. The built-ins under :mod:`dblect.adapters.builtin`
 are auto-discovered, so this package never enumerates them.
 
 An adapter is **validated** when dblect's detectors have been exercised against its
-SQL end-to-end (today, only duckdb). The others carry the runtime semantics dbt's
-adapter docs describe and route through the matching sqlglot dialect once the
-operator opts in via ``--dialect``.
+SQL end-to-end; :func:`validated_adapters` names the current set. The others carry
+the runtime semantics dbt's adapter docs describe and route through the matching
+sqlglot dialect once the operator opts in via ``--dialect``.
 """
 
 from __future__ import annotations

--- a/src/dblect/adapters/builtin/duckdb.py
+++ b/src/dblect/adapters/builtin/duckdb.py
@@ -18,7 +18,7 @@ register(
         validated=True,
         not_null_enforced=True,
         key_enforced=True,
-        default_incremental_strategy=None,  # left unset pending validation
+        default_incremental_strategy=None,  # dbt-duckdb's actual default is unconfirmed
         non_deterministic_builtins=_DUCKDB_NON_DETERMINISTIC_BUILTINS,
     )
 )

--- a/src/dblect/adapters/model.py
+++ b/src/dblect/adapters/model.py
@@ -52,10 +52,11 @@ class AdapterProfile:
 
     ``adapter_type`` is the effective target's dbt name (the manifest's, or the one
     an override selects); ``sqlglot_dialect`` parses its compiled SQL. The two
-    enforcement flags are descriptive provenance, read by the unenforced-constraint
-    findings and never by fact resolution. ``default_incremental_strategy`` is the
-    strategy in force when a model leaves ``incremental_strategy`` unset, or
-    ``None`` where dblect does not know the adapter's default to deduplicate.
+    enforcement flags are metadata only: the unenforced-constraint finding reads
+    them, but nothing uses them to decide whether a native constraint actually
+    holds. ``default_incremental_strategy`` is the strategy in force when a model
+    leaves ``incremental_strategy`` unset, or ``None`` where dblect does not know
+    the adapter's default to deduplicate.
     ``non_deterministic_builtins`` is the complete name set (the portable baseline
     plus this adapter's own builtins) the non-determinism detector matches anonymous
     function calls against; a consumer reads it whole and unions nothing.

--- a/src/dblect/adapters/registry.py
+++ b/src/dblect/adapters/registry.py
@@ -49,8 +49,8 @@ def _ensure_loaded() -> None:
 def _conservative(adapter_type: str, *, sqlglot_dialect: str | None = None) -> AdapterProfile:
     """The profile for an adapter dblect has no specific knowledge of: NOT NULL
     enforced (true on essentially every warehouse), PRIMARY KEY / UNIQUE advisory,
-    no known dedup default (so an unset incremental strategy claims no key), and
-    only the portable non-determinism baseline."""
+    no known dedup default (so an unset incremental strategy carries no dedup
+    guarantee), and only the portable non-determinism baseline."""
     return AdapterProfile(
         adapter_type=adapter_type,
         sqlglot_dialect=sqlglot_dialect if sqlglot_dialect is not None else adapter_type,

--- a/src/dblect/analysis.py
+++ b/src/dblect/analysis.py
@@ -6,7 +6,7 @@ the declaration-level ones (contract resolution, domain-type contradictions acro
 the DAG, not-well-typed aggregations), located by model, column, and contract.
 :func:`~dblect.audit.run_audit` reports the SQL-structural ones (join fan-out,
 window order, the nullability hazards, the rest), located by a span in one compiled
-statement. The two stay distinct in representation and altitude; issue #107 weighs
+statement. The two stay distinct in representation and granularity; issue #107 weighs
 whether to merge the representations as well.
 
 What this module removes is the obligation to *know* there are two families. Asking
@@ -73,7 +73,7 @@ class AnalysisReport:
     """Every finding for one manifest, from every detector family, plus each family's
     own report so a caller that needs the family-specific extras (coverage blocks,
     suppressed directives) still has them. ``findings`` is the merged, sealed view the
-    finding-threading consumers read; the rest is there when an altitude matters."""
+    finding-threading consumers read; the rest is there when that granularity matters."""
 
     findings: tuple[AnalysisFinding, ...]
     check: CheckReport
@@ -102,7 +102,7 @@ def analyze(
     already carries the resolved contracts.
 
     The build's resolved ``determines`` facts are also threaded into the structural audit so
-    join-fanout grounds key coverage through functional dependencies (a declared ``wiki_id
+    join-fanout extends key coverage through functional dependencies (a declared ``wiki_id
     determines wiki_name`` lets a join on the determinant cover a key carrying the dependent).
     The declaration family already reads these off the shared build; this hands the same facts
     to the structural one.

--- a/src/dblect/audit/__init__.py
+++ b/src/dblect/audit/__init__.py
@@ -1,4 +1,4 @@
-"""Audit pipeline: static detectors, replay-determinism, heuristic invariants."""
+"""Audit pipeline: detect SQL hazards, back-map findings to source, and apply suppressions."""
 
 from dblect.audit.sourcemap import SourceSpan, SpanBasis
 from dblect.audit.suppress import SuppressionDirective

--- a/src/dblect/audit/sourcemap.py
+++ b/src/dblect/audit/sourcemap.py
@@ -11,7 +11,8 @@ by compilation does not match, so for those we reach for a second anchor: the
 source line of the ``{{ ... }}`` call that emitted it, found in the raw template's
 Jinja structure. When the gap between two verbatim anchors holds exactly one call
 site the emitted span anchors there (``MACRO_CALL``); SQLFluff reaches the same
-position from an instrumented render, and this reconstructs it from artifacts.
+position by rendering the template with instrumentation, and this reconstructs it
+from the compiled SQL and the parsed template alone, without a custom render.
 When no single source line can be found (several calls in the gap, or a fully
 generated model) the span stays compiled-relative: a wrong source line reads as a
 bug in the tool, so we keep the honest compiled line instead of guessing.

--- a/src/dblect/audit/suppress.py
+++ b/src/dblect/audit/suppress.py
@@ -11,9 +11,6 @@ comment can address both a lint rule and a dblect finding::
     -- only silence one dblect detector:
     select b.k, sum(amount) from a left join b on a.k = b.k group by b.k  -- noqa: DBLECT_NULL_GROUP_AFTER_OUTER_JOIN
 
-    -- one directive, two audiences (the lint rule is dbt lint's, the DBLECT_ code is ours):
-    select b.k, sum(amount) from a left join b on a.k = b.k group by b.k  -- noqa: RF01, DBLECT_JOIN_FANOUT
-
 Two rules govern the codes after the colon:
 
 * A bare ``-- noqa`` (no codes) silences every dblect finding on the line.
@@ -67,15 +64,9 @@ if TYPE_CHECKING:
 
 class Suppressible(Protocol):
     """What a directive needs to decide whether it silences a finding: the kind it carries
-    and the two coordinates it can occupy. Both finding families satisfy this, so matching
-    is written once over the protocol rather than per family.
-
-    ``located_span`` is the back-mapped span the report shows; ``compiled_span`` is the raw
-    compiled coordinate the parser observed. They differ only for a macro-emitted construct,
-    where ``located_span`` names the ``{{ ... }}`` call site in the template and
-    ``compiled_span`` names the emitted line in the compiled SQL. Matching consults each
-    frame against the coordinate that indexes it (:func:`apply`), so a ``-- noqa`` on the
-    call line and one in the macro body both reach the finding, each in its own text."""
+    and the ``located_span``/``compiled_span`` pair described at module level and matched
+    in :func:`apply`. Both finding families expose this, so matching is written once over
+    the protocol instead of once per family."""
 
     @property
     def kind(self) -> SuppressibleKind: ...

--- a/src/dblect/audit/walker.py
+++ b/src/dblect/audit/walker.py
@@ -59,8 +59,8 @@ from dblect.uniqueness.detector import (
 Detector = Callable[[Expr], tuple[Finding, ...]]
 
 # The dialect-agnostic structural detectors. Context-bound detectors (non-determinism
-# from the resolved adapter, uniqueness and nullability grounded against declared
-# facts, inner-flatten grounded against propagated array non-emptiness) are built per
+# from the resolved adapter, uniqueness and nullability checked against declared
+# facts, inner-flatten checked against propagated array non-emptiness) are built per
 # run in `run_audit` and appended there, so they are not listed. The inner-flatten check
 # in particular is run only through its fact-grounded factory so it sees the cross-model
 # non-emptiness map; listing the structural form here too would double-report it.
@@ -161,9 +161,9 @@ def run_audit(
 ) -> AuditReport:
     """Run `detectors` over every model in `manifest`.
 
-    ``profile`` is the run's resolved target: its dialect parses every model and
-    its semantics ground the fact-based detectors, so parsing and enforcement read
-    the same adapter.
+    ``profile`` is the run's resolved target: its dialect parses every model, and
+    its semantics are what the fact-grounded detectors check against, so parsing
+    and enforcement read the same adapter.
 
     Sources, seeds, and snapshots are not scanned: they have no SQL we own.
     Models whose ``compiled_code`` is missing or unparseable are listed in
@@ -172,13 +172,13 @@ def run_audit(
     Context-bound detectors run alongside the configured `detectors` list, each
     built from the resolved profile and the pre-parsed trees: the non-determinism
     detector (its builtin names come from the profile), the uniqueness window
-    order-keys, join-fanout, and non-deterministic-``LIMIT`` detectors (grounded
+    order-keys, join-fanout, and non-deterministic-``LIMIT`` detectors (checked
     against declared keys, the last also against each model's materialization), the
     nullability hazard detectors (GROUP BY, join key, and NOT IN on an
-    inherited-nullable column, grounded against the propagated nullability
-    property), the inner-flatten row-drop detector (grounded against the
+    inherited-nullable column, checked against the propagated nullability
+    property), the inner-flatten row-drop detector (checked against the
     propagated array-non-emptiness property, so a rebuilt-then-unnested array is
-    not flagged), and the snapshot temporal-filter detector (grounded against the
+    not flagged), and the snapshot temporal-filter detector (checked against the
     manifest's snapshots and their validity columns). The fact-grounded ones are
     opportunistic, silent on projects that declare nothing, so they need no opt-in
     flag. They share the audit's pre-parsed trees, so the SQL is parsed once.
@@ -188,8 +188,9 @@ def run_audit(
     :func:`dblect.analysis.analyze` instead, which carries both families so a family
     is never dropped by being forgotten.
     """
-    # ``analyze`` shares the parse and both lineage graphs it already built (rebuilding them,
-    # the heavy substrate, dominates a run); omitted, this builds them, the standalone path.
+    # ``analyze`` already built the parse and both lineage graphs and passes them in here,
+    # skipping a rebuild of that heavy substrate (it dominates a run). Without them, this
+    # is the standalone path, and builds them itself.
     if parsed is None:
         parsed, trees = parse_manifest_models(manifest, dialect=profile.sqlglot_dialect)
     else:
@@ -274,15 +275,9 @@ def _scan_one(
     raw_findings: list[Finding] = []
     for detector in detectors:
         raw_findings.extend(detector(tree))
-    # Directives are read from both texts: the template for a finding the back-map placed on
-    # a source line, and the compiled SQL for one a macro emitted, whose guarding `-- noqa`
-    # renders only into the compiled output. Each finding is matched in the frame(s) it
-    # occupies.
     directives = FramedDirectives.for_node(node)
-    # Findings carry compiled-SQL spans; back-map them onto the source template once per
-    # model, then match directives against the located span. Locating before suppressing
-    # is what lets a `-- noqa` on the line the report shows silence a finding whose
-    # compiled line a macro expansion pushed away from its source line.
+    # Locate before suppressing: a `-- noqa` is matched against the line the report shows,
+    # which can differ from the compiled line a macro expansion produced.
     line_map = build_line_map(node.analysis_sql, node.raw_code)
     located = [_locate(node, f, line_map) for f in raw_findings]
     active, suppressed = apply(located, directives)

--- a/src/dblect/baseline.py
+++ b/src/dblect/baseline.py
@@ -2,7 +2,7 @@
 
 ``dblect check --base-manifest`` analyses the base revision's manifest the same way
 as HEAD and keeps the findings whose identity is new. The diff is over finding sets,
-not edited source lines: a finding is computed over compiled SQL grounded against
+not edited source lines: a finding is computed over compiled SQL resolved against
 upstream models, so a changed macro or an upstream column can introduce one with the
 model's own source file unchanged, which a source-line diff would not see.
 """

--- a/src/dblect/cli/__init__.py
+++ b/src/dblect/cli/__init__.py
@@ -170,8 +170,8 @@ def check(
 
     Both detector families run over the project. The structural family needs only the
     compiled SQL, so it reports on any project. The declaration family resolves the
-    contracts under ``<project_dir>/dblect/`` if present; with none declared it simply
-    reports zero contracts resolved rather than nothing to do.
+    contracts under ``<project_dir>/dblect/`` if present; with none declared it reports
+    zero contracts resolved instead of skipping the family outright.
     """
     from dataclasses import replace
 
@@ -359,8 +359,8 @@ def _analyze_base(
     """Analyse the base revision's manifest the same way HEAD was analysed.
 
     Same dialect resolution, same declarations (``registry``), and the same
-    resolution floor, so a finding's cross-world identity is comparable across the two
-    worlds. The base catalog defaults to a ``catalog.json`` beside ``base_manifest``,
+    resolution floor, so a finding found in one analysis matches the same finding found
+    in the other. The base catalog defaults to a ``catalog.json`` beside ``base_manifest``,
     matching the Slim CI layout where the stored manifest and catalog sit together.
     """
     from dblect.analysis import analyze

--- a/src/dblect/contracts/__init__.py
+++ b/src/dblect/contracts/__init__.py
@@ -5,9 +5,9 @@ SQL for the execution path.
 A model contract relates several columns, rows, or models through methods marked
 :func:`contract`. The method body manipulates column proxies (``self.col``,
 ``models.other.col``), and the operators build an :mod:`~dblect.contracts.ast`
-tree the framework reads. A returned fact feeds the substrate; a returned
-predicate is checked by running. See ``docs/design/declaration-dsl.md`` and
-``docs/design/dblect_technical_intro.md``.
+tree the framework reads. A returned fact is trusted outright, the way a
+declared key is; a returned predicate is checked by running. See
+``docs/design/declaration-dsl.md`` and ``docs/design/dblect_technical_intro.md``.
 """
 
 from __future__ import annotations

--- a/src/dblect/contracts/ast.py
+++ b/src/dblect/contracts/ast.py
@@ -24,7 +24,8 @@ from enum import StrEnum, auto
 
 class AggFunc(StrEnum):
     """The reductions a column proxy offers. ``COUNT`` and ``COUNT_DISTINCT`` are
-    always well typed; the rest carry the coherence obligation the algebra names."""
+    always well typed; ``SUM``, ``AVG``, ``MIN``, and ``MAX`` require the values
+    they combine to share a unit or currency."""
 
     SUM = auto()
     AVG = auto()
@@ -35,8 +36,8 @@ class AggFunc(StrEnum):
 
 
 class ArithOp(StrEnum):
-    """Binary arithmetic over magnitudes (the dimensional algebra lives downstream;
-    here we only record the operator)."""
+    """Binary arithmetic over magnitudes (unit and currency checking happens
+    downstream; here we only record the operator)."""
 
     ADD = auto()
     SUB = auto()
@@ -170,9 +171,9 @@ Pred = Compare | IsNull | InSet | Between | BoolNode
 
 # --- facts ----------------------------------------------------------------------
 #
-# A contract method that returns one of these feeds the substrate rather than
-# being run: it is a vouched assertion the analyzer trusts to discharge
-# obligations and propagate. The bridge lowers each to the matching substrate fact.
+# A contract method that returns one of these is trusted outright rather than
+# run: it is an assertion the analyzer takes as given, the way a declared key
+# is. The bridge lowers each into the matching fact the lineage engine tracks.
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/dblect/contracts/compile.py
+++ b/src/dblect/contracts/compile.py
@@ -12,8 +12,8 @@ well-exercised place.
 side, run against generated rows in an in-memory DuckDB, and compared group by
 group under the predicate's tolerance. This is the runtime-checked half of the
 contract surface, the analyzer never reasons over it. Cross-relation joins
-(``joined_on``) and the materialized-DataFrame escape hatch are not lowered here
-yet; they are the natural next increment.
+(``joined_on``) and the materialized-DataFrame contract form are not lowered
+here yet; they are the natural next increment.
 """
 
 from __future__ import annotations

--- a/src/dblect/contracts/decorator.py
+++ b/src/dblect/contracts/decorator.py
@@ -1,11 +1,11 @@
 """``@contract``: mark a method whose body builds a symbolic expression.
 
-The marker is intentionally tiny. It tags the function so the model contract's
-metaclass finds it during the scan, then :func:`capture` runs the body once with
-a :class:`~dblect.contracts.proxy.ContractSelf` standing in for ``self`` and
-records the AST it returns. Dispatch on that AST decides what the contract does:
-a :data:`~dblect.contracts.ast.FactNode` feeds the substrate (read and trusted
-unless contradicted), a :data:`~dblect.contracts.ast.Pred` is checked by running.
+The marker is intentionally tiny. It tags the function so
+``ModelContract.__init_subclass__`` finds it during the scan, then :func:`capture`
+runs the body once with a :class:`~dblect.contracts.proxy.ContractSelf` standing
+in for ``self`` and records the AST it returns. Dispatch on that AST decides what
+the contract does: a :data:`~dblect.contracts.ast.FactNode` is trusted outright
+unless contradicted, a :data:`~dblect.contracts.ast.Pred` is checked by running.
 See ``docs/design/dsl-reference.md`` (Contracts).
 """
 
@@ -25,9 +25,8 @@ from dblect.contracts.proxy import (
 _MARKER = "_dblect_contract"
 
 # A contract body takes a self-proxy and returns a fact or predicate proxy. The
-# return is typed ``object`` because authors annotate it loosely (or not at all)
-# and the materialized escape hatch returns other shapes; :func:`capture` checks
-# the actual proxy kind at runtime.
+# return is typed ``object`` because authors annotate it loosely (or not at all);
+# :func:`capture` checks the actual proxy kind at runtime.
 ContractMethod = Callable[[ContractSelf], object]
 
 

--- a/src/dblect/contracts/proxy.py
+++ b/src/dblect/contracts/proxy.py
@@ -263,7 +263,7 @@ def _existing_ref(cmp: Compare) -> ValueExpr | None:
 
 class FactProxy:
     """A fact a contract method returns. Inert: it only carries the AST node the
-    bridge lowers to a substrate fact."""
+    bridge lowers into a fact the lineage engine tracks."""
 
     __slots__ = ("fact",)
 
@@ -287,8 +287,8 @@ class ContractSelf:
         return ColumnProxy(Col(None, name))
 
     def __getitem__(self, name: str) -> ColumnProxy:
-        """A column by name, the escape hatch for one that collides with a method
-        here (``self["key"]``, ``self["grain"]``). Indexing never resolves to a
+        """A column by name, for one whose name collides with a method here
+        (``self["key"]``, ``self["grain"]``). Indexing never resolves to a
         method, so it reaches any column attribute access would shadow."""
         return ColumnProxy(Col(None, name))
 
@@ -322,8 +322,8 @@ class ModelProxy:
         return ColumnProxy(Col(self.model, name))
 
     def __getitem__(self, name: str) -> ColumnProxy:
-        """A column by name, the escape hatch for one that collides with the
-        ``model`` slot (``models.other["model"]``). Indexing always names a column."""
+        """A column by name, for one whose name collides with the ``model`` slot
+        (``models.other["model"]``). Indexing always names a column."""
         return ColumnProxy(Col(self.model, name))
 
 

--- a/src/dblect/demo/enums.py
+++ b/src/dblect/demo/enums.py
@@ -1,9 +1,10 @@
 """Illustrative enum vocabularies: ISO 4217 currencies and ISO 3166-1 countries.
 
-Partial slices, enough to exercise the tag algebra in the walkthrough. They are
-ordinary :class:`~dblect.types.UnitEnum` / :class:`~dblect.types.NominalEnum`
-subclasses, the markers that live in ``dblect.types``; a project declares its
-own categories the same way. Widening these is a data edit, not a design change.
+Partial slices, enough to give the walkthrough's unit and category types
+something to hold. They are ordinary :class:`~dblect.types.UnitEnum` /
+:class:`~dblect.types.NominalEnum` subclasses, the markers that live in
+``dblect.types``; a project declares its own categories the same way. Widening
+these is a data edit, not a design change.
 """
 
 from __future__ import annotations

--- a/src/dblect/execution/incremental.py
+++ b/src/dblect/execution/incremental.py
@@ -9,8 +9,8 @@ with nothing built. Each world is read back as an ordinary
 
 The override reaches the bare ``{{ is_incremental() }}`` call. A model that calls
 ``dbt.is_incremental()`` explicitly, or a branch that introspects the existing
-relation's schema at compile, is not reached and degrades to an opaque world
-(reported with its error) while the other world still stands.
+relation's schema at compile, is not reached: that world's compile does not
+succeed, so it is reported with its error while the other world still stands.
 """
 
 from __future__ import annotations
@@ -136,7 +136,8 @@ def _compile_world(
     env: Mapping[str, str],
 ) -> CompiledWorld:
     """Write the override for ``value``, compile, and harvest the manifest. A
-    non-zero compile or a missing manifest yields an opaque world, never a raise."""
+    non-zero compile or a missing manifest returns a ``CompiledWorld`` whose
+    compile did not succeed, never a raise."""
     macro_path.write_text(_override_macro(value))
     proc = run_dbt(dbt, ["compile", "--project-dir", str(work)], env=env)
     if proc.returncode != 0:

--- a/src/dblect/execution/run.py
+++ b/src/dblect/execution/run.py
@@ -1,8 +1,9 @@
 """Run dbt models end-to-end in DuckDB and capture the output.
 
-This is the substrate the static-analysis invariant checks and the runtime
-PBT loop sit on. We use a subprocess as the v1 approach for fidelity:
-in-process Jinja rendering is a follow-up when perf bites.
+The static-analysis invariant checks and the runtime PBT loop both run models
+through this. We shell out to the dbt CLI as a subprocess for fidelity to
+real dbt behavior; in-process Jinja rendering would be faster and is worth
+revisiting if performance becomes a problem.
 
 The contract:
 

--- a/src/dblect/flatten/__init__.py
+++ b/src/dblect/flatten/__init__.py
@@ -1,4 +1,4 @@
-"""Inner-flatten row-drop detection grounded against propagated array non-emptiness.
+"""Inner-flatten row-drop detection checked against propagated array non-emptiness.
 
 The structural detector in :mod:`dblect.sql.patterns` flags an inner ``UNNEST`` that
 can drop a parent row, clearing only the locally provable cases (an outer form, a

--- a/src/dblect/manifest/dag.py
+++ b/src/dblect/manifest/dag.py
@@ -1,8 +1,8 @@
 """Immutable directed acyclic graph keyed by node identifier.
 
 Used by the manifest module to represent dbt's project structure, and reused by
-downstream consumers (type propagation, change-impact) that need topological
-queries over the project DAG.
+downstream consumers (the lineage builder today, more later) that need
+topological queries over the project DAG.
 """
 
 from __future__ import annotations
@@ -125,7 +125,7 @@ class Dag:
         return frozenset(visited)
 
     def _find_cycle_from(self, start: str) -> tuple[str, ...]:
-        """DFS to recover a witness cycle for `CycleError`."""
+        """DFS that finds one cycle to report in `CycleError`."""
         path: list[str] = []
         on_path: set[str] = set()
 

--- a/src/dblect/manifest/parse.py
+++ b/src/dblect/manifest/parse.py
@@ -114,7 +114,7 @@ class ConstraintType(StrEnum):
 class Materialization(StrEnum):
     """How dbt persists (or does not persist) a node's rows.
 
-    The vocabulary is closed, so a check that turns on whether a relation stores its rows can
+    The vocabulary is closed, so code that depends on whether a relation stores its rows can
     branch over these members exhaustively rather than test membership in a raw-string set.
     ``OTHER`` covers adapter-specific materializations (and the absence of a resolved value) so
     the parse stays total; comparisons go through the members to keep typos out of call sites.
@@ -191,11 +191,11 @@ class DbtTestMetadata:
 class ModelConfig:
     """The slice of a node's resolved ``config`` block dblect reasons about.
 
-    Carries only the keys a property currently consumes, not the whole config.
+    Carries only the keys a check currently reads, not the whole config.
     ``unique_key`` is normalized to a tuple of column names: dbt accepts it as a
     single string or a list, and both reduce to the same candidate-key shape.
     More keys (``on_schema_change``, ``cluster_by`` ...) land here as the
-    properties that read them are added.
+    checks that read them are added.
     """
 
     materialized: str | None = None
@@ -225,12 +225,11 @@ class Column:
 class Macro:
     """A macro definition as carried in the manifest's ``macros`` block.
 
-    The source body (`macro_sql`) is what the var-inference macro-following
-    engine expands to reach `var()` calls; `depends_on_macros` is the
-    macro-to-macro edge set that walk recurses through. This view is a faithful
-    transcription of the manifest entry; resolving a name to a definition (the
-    bare-name-then-package lookup) lands with macro-following, which defines what
-    that resolution must satisfy.
+    ``macro_sql`` is the macro's source body and ``depends_on_macros`` is the set
+    of other macros it calls; both matter for tracing a ``var()`` call through the
+    macros that reach it, work var-inference does elsewhere. This view is a plain
+    transcription of the manifest entry: it does not resolve a bare macro name to
+    a definition across packages.
     """
 
     unique_id: str
@@ -295,8 +294,8 @@ class Node:
 
         ``NOT_COMPILED`` when dbt's own flag says so. Otherwise ``STALE_OR_ABSENT``
         when there is a non-trivial source template but no compiled code (the
-        non-hermetic-compile gap), and ``COMPILED`` when there is compiled code or
-        nothing non-trivial to compile.
+        compile run didn't reach the warehouse), and ``COMPILED`` when there is
+        compiled code or nothing non-trivial to compile.
 
         Only SQL nodes carry this signal: a Python (or other non-SQL) model is not
         SQL-analysable, so an empty SQL ``compiled_code`` is not the compile gap and the
@@ -332,7 +331,7 @@ class Node:
 
 # The unique_id prefixes dbt gives the data-flow node kinds, derived from the
 # resource types so the two stay in lockstep ("model.", "source.", "seed.",
-# "snapshot."). ``OTHER`` (tests, analyses) never anchors a generic test.
+# "snapshot."). ``OTHER`` (tests, analyses) is never a generic test's target.
 DATA_FLOW_UID_PREFIXES: tuple[str, ...] = tuple(
     f"{rt.value}." for rt in ResourceType if rt is not ResourceType.OTHER
 )
@@ -346,7 +345,7 @@ def generic_test_target_uid(
     Prefer ``attached_node`` (the modern manifest shape); fall back to the first
     eligible entry in ``depends_on`` for older manifests where ``attached_node``
     isn't populated. ``eligible_prefixes`` narrows which target kinds count, so a
-    caller that grounds only models and sources can pass a subset of the
+    caller interested only in models and sources can pass a subset of the
     data-flow default.
     """
     if node.attached_node and node.attached_node.startswith(eligible_prefixes):
@@ -401,8 +400,8 @@ class Manifest:
             raise ValueError("manifest is missing metadata.adapter_type")
 
         # Macros live under their own top-level `macros` block, separate from
-        # the data-flow `nodes`. They carry no edges into the DAG; the registry
-        # is consumed by macro-following, not by lineage.
+        # the data-flow `nodes`. They carry no edges into the DAG; this registry
+        # is for future work tracing `var()` calls through macros, not for lineage.
         macros = {uid: _macro_from_parsed(uid, m) for uid, m in (parsed.macros or {}).items()}
         return cls(
             schema_version=schema_version,

--- a/src/dblect/nullability/__init__.py
+++ b/src/dblect/nullability/__init__.py
@@ -1,7 +1,8 @@
 """Fact-grounded audit detectors for nullability hazards.
 
-The nullability *property* (per-column tri-state, with outer-join taint and conditional
-NON_NULL activation) lives on the lineage.facts substrate as
+The nullability property marks each column NON_NULL, NULLABLE, or unknown: NULLABLE
+covers a column an outer join can pad with NULLs, and NON_NULL can hold only once a
+condition the query establishes guards it. It is computed in
 ``dblect.lineage.properties.nullability``. This package is the audit-facing consumer:
 detectors that read the proven nullability and flag NULL-sensitive constructs where the
 null silently changes the result: a GROUP BY on an inherited-nullable key, a join keyed

--- a/src/dblect/nullability/detector.py
+++ b/src/dblect/nullability/detector.py
@@ -46,9 +46,9 @@ NullableByName = Mapping[str, frozenset[str]]
 
 
 class NullableCause(StrEnum):
-    """Why a column is nullable upstream, when the substrate can attribute it.
+    """Why a column is nullable upstream, when we can attribute it.
 
-    The ``*_JOIN`` causes are positive structural claims the nullability substrate already
+    The ``*_JOIN`` causes are positive structural claims the nullability property already
     derives (the column is drawn from an outer join's optional side), named by the join kind
     that padded it. ``UNKNOWN`` is the honest fallback: the column is proven NULLABLE, but
     the cause is not derivable here, so the finding names no cause rather than fabricating
@@ -60,8 +60,8 @@ class NullableCause(StrEnum):
     UNKNOWN = "unknown"
 
 
-# Per relation name, the column-to-cause map for proven-NULLABLE columns whose cause the
-# substrate attributes. A column absent from the inner map reads as ``UNKNOWN``.
+# Per relation name, the column-to-cause map for proven-NULLABLE columns whose cause we
+# can attribute. A column absent from the inner map reads as ``UNKNOWN``.
 CauseByName = Mapping[str, Mapping[str, NullableCause]]
 
 
@@ -354,7 +354,7 @@ def _finding(grp_expr: exp.Column, *, written_at: Expr, source: str, column: str
 
 
 def _cause_clause(cause: NullableCause) -> str:
-    """The ``why nullable`` clause, when the substrate attributes a cause. Returns an empty
+    """The ``why nullable`` clause, when we can attribute a cause. Returns an empty
     string for ``UNKNOWN`` so the message degrades honestly rather than fabricating one."""
     match cause:
         case NullableCause.LEFT_JOIN:
@@ -557,9 +557,9 @@ def _cause_by_name(
     """Index, by relation name, the attributable ``why nullable`` cause per column.
 
     Only the outer-join cause is attributable today, read from the same structural
-    analysis the nullability taint uses (:func:`outer_join_nullable_columns`). A column
-    the substrate cannot attribute is simply absent, so the finding reads it as
-    ``UNKNOWN`` and names no cause."""
+    analysis that flags outer-join-nullable columns (:func:`outer_join_nullable_columns`).
+    A column we cannot attribute is simply absent, so the finding reads it as ``UNKNOWN``
+    and names no cause."""
     out: dict[str, dict[str, NullableCause]] = {}
     for name, columns in outer_join_nullable_columns(manifest, parsed=parsed).items():
         out[name] = {col: _CAUSE_OF_SIDE[side] for col, side in columns.items()}
@@ -576,10 +576,11 @@ def make_nullability_detectors(
 ) -> tuple[Detector, ...]:
     """Curry the nullability-consuming detectors against the propagated annotations.
 
-    Runs one cross-model nullability propagation (outer-join taint plus conditional
-    activation, via ``activated_nullability``), indexes the proven-NULLABLE columns by
-    relation name, and curries the GROUP BY, join-key, and NOT-IN detectors against that
-    index. ``profile`` is the run's resolved target (its dialect parses, its semantics
+    Runs one cross-model nullability propagation via ``activated_nullability`` (it marks
+    a column nullable when an outer join can pad it, and activates a NON_NULL fact only
+    once the query establishes the guarding condition), indexes the proven-NULLABLE
+    columns by relation name, and curries the GROUP BY, join-key, and NOT-IN detectors
+    against that index. ``profile`` is the run's resolved target (its dialect parses, its semantics
     ground); ``parsed`` lets the walker share its pre-parsed trees. ``column_graph`` lets the
     audit pass the manifest column graph it already built, so the qualify-and-resolve walk is
     not repeated per fact family. ``fd_by_name`` is the propagated functional-dependency map

--- a/src/dblect/sarif.py
+++ b/src/dblect/sarif.py
@@ -409,7 +409,7 @@ def _notification(descriptor_id: str, text: str, logical_name: str) -> _Notifica
 
 
 def _fingerprint(finding: AnalysisFinding) -> str:
-    # Hash the cross-run identity (kind plus where it lands, no line numbers) so a
+    # Hash the cross-world identity (kind plus where it lands, no line numbers) so a
     # consumer can track the same finding across compilations.
     return hashlib.sha256(repr(cross_world_identity(finding)).encode("utf-8")).hexdigest()
 

--- a/src/dblect/severity.py
+++ b/src/dblect/severity.py
@@ -7,15 +7,10 @@ fails at. A correctness hazard (the analysis says the query returns wrong rows) 
 drift between runs) is a ``warn``; an ``info`` is an observation worth surfacing that on
 its own should not fail anyone's build.
 
-``Severity`` is a ``StrEnum`` so the level values read as the plain words (the CLI flag
-and the JSON field both want ``info``/``warn``/``error``). Comparison is overridden to
-follow an explicit rank rather than the inherited string order, so ``>=`` is a real
-ordering and not a lexicographic accident; comparing a ``Severity`` to anything else
-raises rather than silently falling back to ``str`` order. The per-kind mapping is the
-single place a kind's default level is decided, written as a ``match`` closed by
-``assert_never`` so a new kind without a level is a type error rather than a silent
-default; ``severity_of`` reads a finding's level without the caller knowing which
-detector family produced it.
+The per-kind mapping is the single place a kind's default level is decided, written
+as a ``match`` closed by ``assert_never`` so a new kind without a level is a type
+error rather than a silent default; ``severity_of`` reads a finding's level without
+the caller knowing which detector family produced it.
 """
 
 from __future__ import annotations
@@ -103,11 +98,11 @@ def _structural_severity(kind: FindingKind) -> Severity:
             # Real-project calibration (#125) found the fanout pair firing on every
             # intended fact-to-dimension surrogate-key
             # join: the dimension declares its key on the natural key, and the surrogate
-            # key is a function of it that uniqueness does not yet ground through. They
-            # ship advisory so a textbook star schema stays visible without failing the
-            # build. Raise them back to error once uniqueness grounds through the
-            # surrogate-key expression, or once the lenient/strict split (#116) can hold
-            # the error default in the strict profile.
+            # key is a function of it that the analysis does not yet know is also unique.
+            # They ship advisory so a textbook star schema stays visible without failing
+            # the build. Raise them back to error once the analysis can prove the
+            # surrogate-key expression is unique too, or once the lenient/strict split
+            # (#116) can hold the error default in the strict profile.
             | FindingKind.JOIN_FANOUT
             | FindingKind.CROSS_MODEL_FANOUT
         ):

--- a/src/dblect/sql/_sqlglot.py
+++ b/src/dblect/sql/_sqlglot.py
@@ -72,7 +72,7 @@ class GroupBinding(StrEnum):
     would bind an input column of that name first and the AST cannot rule one out.
 
     A detector may read all three, since over-reporting is its safe direction. A consumer that
-    *grounds* a fact from the group key stops at ``DECIDED`` (see
+    treats the group key as an established fact stops at ``DECIDED`` (see
     :attr:`GroupTarget.grounded_expression`): keys and dependencies are read downstream to
     clear hazards, so a wrong resolution there silences real findings instead of adding a
     spurious one.
@@ -91,8 +91,8 @@ class GroupTarget:
     A finding about the *grouping decision* belongs at ``written_at``, so ``GROUP BY 1`` is
     diagnosed at the clause an analyst reads. One about something written inside the target (a
     ``now()`` call) belongs at ``expression``, where that call is spelled out. The two nodes
-    coincide for a target written in full. ``binding`` decides whether a consumer may ground a
-    fact from ``expression``: see :attr:`grounded_expression`.
+    coincide for a target written in full. ``binding`` decides whether a consumer may treat
+    ``expression`` as an established fact: see :attr:`grounded_expression`.
     """
 
     expression: Expr
@@ -101,8 +101,8 @@ class GroupTarget:
 
     @property
     def grounded_expression(self) -> Expr:
-        """The reading a consumer may ground a fact from: the resolved expression where SQL's
-        own rules decide the binding, and the written node where they do not.
+        """The reading a consumer may treat as an established fact: the resolved expression
+        where SQL's own rules decide the binding, and the written node where they do not.
 
         Falling back to ``written_at`` on a ``PRESUMED`` binding is the conservative reading, and
         it is the one SQL takes whenever the name really is an input column. Two targets can also
@@ -363,9 +363,9 @@ def fn_of(w: exp.Window) -> Expr | None:
 
 
 def row_number_window(node: Expr) -> exp.Window | None:
-    """``node`` as a ``ROW_NUMBER() OVER (...)`` window, or ``None``. Only ``ROW_NUMBER`` grounds
-    a dedup key: it ranks distinctly within a partition, so ``= 1`` keeps exactly one row, whereas
-    ``RANK`` / ``DENSE_RANK`` share a rank across ties and can keep several."""
+    """``node`` as a ``ROW_NUMBER() OVER (...)`` window, or ``None``. Only ``ROW_NUMBER`` gives a
+    working dedup key: it ranks distinctly within a partition, so ``= 1`` keeps exactly one row,
+    whereas ``RANK`` / ``DENSE_RANK`` share a rank across ties and can keep several."""
     if isinstance(node, exp.Window) and isinstance(node.this, exp.RowNumber):
         return node
     return None
@@ -379,7 +379,8 @@ def rank_one_guard_operand(leaf: Expr) -> Expr | None:
     """The operand a ``= 1`` / ``<= 1`` dedup guard constrains to the top rank, or ``None``.
     Recognises ``X = 1``, ``1 = X``, ``X <= 1`` and ``1 >= X`` with a literal integer ``1`` (a
     row number is ``>= 1``, so ``<= 1`` coincides with ``= 1``). Any other comparison keeps more
-    than the top row and grounds no key. ``X`` is returned unevaluated for the caller to test."""
+    than the top row and yields no usable dedup key. ``X`` is returned unevaluated for the
+    caller to test."""
     if isinstance(leaf, exp.EQ):
         if _is_literal_one(leaf.expression):
             return leaf.this

--- a/src/dblect/sql/aggregates.py
+++ b/src/dblect/sql/aggregates.py
@@ -5,12 +5,13 @@ the propagator's aggregate dispatch already uses, dialect-neutral: bigquery
 ``min_by``/``max_by`` arrive as ``ArgMin``/``ArgMax``, duckdb ``median``/``quantile`` have
 dedicated nodes). They are recorded together rather than in two parallel tables.
 
-**Magnitude (result domain).** What domain the result lives in, which decides the
-currency-coherence obligation (``docs/design/domain-type-algebra.md``):
+**Magnitude (result domain).** What domain the result lives in, which decides whether every
+input must share the same tag (e.g. currency) for the result to be valid (see
+``docs/design/domain-type-algebra.md``):
 
 * **COMBINE** synthesizes a new value out of many (``sum``, ``avg``, a spread, a middle).
-  A per-row companion that varies within the group corrupts the result, so a combining
-  reduction carries the coherence obligation.
+  A per-row companion that varies within the group corrupts the result, so combining rows
+  only makes sense when they all share the same tag.
 * **SELECT** returns one of the input values (``min``, ``max``, ``arg_min``). The value is
   real, so the operation does not fail; only its tag is uncertain, because the comparison
   that chose it was tag-blind. The result widens to top.
@@ -110,7 +111,7 @@ _REGISTRY: Mapping[type[exp.AggFunc], AggregateProfile] = {
     exp.Count: AggregateProfile(AggregateBehavior.COUNT, duplicate_sensitive=True),
     exp.CountIf: AggregateProfile(AggregateBehavior.COUNT, duplicate_sensitive=True),
     exp.ApproxDistinct: AggregateProfile(AggregateBehavior.COUNT, duplicate_sensitive=False),
-    # Non-magnitude folds (no coherence obligation), classified on the multiplicity axis.
+    # Non-magnitude folds (no magnitude obligation), classified on the multiplicity axis.
     # Boolean and bitwise-and/or have an idempotent combine (``x AND x = x``, ``x & x = x``),
     # so they are safe; bitwise xor cancels a duplicated row (``x ^ x = 0``) and collection
     # folds gather every row into a container, so both are sensitive.
@@ -161,13 +162,12 @@ def strips_duplicates(agg: exp.Func) -> bool:
 def duplicate_sensitive(agg: exp.Func, *, safe_builtins: frozenset[str] = frozenset()) -> bool:
     """True if a fan-out that duplicates ``agg``'s input rows would distort its result.
 
-    The duplicate-sensitivity predicate of the hazard algebra. A ``DISTINCT`` on the input
-    removes the duplicates before the fold, so any aggregate becomes safe
-    (``count(distinct x)``). Otherwise the answer is the aggregate type's registry fact;
-    a ``max`` or ``bool_or`` is safe, a ``sum`` or ``array_agg`` is sensitive. An
+    A ``DISTINCT`` on the input removes the duplicates before the fold, so any aggregate
+    becomes safe (``count(distinct x)``). Otherwise the answer is the aggregate type's registry
+    fact; a ``max`` or ``bool_or`` is safe, a ``sum`` or ``array_agg`` is sensitive. An
     ``exp.Anonymous`` UDF has no registry type, so it is sensitive unless the adapter names
-    it in ``safe_builtins`` (case-insensitive): the firewall posture keeps an unknown fold
-    firing rather than clearing a fan-out on a guess."""
+    it in ``safe_builtins`` (case-insensitive): treating an unknown fold as sensitive by
+    default keeps a fan-out finding firing rather than clearing it on a guess."""
     if strips_duplicates(agg):
         return False
     profile = _profile(agg)

--- a/src/dblect/sql/anti_join.py
+++ b/src/dblect/sql/anti_join.py
@@ -11,9 +11,10 @@ cannot fan out. The nullability detector consumes every form, since a NULL probe
 as a spurious non-match rather than dropped, the inverse of an ordinary join's hazard.
 
 The classifier is deliberately oracle-free: it decides each form structurally so any consumer
-can call it without threading the nullability substrate. The one edge that needs nullability,
-a ``LEFT JOIN ... IS NULL`` on a column that is not a join key, is left unrecognised here (see
-:func:`_left_is_null_anti_join`); a consumer that holds the substrate decides it itself.
+can call it without threading the nullability analysis through. The one edge that needs
+nullability, a ``LEFT JOIN ... IS NULL`` on a column that is not a join key, is left
+unrecognised here (see :func:`_left_is_null_anti_join`); a consumer that holds that analysis
+decides it itself.
 """
 
 from __future__ import annotations
@@ -147,8 +148,8 @@ def _left_is_null_anti_join(j: exp.Join, *, leaves: list[Expr], from_alias: str)
     column is one of ``R``'s join-key columns in ``P``. A matched row then has ``l.x = R.col`` so
     ``R.col`` is non-NULL there and the filter drops it, keeping exactly the unmatched rows. The
     equality match proves the column non-NULL, so the recognition needs no nullability oracle. An
-    ``IS NULL`` on a non-key column can leak matched rows and is left for a substrate-backed
-    consumer to decide."""
+    ``IS NULL`` on a non-key column can leak matched rows and is left for a consumer with the
+    nullability analysis to decide."""
     matched_alias = j.this.alias_or_name
     matched_cols = _sides_of(sg.on_of(j)).get(matched_alias, frozenset())
     if not matched_cols:
@@ -219,7 +220,7 @@ def _not_in_anti_join(in_node: exp.In, *, from_alias: str, node: Expr) -> AntiJo
 def single_projected_column(query: Expr) -> tuple[str, str] | None:
     """The ``(relation, column)`` a subquery projects, when it is a single bare column over a
     single bare-table FROM with no joins; else ``None``. The lower-cased column matches the
-    nullability substrate's own column keys."""
+    column-key casing the nullability analysis uses."""
     select = query.this if isinstance(query, exp.Subquery) else query
     if not isinstance(select, exp.Select) or sg.joins_of(select):
         return None

--- a/src/dblect/sql/findings.py
+++ b/src/dblect/sql/findings.py
@@ -2,7 +2,7 @@
 
 A ``Finding`` is a single structural observation about one SQL statement, located
 by a line span. Every detector layer emits these: the structural pattern detectors
-in :mod:`dblect.sql.patterns`, the lineage-grounded detectors under
+in :mod:`dblect.sql.patterns`, and the lineage-based detectors under
 :mod:`dblect.nullability`, :mod:`dblect.uniqueness`, :mod:`dblect.snapshot`, and
 :mod:`dblect.flatten`. ``FindingKind`` is their shared vocabulary, so it lives here
 rather than in any one detector module.
@@ -68,16 +68,14 @@ def suppression_hint(kind: FindingKind | CheckFindingKind) -> str:
 class Finding:
     """A single static-analysis observation about a SQL statement.
 
-    ``line_start`` and ``line_end`` are 1-indexed line numbers in the SQL
-    the detector was given — the model's ``compiled_code``, which dbt
-    renders with refs and macro calls expanded inline. Line numbers
-    correspond to the compiled output; the reporter still surfaces the
+    ``line_start`` and ``line_end`` are 1-indexed line numbers in the SQL the detector was
+    given: the model's ``compiled_code``, which dbt renders with refs and macro calls expanded
+    inline. Line numbers correspond to the compiled output; the reporter still surfaces the
     model's source file path so navigation works as expected.
 
-    A value of ``0`` means we couldn't pin the finding to a line, which
-    happens when the offending AST node has no ``Identifier`` descendants
-    sqlglot stamped with position info. Callers can treat ``0`` as "model
-    scope, line unknown" and report it without a line number.
+    A value of ``0`` means we couldn't pin the finding to a line, which happens when no node
+    in the offending AST subtree carries a line number sqlglot stamped. Callers can treat ``0``
+    as "model scope, line unknown" and report it without a line number.
     """
 
     kind: FindingKind

--- a/src/dblect/sql/guards.py
+++ b/src/dblect/sql/guards.py
@@ -14,12 +14,13 @@ The guards read one fact about the surrounding query: which relation aliases the
 join NULL-pads (``nullable``, from :func:`outer_join_optional_aliases`). A column whose
 qualifier is not among them is drawn from a relation the join keeps present, so it is a
 guaranteed-present value for the fallback rules. An unqualified column carries no alias to
-check, so it is treated as not-guaranteed-present: the firewall posture keeps firing under
-uncertainty rather than clearing on a guess.
+check, so it is treated as not-guaranteed-present: staying uncertain keeps a detector firing
+rather than clearing it on a guess.
 
-The catalog is the evidence side of the broad-net posture (``docs/design/hazard-algebra.md``):
-each guard recognises a proven-safe shape, and an unrecognised shape keeps firing, so an
-incomplete catalog costs a false positive, never a false negative.
+The catalog is the evidence side of dblect's conservative-by-default design (see
+``docs/design/hazard-algebra.md``): each guard recognises a proven-safe shape, and an
+unrecognised shape keeps firing, so an incomplete catalog costs a false positive, never a
+false negative.
 """
 
 from __future__ import annotations

--- a/src/dblect/sql/parse.py
+++ b/src/dblect/sql/parse.py
@@ -4,8 +4,8 @@ A model usually compiles to a single ``SELECT``, but a macro that emits a helper
 inline produces a script: leading ``CREATE [TEMPORARY] FUNCTION`` / ``DECLARE`` /
 ``SET`` statements before the terminal query. `parse_result_statement` keeps the final
 top-level query and drops the prelude. A call to an inline-defined function stays an
-ordinary call, which the propagator reads as a value-erasing transform, so an inline
-UDF degrades to the opaque posture rather than failing the parse.
+ordinary call, which the propagator conservatively treats as a value-erasing transform
+rather than failing the parse.
 
 A script with more than one query, or none, cannot be reduced to a single model, so
 the caller records a resolution-coverage miss instead of guessing. `parse_sql` is the

--- a/src/dblect/sql/patterns.py
+++ b/src/dblect/sql/patterns.py
@@ -808,8 +808,8 @@ def _array_expr_nonempty(
 
     The intrinsic constructors the SQL vocabulary proves from the node alone are the always-on
     local cases: a literal ``ARRAY[...]``, a ``GENERATE_ARRAY`` over literal bounds. For a
-    column, the answer comes from ``column_is_nonempty``, the lineage-grounded predicate the
-    audit supplies; without it, a column is treated as opaque, so the detector module stays
+    column, the answer comes from ``column_is_nonempty``, the predicate the audit's lineage
+    analysis supplies; without it, a column is treated as opaque, so the detector module stays
     free of lineage types.
 
     Non-emptiness is proved where the array is *produced*. A column that arrives through the

--- a/src/dblect/templating.py
+++ b/src/dblect/templating.py
@@ -75,9 +75,10 @@ def make_environment() -> Environment:
 def shared_environment() -> Environment:
     """The dbt-template parsing environment, materialized once on first use.
 
-    Building an environment wires three extensions, and a caller parsing one
-    environment per node otherwise. The environment only ever ``parse``s (it never
-    renders and holds no per-source state), so a single instance serves every walk.
-    Callers that want an isolated environment build one with :func:`make_environment`.
+    Building an environment wires three extensions, and a caller that parses one tree
+    per node would otherwise pay that cost on every node. The environment only ever
+    ``parse``s (it never renders and holds no per-source state), so a single instance
+    serves every walk. Callers that want an isolated environment build one with
+    :func:`make_environment`.
     """
     return make_environment()

--- a/src/dblect/types/__init__.py
+++ b/src/dblect/types/__init__.py
@@ -1,5 +1,5 @@
-"""The dblect declaration layer: domain types, model contracts, and the bridge
-that turns them into substrate facts.
+"""The dblect declaration layer: domain types, model contracts, and the fact
+bridge that turns them into lineage facts.
 
 A project declares meaning here, in Python beside its dbt project: domain types
 built from SQL primitives, bound to models by contracts. The framework reads the

--- a/src/dblect/types/bridge.py
+++ b/src/dblect/types/bridge.py
@@ -1,8 +1,8 @@
-"""The fact bridge: registered contracts become substrate facts and findings.
+"""The fact bridge: registered contracts become lineage facts and findings.
 
 This is the connective tissue between the authoring surface and the lineage
 engine. It resolves every contract's ``dbt_model`` and column references against
-the manifest, then emits the facts the propagation properties ground from:
+the manifest, then emits the facts that seed each property:
 
 * a :class:`~dblect.lineage.properties.domain_type.DomainTag` per typed
   magnitude column, with its unit and nominal companions bound to the columns
@@ -13,8 +13,8 @@ the manifest, then emits the facts the propagation properties ground from:
 * the foreign-key edges the grain analysis reads.
 
 Resolution runs after the whole registry is populated, so a name that does not
-resolve becomes a :class:`ContractIssue` and the remaining contracts still
-ground their facts. The discoverers wrap this for the substrate's
+resolve becomes a :class:`ContractIssue` while the remaining contracts still
+produce their facts. The discoverers wrap this for the lineage engine's
 ``FactDiscoverer`` protocol. See ``docs/design/propagation-soundness.md``.
 """
 
@@ -175,7 +175,7 @@ def _build_tag(
     decl_name: str, spec: DomainSpec, src: SourceRef, known: frozenset[str] | None
 ) -> tuple[BoundTag | None, list[ContractIssue]]:
     """Derive the bound tag for one domain-typed column, or the findings that
-    keep it from grounding.
+    keep it from becoming a fact.
 
     Returns ``(None, [])`` when the type carries no magnitude (nothing to tag,
     and nothing wrong). Validation against a known column set runs only when one
@@ -418,8 +418,8 @@ def _resolve_methods(
     manifest: Manifest,
     out: _Accumulator,
 ) -> None:
-    """Lower each captured ``@contract`` method onto the substrate. A fact becomes
-    its matching ground fact (a dependency, a key, an edge); a predicate is set
+    """Lower each captured ``@contract`` method into what the lineage engine
+    reads: a fact becomes a dependency, a key, or an edge; a predicate is set
     aside for the execution loop. A body that failed at capture is a finding."""
     for method in cspec.methods:
         if method.error is not None:
@@ -550,11 +550,11 @@ def _own_columns(
 ) -> list[str] | None:
     """The column names of ``columns``, all of which must live on the contract's
     own model and (when ``known`` is supplied) name a real column. A reference into
-    another model is a finding, since the dependency and key facts the substrate
-    carries are single-relation; a column absent from ``known`` is an unknown-column
-    finding, matching the declaration path. ``fold`` case-folds the returned names
-    to the dependency property's lowercased column universe; key and grain facts
-    keep the authored case, which is why they pass ``fold=False``."""
+    another model is a finding, since dependency and key facts are single-relation; a
+    column absent from ``known`` is an unknown-column finding, matching the
+    declaration path. ``fold`` case-folds the returned names to the dependency
+    property's lowercased column universe; key and grain facts keep the authored
+    case, which is why they pass ``fold=False``."""
     names: list[str] = []
     for col in columns:
         if col.model is not None:
@@ -712,7 +712,7 @@ class _KeyDiscoverer:
 
 class _FdDiscoverer:
     """Yields the contract-sourced functional-dependency facts (from
-    ``self.a.determines(self.b)`` methods) that ground the FD property."""
+    ``self.a.determines(self.b)`` methods) that the FD property reads."""
 
     def discover(
         self, manifest: Manifest, *, name_to_source: Mapping[str, SourceRef]

--- a/src/dblect/types/contract.py
+++ b/src/dblect/types/contract.py
@@ -10,7 +10,7 @@ Each annotated field becomes one declaration: a domain type (the column carries
 that meaning), a ``PrimaryKey`` / ``ForeignKey`` marker (a key the grain
 analysis reads), or a scalar type. ``Field(...)`` carries the Pydantic-style
 constraint vocabulary and inline fixings at one binding site. Resolution against
-the manifest happens later in the bridge, so a misspelled model is a finding,
+the manifest happens later, in the fact bridge, so a misspelled model is a finding,
 not an ``ImportError`` that blinds the audit. See
 ``docs/design/declaration-dsl.md``.
 """
@@ -60,9 +60,9 @@ _CONSTRAINT_ALIASES: Mapping[str, tuple[str, float]] = {
 
 @dataclass(frozen=True, slots=True)
 class _FieldSpec:
-    """What a ``Field(...)`` call captured: checkable constraints and inline
-    fixings (the vouched-meaning half, applied as a refinement of the column's
-    declared type)."""
+    """What a ``Field(...)`` call captured: checkable constraints (proved against
+    data) and inline fixings (the author's own assertion, applied as a
+    refinement of the column's declared type)."""
 
     constraints: Constraints | None
     fixings: Mapping[str, object]
@@ -123,7 +123,7 @@ class PrimaryKey:
 class ForeignKey:
     """Marker annotation naming another model's column: ``ForeignKey("dim.col")``.
 
-    Doubles as the grain edge the fan-out analysis reads. An existing dbt
+    Doubles as an edge the grain analysis reads. An existing dbt
     ``relationships`` test is read as the same fact, so a project need not
     restate it.
     """

--- a/src/dblect/types/enums.py
+++ b/src/dblect/types/enums.py
@@ -1,4 +1,4 @@
-"""Marker bases that classify a domain type's enum fields by how the substrate
+"""Marker bases that classify a domain type's enum fields by how a domain tag
 carries them.
 
 A :class:`UnitEnum` is a *dimensional* unit (a currency is the worked example),

--- a/src/dblect/types/scalars.py
+++ b/src/dblect/types/scalars.py
@@ -2,7 +2,7 @@
 
 A domain type's field is read by what it *is*, not annotated by hand. The
 classification is the seam between the author's ordinary Python annotations and
-the substrate's tag algebra (``docs/design/domain-type-algebra.md``):
+dblect's tag algebra (``docs/design/domain-type-algebra.md``):
 
 * a numeric :class:`Decimal` (or ``Decimal(p, s)``), a :class:`Count`, or a
   floating-point ``float`` / :class:`Float` is a **magnitude**, the field a tag
@@ -15,9 +15,9 @@ the substrate's tag algebra (``docs/design/domain-type-algebra.md``):
   (``int`` / :class:`Integer` / :class:`BigInt`) carry **no** tag.
 
 A bare integer is the one scalar whose role its algebra does not settle: an
-integer is algebraically a perfect quantity, yet by role it is as often an
+integer is algebraically a quantity, yet by role it is as often an
 identifier or a calendar year, which are tags. The lenient default reads it as
-opaque (inert), making no claim either way; a measure is spelled ``Count`` /
+inert, making no claim either way; a measure is spelled ``Count`` /
 ``Decimal`` and an identifier or year carries its own domain type. A future
 strict mode rejects a bare integer instead, per the lenient/strict switch in
 ``docs/design/domain-type-algebra.md``.
@@ -53,7 +53,7 @@ class FieldDef:
     ``enum`` is set for a unit or nominal enum field; ``pytype`` is set for a
     plain ``bool``/``str`` nominal field; ``precision``/``scale`` carry a
     decimal magnitude's parameters. They pin what a fixing must look like and
-    how the bridge builds the field's tag coordinate.
+    how the fact bridge builds the field's tag coordinate.
     """
 
     name: str
@@ -66,9 +66,9 @@ class FieldDef:
 
 class Decimal:
     """A fixed-point magnitude type, usable bare (``Decimal``) or parameterized
-    (``Decimal(18, 2)``). The parameters annotate precision and scale; the
-    substrate does not yet reason over them, but the contract carries them so a
-    later width check has them to hand."""
+    (``Decimal(18, 2)``). The parameters annotate precision and scale; dblect does
+    not yet reason over them, but the contract carries them so a later width
+    check has them to hand."""
 
     __slots__ = ("precision", "scale")
 

--- a/src/dblect/uniqueness/__init__.py
+++ b/src/dblect/uniqueness/__init__.py
@@ -1,10 +1,10 @@
 """Fact-grounded audit detectors for uniqueness hazards.
 
 The uniqueness *facts* (candidate keys per relation, declared and propagated)
-live on the lineage.facts substrate as ``dblect.lineage.properties.uniqueness``.
-This package is the audit-facing consumer: detectors that read those keys and
-flag window order-key, join-fanout, and non-deterministic ``LIMIT`` hazards on a
-project's SQL.
+are computed in ``dblect.lineage.properties.uniqueness``. This package is the
+audit-facing consumer: detectors that read those keys and flag window
+order-key, join-fanout, and non-deterministic ``LIMIT`` hazards on a project's
+SQL.
 """
 
 from dblect.uniqueness.detector import (

--- a/src/dblect/uniqueness/detector.py
+++ b/src/dblect/uniqueness/detector.py
@@ -18,15 +18,15 @@ to make a claim, and stay silent otherwise):
 * ``detect_cross_model_fanout``: a duplicate-sensitive aggregate that folds a
   magnitude an upstream fan-out replicated, over a relation no longer keyed at the
   magnitude's grain. This one also reads ``where_provenance`` to find the origin a
-  magnitude traces to, the grain ``grain_preserved`` is asked about. A COUNT fold
-  (``COUNT(*)``, ``COUNT(col)``) yields a cardinality, not a magnitude: it counts the
-  relation's rows, whose grain the relation preserves, so it stays silent (the ``SUM(qty)``
-  analog), unlike ``SUM(amount)``.
+  magnitude traces to, then asks ``grain_preserved`` whether that origin's grain
+  still holds. A COUNT fold (``COUNT(*)``, ``COUNT(col)``) yields a cardinality, not
+  a magnitude: it counts the relation's rows, whose grain the relation preserves, so
+  it stays silent (the ``SUM(qty)`` analog), unlike ``SUM(amount)``.
 
-The first two read keys from the lineage.facts uniqueness substrate: per-model keys
-come from cross-model propagation (``uniqueness_property`` over the relation graph),
-and a per-tree scope index (``relation_scope_keys``) supplies the keys of CTE and
-inline-subquery scopes, which are not relations the propagator annotates.
+The first two read keys from two places: cross-model propagation
+(``uniqueness_property`` over the relation graph) supplies per-model keys, and a
+per-tree scope index (``relation_scope_keys``) supplies the keys of CTE and
+inline-subquery scopes, which the propagator does not annotate as relations.
 """
 
 from __future__ import annotations
@@ -160,13 +160,13 @@ def detect_non_unique_aggregate_order_keys(
 
     Only the top-n shape fires: an ordered aggregate with no inner ``LIMIT`` keeps every element,
     so its membership is deterministic regardless of ties (only the internal tie order is
-    unstable, which the unordered-aggregate detector's territory). An aggregate with no
+    unstable, which is the unordered-aggregate detector's territory). An aggregate with no
     ``ORDER BY`` at all is that detector's job too, and stays silent here.
 
     Conservative toward silence, like the window check: single-source scopes only (a join or
     ``UNION`` needs column-level lineage), bare-column order and group keys only (an expression
     needs an equivalence we do not model), and silent when no source key is known (the firewall
-    posture, with no grain to name there is no positive fact to fire on).
+    posture: with no grain to name, there is no positive fact to fire on).
     """
     scopes = _scope_index_for(tree, model_keys, scope_index)
     out: list[Finding] = []
@@ -531,7 +531,7 @@ def make_fact_grounded_detectors(
     fd_facts: tuple[Fact[FDSet, SourceRef], ...] = (),
     fd_by_name: Mapping[str, FDSet] | None = None,
 ) -> tuple[Detector, ...]:
-    """Curry the fact-grounded detectors against substrate-derived keys.
+    """Curry the fact-grounded detectors against the propagated uniqueness keys.
 
     Per-model keys come from one cross-model propagation of the uniqueness
     property over the relation graph; ``parsed`` lets the caller share the audit's
@@ -658,8 +658,8 @@ def detect_cross_model_fanout(
 
     Silent when the FROM is not a single ref'd relation (a join or a CTE/subquery needs
     column-level reasoning kept for later), when the aggregate is duplicate-safe, and when the
-    origin relation has no known key, the firewall posture: with no grain to name there is no
-    positive fact to fire on. Also silent on a COUNT-behavior fold (``COUNT(*)``, ``COUNT(1)``,
+    origin relation has no known key (the firewall posture: with no grain to name, there is
+    no positive fact to fire on). Also silent on a COUNT-behavior fold (``COUNT(*)``, ``COUNT(1)``,
     ``COUNT(col)``, ``COUNT_IF``): it yields a cardinality, not a magnitude, so it counts the
     relation's rows (whose grain the relation preserves) rather than summing a replicated value.
     That makes every COUNT the ``SUM(qty)`` analog (a fold at the genuine, un-replicated grain),

--- a/src/dblect/varinf/__init__.py
+++ b/src/dblect/varinf/__init__.py
@@ -3,8 +3,8 @@ project and infer enough about each to enumerate worlds.
 
 This package is the discovery half of the flag system. The Jinja front end
 (:mod:`dblect.templating`, :mod:`dblect.varinf.walker`) turns a node's source
-Jinja into :class:`~dblect.varinf.usage.VarUsage` records; later streams fold
-those into typed, domain-bearing flags.
+Jinja into :class:`~dblect.varinf.usage.VarUsage` records; a later pass folds
+those into flags with a known type and value domain.
 """
 
 from dblect.varinf.usage import (

--- a/src/dblect/varinf/usage.py
+++ b/src/dblect/varinf/usage.py
@@ -3,8 +3,8 @@
 
 These are the contract between the source-Jinja walker and the inference layer
 that folds usages into a type and a domain. The walker produces them; nothing
-here interprets them. The position is carried as a :data:`UsageContext`, a sum
-of small frozen records (one per syntactic shape) rather than a string tag, so a
+here interprets them. The position is carried as a :data:`UsageContext`, a closed
+set of small frozen records (one per syntactic shape) rather than a string tag, so a
 consumer matches over real variants and the type checker enforces exhaustiveness.
 
 The control-flow versus value-substitution distinction the world enumerator
@@ -187,9 +187,10 @@ class SourceLocation:
 class VarUsage:
     """One ``var()`` / ``env_var()`` reference, with the position it was found in.
 
-    ``macro_trail`` is empty for a direct reference; the macro-following stream
-    fills it with the macros traversed to reach a usage. ``confidence`` carries
-    the walker's certainty (see :class:`Confidence`).
+    ``macro_trail`` is empty for a direct reference; a later pass that follows
+    ``var`` calls through macro bodies fills it with the macros traversed to
+    reach a usage. ``confidence`` carries the walker's certainty (see
+    :class:`Confidence`).
     """
 
     var_name: str

--- a/src/dblect/varinf/walker.py
+++ b/src/dblect/varinf/walker.py
@@ -9,10 +9,10 @@ control-flow versus value-substitution signal the world enumerator depends on is
 read straight off the resulting :data:`UsageContext` variant, with no text
 heuristics.
 
-Direct usage only. A ``var`` reached through a macro is the macro-following
-stream's concern, so a ``var`` passed to another call is recorded as a
-:class:`MacroArg` here and followed there. A body the environment cannot parse
-degrades to one :class:`OpaqueNode` diagnostic rather than raising.
+Direct usage only. A ``var`` reached through a macro is left for a later pass
+that follows ``var`` calls through macro bodies: this walker records it as a
+:class:`MacroArg` rather than following the call. A body the environment
+cannot parse degrades to one :class:`OpaqueNode` diagnostic rather than raising.
 """
 
 from __future__ import annotations
@@ -67,7 +67,8 @@ _COMPARISON_OP_VALUES: frozenset[str] = frozenset(op.value for op in ComparisonO
 
 # How each comparison flips when the literal is written on the left
 # (``100 < var('x')`` is ``var('x') > 100``). Equality is symmetric, so eq/ne map
-# to themselves. Total over ComparisonOp and its own inverse.
+# to themselves. Every ComparisonOp member has an entry here, so the flip lookup
+# never raises.
 _FLIPPED_COMPARISON: dict[ComparisonOp, ComparisonOp] = {
     ComparisonOp.EQ: ComparisonOp.EQ,
     ComparisonOp.NE: ComparisonOp.NE,
@@ -251,7 +252,7 @@ class _Walker:
         Every classified emission funnels through here, so the inline-default walk
         lives in one place: ``var('x', <default>)`` can carry another var whatever
         the outer var's position. The default is walked even when the outer name is
-        dynamic and its own usage skipped, the inner var being real either way.
+        dynamic and its own usage is skipped, because the inner var is real either way.
         """
         name = _string_arg0(call)
         if name is not None:


### PR DESCRIPTION
## What this does

Replaces #233 with the corrected calibration validated on #236. #233 was
never merged, so this is a first, direct pass on the untouched original
prose in these 10 package areas, not a re-pass on top of #233's content.

## Why not just merge #233

#233 used the same instructions as the discarded over-corrected pilot that
got fixed on #236 -- worked examples, extra paragraphs, reader-oriented
headers. It wasn't as bloated as that pilot, but it wasn't calibrated to
the actual bar either. Rather than merge something known-suboptimal and
trim it in a follow-up, this replaces it directly with the corrected pass.

## The result

Jargon replaced by what it means inline, same length or shorter, no new
examples, no restructuring. Net change across the 10 areas (44 files):
**-9 lines** (232 insertions, 241 deletions) -- shorter than the untouched
original, not just no longer padded.

## A few of these surfaced more than wording

- `adapters/__init__.py` claimed only DuckDB is validated; `bigquery.py`
  has had `validated=True` since PR #165. Pointed at `validated_adapters()`
  instead of a claim that can go stale again.
- `sql/findings.py`'s line-0 explanation named "no `Identifier`
  descendants" as the cause, but `_sqlglot.line_range` was changed to walk
  all descendants (its own docstring explains why). Corrected.
- `audit/__init__.py` named "replay-determinism" and "heuristic invariants"
  as built package components; neither exists. `manifest/dag.py` and
  `manifest/parse.py` had the same pattern for "change-impact" analysis and
  "macro-following" -- both confirmed future work, not built.
- `audit/suppress.py` explained the same `located_span`/`compiled_span`
  framing three times in one file; cut two of the three.
- `contracts/decorator.py`'s "model contract's metaclass" claim (the real
  mechanism is `__init_subclass__`) is confirmed fixed on this pass too.

## Test plan

- [x] `ruff check`
- [x] `ruff format --check`
- [x] `pyright`
- [x] `pytest` (full suite, 1584 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAE4C5m7unT2uPjd1XthjN