### PR TITLE
feat(lineage): declared dependencies survive UNION merges via grounding identity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "sqlglot>=25.0",
+    "sqlglot>=30.0",
     "jinja2>=3.1",
     "typer>=0.12",
     "pyyaml>=6.0",

--- a/src/dblect/check/worlds.py
+++ b/src/dblect/check/worlds.py
@@ -36,10 +36,18 @@ from dblect.check.run import (
     suppress_check_findings,
     world_findings,
 )
-from dblect.lineage.facts.model import Fact, WorldRef
+from dblect.lineage.facts.model import CompileValue, Fact, Provenance, WorldRef
 from dblect.lineage.graph import ColumnRef, SourceRef
 from dblect.lineage.properties.domain_type import DomainTag
 from dblect.lineage.properties.functional_dependency import FDSet
+
+
+def _require_compile_value(provenance: Provenance) -> None:
+    """A compile fact carries only a toolchain-minted value. Any other provenance
+    routed through this seam would be re-grounded as if declared; for FDs that
+    would lift a flag-pinned value into a world axiom that survives unions."""
+    if not isinstance(provenance, CompileValue):
+        raise ValueError(f"a compile fact requires CompileValue provenance, got {provenance}")
 
 
 @dataclass(frozen=True, slots=True)
@@ -49,6 +57,9 @@ class TagCompileFact:
 
     fact: Fact[DomainTag, ColumnRef]
 
+    def __post_init__(self) -> None:
+        _require_compile_value(self.fact.provenance)
+
 
 @dataclass(frozen=True, slots=True)
 class FdCompileFact:
@@ -56,6 +67,9 @@ class FdCompileFact:
     value pins the key to in that world."""
 
     fact: Fact[FDSet, SourceRef]
+
+    def __post_init__(self) -> None:
+        _require_compile_value(self.fact.provenance)
 
 
 # A per-world fact, tagged by the property it grounds so the enumerator routes it

--- a/src/dblect/lineage/properties/__init__.py
+++ b/src/dblect/lineage/properties/__init__.py
@@ -32,6 +32,7 @@ from dblect.lineage.properties.domain_type import (
 )
 from dblect.lineage.properties.functional_dependency import (
     FD,
+    DeclaredFD,
     FDSet,
     determines,
     functional_dependency_grounding,
@@ -59,6 +60,7 @@ __all__ = [
     "ArrayNonEmpty",
     "CandidateKeySet",
     "Concrete",
+    "DeclaredFD",
     "Dimension",
     "DomainTag",
     "FDSet",

--- a/src/dblect/lineage/properties/functional_dependency.py
+++ b/src/dblect/lineage/properties/functional_dependency.py
@@ -82,16 +82,52 @@ class DeclaredFD:
     """A declared dependency's live instance in one relation.
 
     ``origin`` and ``declared`` name the axiom: the relation the dependency was
-    declared about, and the dependency in that relation's column names. ``fd`` is
-    the same dependency under the current relation's output names, renamed as the
-    walk climbs. All three fields key the match at a union merge: origin alone is
-    not enough (one relation can declare two dependencies that arms rename onto
-    the same output columns), and the axiom alone is not either (an arm can cross
-    the declared columns, running the instance the other way)."""
+    declared about, and the dependency in that relation's column names.
+    ``binding`` maps each declared column to the output column now carrying its
+    value, one pair per declared column, maintained as the walk climbs. The
+    per-column form is what a union merge compares: origin alone is not enough
+    (one relation can declare two dependencies that arms rename onto the same
+    output columns), and a renamed dependency is not either, because it forgets
+    which declared column feeds which output, so arms crossing the columns of a
+    multi-column determinant would look identical while running the axiom two
+    different ways."""
 
     origin: SourceRef
     declared: FD
-    fd: FD
+    binding: frozenset[tuple[str, str]]
+
+    def __post_init__(self) -> None:
+        cols = self.declared.determinant | {self.declared.dependent}
+        if frozenset(c for c, _ in self.binding) != cols or len(self.binding) != len(cols):
+            raise ValueError(f"binding must map exactly the declared columns {sorted(cols)}")
+
+    @staticmethod
+    def identity(origin: SourceRef, declared: FD) -> DeclaredFD:
+        """The instance at its declaring relation: every column bound to itself."""
+        cols = declared.determinant | {declared.dependent}
+        return DeclaredFD(origin, declared, frozenset((c, c) for c in cols))
+
+    @property
+    def fd(self) -> FD:
+        """The dependency under the current relation's output names."""
+        current = dict(self.binding)
+        return FD(
+            frozenset(current[c] for c in self.declared.determinant),
+            current[self.declared.dependent],
+        )
+
+    def renamed(self, lookup: Callable[[str], tuple[str, ...] | None]) -> DeclaredFD | None:
+        """The instance carried through a projection: each bound column renamed to
+        one of the output names ``lookup`` gives it, or ``None`` when a column does
+        not survive. One output name per column suffices (copies of a column carry
+        equal values), picked stably."""
+        bound: set[tuple[str, str]] = set()
+        for declared_col, current in self.binding:
+            names = lookup(current)
+            if not names:
+                return None
+            bound.add((declared_col, min(names)))
+        return replace(self, binding=frozenset(bound))
 
 
 @dataclass(frozen=True, slots=True)
@@ -214,7 +250,7 @@ def _lift_declared(fact: Fact[FDSet, SourceRef]) -> Fact[FDSet, SourceRef]:
         case Declared():
             if fact.value.is_bottom:
                 return fact
-            instances = frozenset(DeclaredFD(fact.scope, fd, fd) for fd in fact.value.fds)
+            instances = frozenset(DeclaredFD.identity(fact.scope, fd) for fd in fact.value.fds)
             return replace(fact, value=FDSet(fact.value.fds, fact.value.declared | instances))
         case NativeConstraint() | CompileValue():
             return fact
@@ -302,15 +338,7 @@ class _FdWalk:
         return NO_FDS
 
     def _with_scope(self, node: Expr, cte_scope: Mapping[str, FDSet]) -> dict[str, FDSet]:
-        """``cte_scope`` extended with the CTEs ``node`` declares, each resolved in
-        the scope the ones before it built."""
-        local = dict(cte_scope)
-        with_ = node.args.get("with_")
-        if isinstance(with_, exp.With):
-            for cte in with_.expressions:
-                if isinstance(cte, exp.CTE) and isinstance(cte.this, Expr):
-                    local[cte.alias_or_name] = self.scope_fds(cte.this, cte_scope=local)
-        return local
+        return sg.with_scope(node, cte_scope, lambda n, s: self.scope_fds(n, cte_scope=s))
 
     def _union(self, u: exp.Union, *, cte_scope: Mapping[str, FDSet]) -> FDSet:
         """The union merge: keep exactly the declared instances every arm shares.
@@ -318,27 +346,32 @@ class _FdWalk:
         A union adds the cross pairs, one row from each arm, so survival is a
         coverage question. Every derived dependency's witness is arm-local and
         dies. A declared instance carried by every arm from one declaration, with
-        the same current columns once the arms are lined up by position under the
+        the same column binding once the arms are lined up by position under the
         first arm's names (as SQL merges them), draws every merged row's pair from
         that one world, so the cross pairs are covered and the instance survives
-        whole. UNION and UNION ALL merge alike (the dedup only removes rows). An
-        arm without positionally nameable outputs (a star, a duplicated name, not
-        a plain SELECT) leaves nothing to line up."""
-        local = self._with_scope(u, cte_scope)
-        arms = _union_arms(u)
-        carried = [self.scope_fds(arm, cte_scope=local) for arm in arms]
+        whole. UNION and UNION ALL merge alike (the dedup only removes rows). A
+        merge by name, or an arm without positionally nameable outputs (a star, a
+        duplicated name, not a plain SELECT), leaves nothing to line up. The arms'
+        names are checked before any arm is walked, and the walk stops at the
+        first empty intersection, so a merge that cannot keep anything skips the
+        recursion it would not use."""
+        arms = sg.union_arms(u)
+        if arms is None:
+            return NO_FDS
         names = [_positional_outputs(arm) for arm in arms]
         first = names[0] if names else None
         if first is None or any(n is None or len(n) != len(first) for n in names):
             return NO_FDS
+        local = self._with_scope(u, cte_scope)
         shared: frozenset[DeclaredFD] | None = None
-        for arm_names, arm_value in zip(names, carried, strict=True):
+        for arm_names, arm in zip(names, arms, strict=True):
             assert arm_names is not None
             rename = {src: (dst,) for src, dst in zip(arm_names, first, strict=True)}
-            aligned = _remap_declared(arm_value.declared, rename)
+            aligned = _remap_declared(self.scope_fds(arm, cte_scope=local).declared, rename)
             shared = aligned if shared is None else shared & aligned
-        if not shared:
-            return NO_FDS
+            if not shared:
+                return NO_FDS
+        assert shared is not None
         return FDSet(frozenset(inst.fd for inst in shared), shared)
 
     def _select(self, sel: exp.Select, *, cte_scope: Mapping[str, FDSet]) -> FDSet:
@@ -384,13 +417,10 @@ class _FdWalk:
             # Grouping aggregates everything outside the group key away, so only a
             # dependency lying entirely within it still describes the output rows.
             # The group rows' pairs are a subset of the input's, so an instance
-            # inside the key keeps its grounding.
+            # inside the key keeps its grounding: one survival rule, applied to the
+            # plain set and then read back for the instances.
             carried = _within(carried, group_names)
-            declared = frozenset(
-                inst
-                for inst in declared
-                if inst.fd.determinant | {inst.fd.dependent} <= group_names
-            )
+            declared = frozenset(inst for inst in declared if inst.fd in carried)
 
         out = carried if star else _remap(carried, rename)
         out_declared = declared if star else _remap_declared(declared, rename)
@@ -471,21 +501,21 @@ class _FdWalk:
                 padded.add(aliases[i])
                 padded.update(aliases[:i])
 
+        qrename, star = _qualified_rename(sel)
+        if star:
+            return NO_FDS  # a star over a join leaves the output universe ambiguous
+
         qfds: set[tuple[frozenset[_QCol], _QCol]] = set()
-        qdeclared: list[tuple[DeclaredFD, frozenset[_QCol], _QCol]] = []
+        declared_out: set[DeclaredFD] = set()
         for alias, base in sources:
             if alias in padded:
                 continue
             for fd in base.value.fds:
                 qfds.add((frozenset((alias, d) for d in fd.determinant), (alias, fd.dependent)))
-            qdeclared.extend(
-                (
-                    inst,
-                    frozenset((alias, d) for d in inst.fd.determinant),
-                    (alias, inst.fd.dependent),
-                )
-                for inst in base.value.declared
-            )
+            for inst in base.value.declared:
+                carried = inst.renamed(lambda cur, alias=alias: qrename.get((alias, cur)))
+                if carried is not None:
+                    declared_out.add(carried)
         for j in joins:
             if sg.join_side_of(j) is not sg.JoinSide.INNER:
                 continue
@@ -505,14 +535,6 @@ class _FdWalk:
                 if qc is not None:
                     qfds.add((frozenset(), qc))
 
-        qrename, star = _qualified_rename(sel)
-        if star:
-            return NO_FDS  # a star over a join leaves the output universe ambiguous
-        declared_out: set[DeclaredFD] = set()
-        for inst, det, dep in qdeclared:
-            fd = _project_one(det, dep, qrename)
-            if fd is not None:
-                declared_out.add(replace(inst, fd=fd))
         return FDSet(_project_qualified(qfds, qrename), frozenset(declared_out))
 
 
@@ -532,20 +554,6 @@ def _group_columns(sel: exp.Select) -> frozenset[str] | None:
             return None
         out.add(sg.column_name(g).lower())
     return frozenset(out)
-
-
-def _union_arms(u: exp.Union) -> list[Expr]:
-    """The arms of ``u`` in order, a chain of unions (left-nested by the parser)
-    flattened so an instance shared by every arm survives the whole chain in one
-    pass. Mixing UNION and UNION ALL is fine: the merged rows are drawn from the
-    arms' rows either way."""
-    arms: list[Expr] = []
-    for side in (u.this, u.expression):
-        if isinstance(side, exp.Union):
-            arms.extend(_union_arms(side))
-        elif isinstance(side, Expr):
-            arms.append(side)
-    return arms
 
 
 def _positional_outputs(arm: Expr) -> tuple[str, ...] | None:
@@ -585,15 +593,12 @@ def _remap(fds: frozenset[FD], rename: Mapping[str, tuple[str, ...]]) -> frozens
 def _remap_declared(
     instances: frozenset[DeclaredFD], rename: Mapping[str, tuple[str, ...]]
 ) -> frozenset[DeclaredFD]:
-    """Rename each instance's current dependency by the same rules as
+    """Rename each instance's binding by the same survival rules as
     :func:`_remap`, keeping its grounding; an instance whose columns do not all
     survive drops with them."""
-    out: set[DeclaredFD] = set()
-    for inst in instances:
-        fd = _remap_one(inst.fd, rename)
-        if fd is not None:
-            out.add(replace(inst, fd=fd))
-    return frozenset(out)
+    return frozenset(
+        carried for inst in instances if (carried := inst.renamed(rename.get)) is not None
+    )
 
 
 def _remap_one(fd: FD, rename: Mapping[str, tuple[str, ...]]) -> FD | None:

--- a/src/dblect/lineage/properties/functional_dependency.py
+++ b/src/dblect/lineage/properties/functional_dependency.py
@@ -22,22 +22,41 @@ grouped result). A candidate key read from the uniqueness property determines
 every column selected alongside it, since a relation unique on ``K`` admits one
 row per ``K`` value. And a join carries each kept side's dependencies (qualified
 by source alias) plus an inner join's ``ON`` equalities as mutual determinations.
-Posture elsewhere is silent-when-unproven: an outer join's NULL-padded side and
-two UNION arms that can each satisfy a dependency their union violates both prove
-nothing.
+
+A declared dependency is more than a relation fact: it is an axiom about the
+declaring relation's world (``order_id determines user_id`` because one order
+cannot belong to two users), so it travels as a grounded instance
+(:class:`DeclaredFD`) beside the plain set. The distinction pays at a UNION. A
+dependency is universally quantified over row pairs, and a union adds exactly the
+cross pairs, one row from each arm; a derived dependency's witness is arm-local
+(two arms can each pin a column to a different constant), so every derived
+dependency dies at the merge, while an instance that every arm carries from one
+declaration covers the cross pairs too and survives with its grounding. Posture
+elsewhere is silent-when-unproven: an outer join's NULL-padded side proves
+nothing, and INTERSECT and EXCEPT claim nothing (each keeps a subset of one arm's
+rows, which cannot break a dependency, so carrying the covering arm is a possible
+refinement).
 """
 
 from __future__ import annotations
 
 from collections.abc import Callable, Collection, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
+from typing import assert_never
 
 import sqlglot.expressions as exp
 from sqlglot import Expr
 
 from dblect.lineage.facts.grounding import grounded_scopes, grounding
 from dblect.lineage.facts.lattice import Lattice
-from dblect.lineage.facts.model import Annotation, Fact, Opacity
+from dblect.lineage.facts.model import (
+    Annotation,
+    CompileValue,
+    Declared,
+    Fact,
+    NativeConstraint,
+    Opacity,
+)
 from dblect.lineage.facts.property import DepContext, Property, PropertyRef, relation_property
 from dblect.lineage.graph import SourceRef, source_ref_meta
 from dblect.lineage.properties.predicate_flow import explicit_rename, has_star
@@ -59,19 +78,45 @@ class FD:
 
 
 @dataclass(frozen=True, slots=True)
+class DeclaredFD:
+    """A declared dependency's live instance in one relation.
+
+    ``origin`` and ``declared`` name the axiom: the relation the dependency was
+    declared about, and the dependency in that relation's column names. ``fd`` is
+    the same dependency under the current relation's output names, renamed as the
+    walk climbs. All three fields key the match at a union merge: origin alone is
+    not enough (one relation can declare two dependencies that arms rename onto
+    the same output columns), and the axiom alone is not either (an arm can cross
+    the declared columns, running the instance the other way)."""
+
+    origin: SourceRef
+    declared: FD
+    fd: FD
+
+
+@dataclass(frozen=True, slots=True)
 class FDSet:
     """The dependencies a relation is known to satisfy.
 
-    ``fds`` holds the known dependencies; the empty set is the lattice ``top``
-    ("no dependency known"). ``is_bottom`` marks the formal universal element (the
-    lattice ``bottom``): it absorbs under ``meet`` and is the identity under
-    ``join``, and no resolution of real declarations reaches it, since dependency
-    claims only ever union. Equality is structural, so ``FDSet(frozenset())``
-    (top) and the bottom sentinel are distinct values.
+    ``fds`` holds every known dependency; the empty set is the lattice ``top``
+    ("no dependency known"). ``declared`` holds the grounded instances among them,
+    each still tied to its declaration; every instance's current dependency is in
+    ``fds`` (enforced at construction), so a consumer reading ``fds`` alone sees
+    everything. ``is_bottom`` marks the formal universal element (the lattice
+    ``bottom``): it absorbs under ``meet`` and is the identity under ``join``, and
+    no resolution of real declarations reaches it, since dependency claims only
+    ever union. Equality is structural, so ``FDSet(frozenset())`` (top) and the
+    bottom sentinel are distinct values.
     """
 
     fds: frozenset[FD]
+    declared: frozenset[DeclaredFD] = frozenset()
     is_bottom: bool = False
+
+    def __post_init__(self) -> None:
+        missing = {inst.fd for inst in self.declared} - self.fds
+        if missing:
+            raise ValueError(f"declared instances name dependencies outside fds: {missing}")
 
     @staticmethod
     def of(*fds: FD) -> FDSet:
@@ -88,19 +133,22 @@ ALL_FDS: FDSet = FDSet(frozenset(), is_bottom=True)
 
 
 def _meet(a: FDSet, b: FDSet) -> FDSet:
-    """Most precise value consistent with both: the union of the dependencies."""
+    """Most precise value consistent with both: the union of the dependencies,
+    grounded instances included."""
     if a.is_bottom or b.is_bottom:
         return ALL_FDS
-    return FDSet(a.fds | b.fds)
+    return FDSet(a.fds | b.fds, a.declared | b.declared)
 
 
 def _join(a: FDSet, b: FDSet) -> FDSet:
-    """Least precise value both refine: the dependencies both sides carry."""
+    """Least precise value both refine: the dependencies both sides carry. An
+    instance survives only whole (same grounding, same current columns), so the
+    same dependency grounded at two different origins keeps neither instance."""
     if a.is_bottom:
         return b
     if b.is_bottom:
         return a
-    return FDSet(a.fds & b.fds)
+    return FDSet(a.fds & b.fds, a.declared & b.declared)
 
 
 FUNCTIONAL_DEPENDENCY_LATTICE: Lattice[FDSet] = Lattice(
@@ -154,15 +202,41 @@ def minimal_cover(value: FDSet, cols: frozenset[str]) -> frozenset[str]:
 # --- grounding -----------------------------------------------------------------
 
 
+def _lift_declared(fact: Fact[FDSet, SourceRef]) -> Fact[FDSet, SourceRef]:
+    """Ground a declaration's dependencies as instances carrying its identity.
+
+    A declaration is a person's axiom about the scope's world, so each of its
+    dependencies becomes a :class:`DeclaredFD` at that scope. The provenance space
+    is closed and each kind is decided explicitly: a native constraint holds by
+    the warehouse's write path and a compile value is minted by the toolchain, so
+    neither claims a world and neither grounds an instance."""
+    match fact.provenance:
+        case Declared():
+            if fact.value.is_bottom:
+                return fact
+            instances = frozenset(DeclaredFD(fact.scope, fd, fd) for fd in fact.value.fds)
+            return replace(fact, value=FDSet(fact.value.fds, fact.value.declared | instances))
+        case NativeConstraint() | CompileValue():
+            return fact
+    assert_never(fact.provenance)
+
+
+def _lifted(
+    facts: Mapping[SourceRef, tuple[Fact[FDSet, SourceRef], ...]],
+) -> Mapping[SourceRef, tuple[Fact[FDSet, SourceRef], ...]]:
+    return {scope: tuple(_lift_declared(f) for f in bucket) for scope, bucket in facts.items()}
+
+
 def functional_dependency_grounding(
     facts: Mapping[SourceRef, tuple[Fact[FDSet, SourceRef], ...]],
     *,
     opaque: Collection[SourceRef] = (),
 ) -> Callable[[SourceRef], Annotation[FDSet]]:
     """Fold the per-relation dependency facts into grounded annotations. The same
-    fold every property uses: an opt-out grounds EXPLICIT top, a resolved bucket
-    grounds its value CONCRETE, everything else the IMPLICIT-top default."""
-    return grounding(facts, opaque, FUNCTIONAL_DEPENDENCY_LATTICE)
+    fold every property uses (an opt-out grounds EXPLICIT top, a resolved bucket
+    grounds its value CONCRETE, everything else the IMPLICIT-top default), over
+    facts whose declarations are first lifted into grounded instances."""
+    return grounding(_lifted(facts), opaque, FUNCTIONAL_DEPENDENCY_LATTICE)
 
 
 def functional_dependency_grounded_scopes(
@@ -172,7 +246,7 @@ def functional_dependency_grounded_scopes(
 ) -> set[SourceRef]:
     """The relations a dependency fact grounded, for coverage. Reads the same fold
     ``functional_dependency_grounding`` does."""
-    return grounded_scopes(facts, opaque, FUNCTIONAL_DEPENDENCY_LATTICE)
+    return grounded_scopes(_lifted(facts), opaque, FUNCTIONAL_DEPENDENCY_LATTICE)
 
 
 # --- the relation reducer --------------------------------------------------------
@@ -180,19 +254,21 @@ def functional_dependency_grounded_scopes(
 # The relation-algebra walk for dependencies, the same shape as the predicate-flow
 # walk: single-source scopes carry, rename through the projection, and every shape
 # outside the modelled fragment drops to the empty set rather than over-claiming.
+# The walk's value is an FDSet whose declared instances ride along under exactly
+# the same renames and cuts as the plain dependencies, so the two can never drift.
 
 
 @dataclass(frozen=True, slots=True)
 class _Base:
-    """What a resolved FROM source contributes: its dependencies (in its output
-    column names) and, for a base table with the uniqueness edge live, its
+    """What a resolved FROM source contributes: its dependency value (in its
+    output column names) and, for a base table with the uniqueness edge live, its
     candidate keys (each of which determines the columns read alongside it)."""
 
-    fds: frozenset[FD]
+    value: FDSet
     keys: frozenset[Key] = frozenset()
 
 
-_NOTHING: _Base = _Base(frozenset())
+_NOTHING: _Base = _Base(NO_FDS)
 
 # Resolves a base (non-CTE) table reference to what it contributes. The reducer's
 # implementation recurses through the shared propagator via the table's stamped
@@ -205,37 +281,80 @@ class _FdWalk:
 
     ``base_resolve`` resolves a base table; CTEs and inline subqueries are
     resolved structurally within the walk. Single-source scopes carry fully; a
-    join carries its kept sides (see :meth:`_join_select`); a UNION proves
-    nothing, and an unmodellable group shape (positional or computed group keys)
-    drops the scope's dependencies entirely.
+    join carries its kept sides (see :meth:`_join_select`); a UNION keeps the
+    declared instances every arm shares and nothing else (see :meth:`_union`);
+    and an unmodellable group shape (positional or computed group keys) drops the
+    scope's dependencies entirely.
     """
 
     def __init__(self, base_resolve: _BaseResolve) -> None:
         self._base_resolve = base_resolve
 
-    def scope_fds(self, node: Expr, *, cte_scope: Mapping[str, frozenset[FD]]) -> frozenset[FD]:
+    def scope_fds(self, node: Expr, *, cte_scope: Mapping[str, FDSet]) -> FDSet:
         if isinstance(node, exp.Select):
             return self._select(node, cte_scope=cte_scope)
-        return frozenset()
+        if isinstance(node, exp.Union):
+            return self._union(node, cte_scope=cte_scope)
+        # INTERSECT and EXCEPT keep a subset of one arm's rows, which cannot break
+        # a dependency; they still claim nothing (carrying the covering arm is a
+        # possible refinement, not the current contract), and so does every other
+        # unmodelled shape.
+        return NO_FDS
 
-    def _select(self, sel: exp.Select, *, cte_scope: Mapping[str, frozenset[FD]]) -> frozenset[FD]:
+    def _with_scope(self, node: Expr, cte_scope: Mapping[str, FDSet]) -> dict[str, FDSet]:
+        """``cte_scope`` extended with the CTEs ``node`` declares, each resolved in
+        the scope the ones before it built."""
         local = dict(cte_scope)
-        with_ = sel.args.get("with_")
+        with_ = node.args.get("with_")
         if isinstance(with_, exp.With):
             for cte in with_.expressions:
                 if isinstance(cte, exp.CTE) and isinstance(cte.this, Expr):
                     local[cte.alias_or_name] = self.scope_fds(cte.this, cte_scope=local)
+        return local
+
+    def _union(self, u: exp.Union, *, cte_scope: Mapping[str, FDSet]) -> FDSet:
+        """The union merge: keep exactly the declared instances every arm shares.
+
+        A union adds the cross pairs, one row from each arm, so survival is a
+        coverage question. Every derived dependency's witness is arm-local and
+        dies. A declared instance carried by every arm from one declaration, with
+        the same current columns once the arms are lined up by position under the
+        first arm's names (as SQL merges them), draws every merged row's pair from
+        that one world, so the cross pairs are covered and the instance survives
+        whole. UNION and UNION ALL merge alike (the dedup only removes rows). An
+        arm without positionally nameable outputs (a star, a duplicated name, not
+        a plain SELECT) leaves nothing to line up."""
+        local = self._with_scope(u, cte_scope)
+        arms = _union_arms(u)
+        carried = [self.scope_fds(arm, cte_scope=local) for arm in arms]
+        names = [_positional_outputs(arm) for arm in arms]
+        first = names[0] if names else None
+        if first is None or any(n is None or len(n) != len(first) for n in names):
+            return NO_FDS
+        shared: frozenset[DeclaredFD] | None = None
+        for arm_names, arm_value in zip(names, carried, strict=True):
+            assert arm_names is not None
+            rename = {src: (dst,) for src, dst in zip(arm_names, first, strict=True)}
+            aligned = _remap_declared(arm_value.declared, rename)
+            shared = aligned if shared is None else shared & aligned
+        if not shared:
+            return NO_FDS
+        return FDSet(frozenset(inst.fd for inst in shared), shared)
+
+    def _select(self, sel: exp.Select, *, cte_scope: Mapping[str, FDSet]) -> FDSet:
+        local = self._with_scope(sel, cte_scope)
 
         from_ = sg.from_of(sel)
         if from_ is None or not isinstance(from_.this, Expr):
-            return frozenset()
+            return NO_FDS
         joins = sg.joins_of(sel)
         if joins:
             return self._join_select(sel, from_.this, joins, cte_scope=local)
         base = self._resolve_source(from_.this, cte_scope=local)
         if base is None:
-            return frozenset()
-        carried = base.fds
+            return NO_FDS
+        carried = base.value.fds
+        declared = base.value.declared
 
         # A dependency is universally quantified over row pairs, and a WHERE only
         # removes pairs, so everything carries; an equality filter additionally pins
@@ -261,14 +380,20 @@ class _FdWalk:
         if group is not None and group.expressions:
             group_names = _group_columns(sel)
             if group_names is None:
-                return frozenset()  # unmodellable group shape: prove nothing
+                return NO_FDS  # unmodellable group shape: prove nothing
             # Grouping aggregates everything outside the group key away, so only a
             # dependency lying entirely within it still describes the output rows.
-            carried = frozenset(
-                fd for fd in carried if fd.determinant | {fd.dependent} <= group_names
+            # The group rows' pairs are a subset of the input's, so an instance
+            # inside the key keeps its grounding.
+            carried = _within(carried, group_names)
+            declared = frozenset(
+                inst
+                for inst in declared
+                if inst.fd.determinant | {inst.fd.dependent} <= group_names
             )
 
         out = carried if star else _remap(carried, rename)
+        out_declared = declared if star else _remap_declared(declared, rename)
         if group_names is not None:
             group_out = group_names if star else _remap_columns(group_names, rename)
             if group_out is not None:
@@ -277,11 +402,9 @@ class _FdWalk:
                 out = out | {
                     FD(group_out, name) for name in _named_outputs(sel) if name not in group_out
                 }
-        return out
+        return FDSet(out, out_declared)
 
-    def _resolve_source(
-        self, node: Expr, *, cte_scope: Mapping[str, frozenset[FD]]
-    ) -> _Base | None:
+    def _resolve_source(self, node: Expr, *, cte_scope: Mapping[str, FDSet]) -> _Base | None:
         if isinstance(node, exp.Table):
             if node.name in cte_scope:
                 return _Base(cte_scope[node.name])
@@ -299,8 +422,8 @@ class _FdWalk:
         from_node: Expr,
         joins: list[exp.Join],
         *,
-        cte_scope: Mapping[str, frozenset[FD]],
-    ) -> frozenset[FD]:
+        cte_scope: Mapping[str, FDSet],
+    ) -> FDSet:
         """Dependencies a join carries to the projection.
 
         An FD that holds on a joined relation holds on the join wherever that side's
@@ -308,9 +431,11 @@ class _FdWalk:
         from that relation's rows agreeing on it, and a join only filters or duplicates
         such rows (a duplicate still agrees on the dependent). So each kept side's
         dependencies carry, an inner join's ``ON`` equalities add a mutual determination
-        between the joined columns, and an equality filter pins its column. Everything
-        is tracked qualified by source alias (a join can expose two ``country``
-        columns), then projected onto the output names.
+        between the joined columns, and an equality filter pins its column. A kept
+        side's declared instances carry the same way, since its pairs are still the
+        declared world's pairs, at worst duplicated. Everything is tracked qualified
+        by source alias (a join can expose two ``country`` columns), then projected
+        onto the output names.
 
         Padding is what breaks an FD: an outer join fills its optional side with NULL
         on unmatched rows, so a padded side's dependencies are dropped (until the NULL
@@ -323,15 +448,15 @@ class _FdWalk:
         join (sound to omit; the key path stays single-source for now)."""
         group = sg.group_of(sel)
         if group is not None and group.expressions:
-            return frozenset()
+            return NO_FDS
 
         sources: list[tuple[str, _Base]] = []
         for node in (from_node, *(j.this for j in joins)):
             if not isinstance(node, Expr):
-                return frozenset()
+                return NO_FDS
             base = self._resolve_source(node, cte_scope=cte_scope)
             if base is None:
-                return frozenset()
+                return NO_FDS
             sources.append((node.alias_or_name.lower(), base))
 
         aliases = [alias for alias, _ in sources]
@@ -347,11 +472,20 @@ class _FdWalk:
                 padded.update(aliases[:i])
 
         qfds: set[tuple[frozenset[_QCol], _QCol]] = set()
+        qdeclared: list[tuple[DeclaredFD, frozenset[_QCol], _QCol]] = []
         for alias, base in sources:
             if alias in padded:
                 continue
-            for fd in base.fds:
+            for fd in base.value.fds:
                 qfds.add((frozenset((alias, d) for d in fd.determinant), (alias, fd.dependent)))
+            qdeclared.extend(
+                (
+                    inst,
+                    frozenset((alias, d) for d in inst.fd.determinant),
+                    (alias, inst.fd.dependent),
+                )
+                for inst in base.value.declared
+            )
         for j in joins:
             if sg.join_side_of(j) is not sg.JoinSide.INNER:
                 continue
@@ -373,8 +507,13 @@ class _FdWalk:
 
         qrename, star = _qualified_rename(sel)
         if star:
-            return frozenset()  # a star over a join leaves the output universe ambiguous
-        return _project_qualified(qfds, qrename)
+            return NO_FDS  # a star over a join leaves the output universe ambiguous
+        declared_out: set[DeclaredFD] = set()
+        for inst, det, dep in qdeclared:
+            fd = _project_one(det, dep, qrename)
+            if fd is not None:
+                declared_out.add(replace(inst, fd=fd))
+        return FDSet(_project_qualified(qfds, qrename), frozenset(declared_out))
 
 
 def _group_columns(sel: exp.Select) -> frozenset[str] | None:
@@ -395,18 +534,77 @@ def _group_columns(sel: exp.Select) -> frozenset[str] | None:
     return frozenset(out)
 
 
+def _union_arms(u: exp.Union) -> list[Expr]:
+    """The arms of ``u`` in order, a chain of unions (left-nested by the parser)
+    flattened so an instance shared by every arm survives the whole chain in one
+    pass. Mixing UNION and UNION ALL is fine: the merged rows are drawn from the
+    arms' rows either way."""
+    arms: list[Expr] = []
+    for side in (u.this, u.expression):
+        if isinstance(side, exp.Union):
+            arms.extend(_union_arms(side))
+        elif isinstance(side, Expr):
+            arms.append(side)
+    return arms
+
+
+def _positional_outputs(arm: Expr) -> tuple[str, ...] | None:
+    """An arm's output column names in projection order, or ``None`` when they
+    cannot be lined up positionally (a star, a duplicated name, not a SELECT)."""
+    if not isinstance(arm, exp.Select):
+        return None
+    names: list[str] = []
+    for proj in arm.expressions:
+        if isinstance(proj, exp.Star):
+            return None
+        inner = proj.this if isinstance(proj, exp.Alias) else proj
+        if isinstance(inner, exp.Column) and isinstance(inner.this, exp.Star):
+            return None
+        names.append(proj.alias_or_name.lower())
+    if len(set(names)) != len(names):
+        return None
+    return tuple(names)
+
+
+def _within(fds: frozenset[FD], columns: frozenset[str]) -> frozenset[FD]:
+    """The dependencies mentioning only ``columns``."""
+    return frozenset(fd for fd in fds if fd.determinant | {fd.dependent} <= columns)
+
+
 def _remap(fds: frozenset[FD], rename: Mapping[str, tuple[str, ...]]) -> frozenset[FD]:
     """Rename each dependency onto the projection's output names, dropping any whose
-    columns do not all survive. One output name per input column suffices (copies of
-    a column carry equal values), picked stably."""
+    columns do not all survive."""
     out: set[FD] = set()
     for fd in fds:
-        determinant = _remap_columns(fd.determinant, rename)
-        dependent = rename.get(fd.dependent)
-        if determinant is None or not dependent:
-            continue
-        out.add(FD(determinant, min(dependent)))
+        renamed = _remap_one(fd, rename)
+        if renamed is not None:
+            out.add(renamed)
     return frozenset(out)
+
+
+def _remap_declared(
+    instances: frozenset[DeclaredFD], rename: Mapping[str, tuple[str, ...]]
+) -> frozenset[DeclaredFD]:
+    """Rename each instance's current dependency by the same rules as
+    :func:`_remap`, keeping its grounding; an instance whose columns do not all
+    survive drops with them."""
+    out: set[DeclaredFD] = set()
+    for inst in instances:
+        fd = _remap_one(inst.fd, rename)
+        if fd is not None:
+            out.add(replace(inst, fd=fd))
+    return frozenset(out)
+
+
+def _remap_one(fd: FD, rename: Mapping[str, tuple[str, ...]]) -> FD | None:
+    """One dependency renamed onto the projection's output names, or ``None`` when
+    a column does not survive. One output name per input column suffices (copies of
+    a column carry equal values), picked stably."""
+    determinant = _remap_columns(fd.determinant, rename)
+    dependent = rename.get(fd.dependent)
+    if determinant is None or not dependent:
+        return None
+    return FD(determinant, min(dependent))
 
 
 def _remap_columns(
@@ -473,22 +671,31 @@ def _qualified_rename(sel: exp.Select) -> tuple[dict[_QCol, tuple[str, ...]], bo
     return {qc: tuple(names) for qc, names in out.items()}, star
 
 
+def _project_one(
+    determinant: frozenset[_QCol], dependent: _QCol, rename: Mapping[_QCol, tuple[str, ...]]
+) -> FD | None:
+    """One qualified dependency projected onto the output names, or ``None`` when a
+    column does not survive. One output name per column suffices (copies carry
+    equal values), picked stably."""
+    dep_names = rename.get(dependent)
+    if not dep_names:
+        return None
+    det_names = [rename.get(d) for d in determinant]
+    if any(names is None for names in det_names):
+        return None
+    return FD(frozenset(min(names) for names in det_names if names is not None), min(dep_names))
+
+
 def _project_qualified(
     qfds: set[tuple[frozenset[_QCol], _QCol]], rename: Mapping[_QCol, tuple[str, ...]]
 ) -> frozenset[FD]:
     """Rename each qualified dependency onto the projection's output names, dropping any
-    whose columns do not all survive. One output name per column suffices (copies carry
-    equal values), picked stably."""
+    whose columns do not all survive."""
     out: set[FD] = set()
     for determinant, dependent in qfds:
-        dep_names = rename.get(dependent)
-        if not dep_names:
-            continue
-        det_names = [rename.get(d) for d in determinant]
-        if any(names is None for names in det_names):
-            continue
-        determinant_out = frozenset(min(names) for names in det_names if names is not None)
-        out.add(FD(determinant_out, min(dep_names)))
+        fd = _project_one(determinant, dependent, rename)
+        if fd is not None:
+            out.add(fd)
     return frozenset(out)
 
 
@@ -529,11 +736,13 @@ def functional_dependency_property(
                 key_ann = ctx.annotation(uniqueness, ref)
                 if key_ann is not None:
                     keys = key_ann.value.keys
-            return _Base(ann.value.fds, keys)
+            # The bottom sentinel carries no dependencies to walk with; strip it to
+            # the plain sets here, exactly as the set-valued walk always has.
+            return _Base(FDSet(ann.value.fds, ann.value.declared), keys)
 
-        fds = _FdWalk(base_resolve).scope_fds(deriv, cte_scope={})
-        opacity = Opacity.CONCRETE if fds else Opacity.IMPLICIT
-        return Annotation(FDSet(fds), opacity, provisional=provisional)
+        value = _FdWalk(base_resolve).scope_fds(deriv, cte_scope={})
+        opacity = Opacity.CONCRETE if value.fds else Opacity.IMPLICIT
+        return Annotation(value, opacity, provisional=provisional)
 
     return relation_property(
         name="functional_dependency",

--- a/src/dblect/lineage/properties/predicate_flow.py
+++ b/src/dblect/lineage/properties/predicate_flow.py
@@ -160,12 +160,7 @@ class _FlowWalk:
     def _select(
         self, sel: exp.Select, *, cte_scope: Mapping[str, frozenset[Canon]]
     ) -> frozenset[Canon]:
-        local = dict(cte_scope)
-        with_ = sel.args.get("with_")
-        if isinstance(with_, exp.With):
-            for cte in with_.expressions:
-                if isinstance(cte, exp.CTE) and isinstance(cte.this, Expr):
-                    local[cte.alias_or_name] = self.scope_filter(cte.this, cte_scope=local)
+        local = sg.with_scope(sel, cte_scope, lambda n, s: self.scope_filter(n, cte_scope=s))
 
         from_ = sg.from_of(sel)
         if from_ is None or not isinstance(from_.this, Expr):

--- a/src/dblect/lineage/properties/uniqueness.py
+++ b/src/dblect/lineage/properties/uniqueness.py
@@ -803,12 +803,7 @@ class _RelationWalk:
         return carried
 
     def _select(self, sel: exp.Select, *, cte_scope: Mapping[str, _Carried]) -> _Carried:
-        local = dict(cte_scope)
-        with_ = sel.args.get("with_")
-        if isinstance(with_, exp.With):
-            for cte in with_.expressions:
-                if isinstance(cte, exp.CTE) and isinstance(cte.this, Expr):
-                    local[cte.alias_or_name] = self.scope_keys(cte.this, cte_scope=local)
+        local = sg.with_scope(sel, cte_scope, lambda n, s: self.scope_keys(n, cte_scope=s))
 
         from_ = sg.from_of(sel)
         if from_ is None or not isinstance(from_.this, Expr):

--- a/src/dblect/sql/_sqlglot.py
+++ b/src/dblect/sql/_sqlglot.py
@@ -33,12 +33,8 @@ class JoinSide(StrEnum):
 
 
 def from_of(sel: exp.Select) -> exp.From | None:
-    """The ``FROM`` clause of a ``SELECT``, or ``None`` if absent.
-
-    sqlglot 30+ keys the arg ``"from_"``; older 25.x kept it as ``"from"``.
-    We try both so the static-analysis layer doesn't pin a minor version.
-    """
-    return cast("exp.From | None", sel.args.get("from_") or sel.args.get("from"))
+    """The ``FROM`` clause of a ``SELECT``, or ``None`` if absent."""
+    return cast("exp.From | None", sel.args.get("from_"))
 
 
 def where_of(sel: exp.Select) -> exp.Where | None:

--- a/src/dblect/sql/_sqlglot.py
+++ b/src/dblect/sql/_sqlglot.py
@@ -81,6 +81,30 @@ def with_scope(
     return local
 
 
+def union_arms(u: exp.Union) -> list[Expr] | None:
+    """The arms of a union chain in order: same-operator nesting flattened and
+    parenthesized arms unwrapped, since parens change neither the merged rows nor
+    the arms' output names (dbt_utils-style generated unions parenthesize every
+    arm). Mixing UNION and UNION ALL is fine: the merged rows are drawn from the
+    arms' rows either way. ``None`` when any link merges by name (``BY NAME``,
+    ``CORRESPONDING``), where alignment is by alias rather than position."""
+    if u.args.get("by_name"):
+        return None
+    arms: list[Expr] = []
+    for side in (u.this, u.expression):
+        if not isinstance(side, Expr):
+            return None
+        node = side.unnest()
+        if isinstance(node, exp.Union):
+            inner = union_arms(node)
+            if inner is None:
+                return None
+            arms.extend(inner)
+        else:
+            arms.append(node)
+    return arms
+
+
 class GroupBinding(StrEnum):
     """How firmly a ``GROUP BY`` target is bound to the expression it denotes.
 

--- a/src/dblect/sql/_sqlglot.py
+++ b/src/dblect/sql/_sqlglot.py
@@ -13,10 +13,10 @@ documents its key and what shape it returns.
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import TypeGuard, cast
+from typing import TypeGuard, TypeVar, cast
 
 import sqlglot.expressions as exp
 from sqlglot import Expr
@@ -61,6 +61,24 @@ def laterals_of(sel: exp.Select) -> list[exp.Lateral]:
 
 def group_of(sel: exp.Select) -> exp.Group | None:
     return cast("exp.Group | None", sel.args.get("group"))
+
+
+_V = TypeVar("_V")
+
+
+def with_scope(
+    node: Expr, cte_scope: Mapping[str, _V], resolve: Callable[[Expr, Mapping[str, _V]], _V]
+) -> dict[str, _V]:
+    """``cte_scope`` extended with the CTEs ``node`` declares, each resolved by
+    ``resolve`` in the scope the ones before it built. The one CTE fold every
+    relation walk shares, whatever value it carries per scope."""
+    local = dict(cte_scope)
+    with_ = node.args.get("with_")
+    if isinstance(with_, exp.With):
+        for cte in with_.expressions:
+            if isinstance(cte, exp.CTE) and isinstance(cte.this, Expr):
+                local[cte.alias_or_name] = resolve(cte.this, local)
+    return local
 
 
 class GroupBinding(StrEnum):

--- a/tests/check/test_worlds.py
+++ b/tests/check/test_worlds.py
@@ -20,9 +20,12 @@ from __future__ import annotations
 
 from dataclasses import replace
 
+import pytest
+
 from dblect.adapters import profile_for_adapter
 from dblect.check import (
     CheckFindingKind,
+    FdCompileFact,
     TagCompileFact,
     base_world_facts,
     build_check_graphs,
@@ -32,9 +35,20 @@ from dblect.check import (
     world_findings,
 )
 from dblect.demo import Currency, Money
-from dblect.lineage.facts.model import BASE_WORLD, CompileOrigin, CompileValue, Fact, WorldRef
-from dblect.lineage.graph import ColumnRef
+from dblect.lineage.facts.model import (
+    BASE_WORLD,
+    CompileOrigin,
+    CompileValue,
+    Declared,
+    DeclaredSource,
+    Fact,
+    NativeConstraint,
+    Provenance,
+    WorldRef,
+)
+from dblect.lineage.graph import ColumnRef, SourceKind, SourceRef
 from dblect.lineage.properties.domain_type import DomainTag
+from dblect.lineage.properties.functional_dependency import FD, FDSet
 from dblect.manifest import Manifest, ResourceType
 from dblect.types import ModelContract, active_registry, isolated_registry, resolve_contracts
 from tests._manifest_builders import cols as _cols
@@ -223,3 +237,25 @@ def test_world_findings_honor_noqa_suppression() -> None:
 
     kinds = [f.kind for r in result.per_world for f in r.findings]
     assert CheckFindingKind.DOMAIN_TYPE_CONTRADICTION not in kinds
+
+
+# A compile fact is the per-world seam: only a toolchain-minted value belongs in
+# one. A declared fact routed through would be lifted by the FD grounding into a
+# world axiom that survives unions, silently promoting a flag-pinned value into a
+# user assertion, so the wrappers refuse every other provenance at construction.
+@pytest.mark.parametrize(
+    "provenance",
+    [Declared(DeclaredSource.USER_ASSERTED), NativeConstraint(enforced_on_write=True)],
+    ids=["declared", "native-constraint"],
+)
+def test_compile_facts_require_compile_value_provenance(provenance: Provenance) -> None:
+    manifest = _passthrough_manifest()
+    with pytest.raises(ValueError, match="CompileValue"):
+        TagCompileFact(replace(_usd_source_fact(manifest), provenance=provenance))
+    fd_fact = Fact(
+        scope=SourceRef(SourceKind.SOURCE, "source.shop.raw.payments"),
+        value=FDSet.of(FD(frozenset({"country"}), "currency")),
+        provenance=provenance,
+    )
+    with pytest.raises(ValueError, match="CompileValue"):
+        FdCompileFact(fd_fact)

--- a/tests/lineage/test_functional_dependency_lattice.py
+++ b/tests/lineage/test_functional_dependency_lattice.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 from itertools import combinations, product
 
+import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
@@ -31,6 +32,7 @@ from dblect.lineage.properties.functional_dependency import (
     FD,
     FUNCTIONAL_DEPENDENCY_LATTICE,
     NO_FDS,
+    DeclaredFD,
     FDSet,
     determines,
     minimal_cover,
@@ -41,12 +43,43 @@ _COLS = ("a", "b", "c", "d")
 
 _col_sets = st.frozensets(st.sampled_from(_COLS), max_size=3)
 _fds = st.builds(FD, determinant=_col_sets, dependent=st.sampled_from(_COLS))
-_fd_sets = st.frozensets(_fds, max_size=4).map(FDSet)
+
+_REL = SourceRef(SourceKind.MODEL, "model.shop.payments")
+_ORIGINS = (
+    SourceRef(SourceKind.SOURCE, "source.shop.raw.payments"),
+    SourceRef(SourceKind.SOURCE, "source.shop.raw.customers"),
+)
+
+
+def _fd_sort_key(fd: FD) -> tuple[tuple[str, ...], str]:
+    return (tuple(sorted(fd.determinant)), fd.dependent)
+
+
+@st.composite
+def _fd_set(draw: st.DrawFn) -> FDSet:
+    """An FD set whose declared instances respect the value's invariant: each
+    instance's current dependency is among ``fds``."""
+    fds = draw(st.frozensets(_fds, max_size=4))
+    declared: frozenset[DeclaredFD] = frozenset()
+    if fds:
+        declared = draw(
+            st.frozensets(
+                st.builds(
+                    DeclaredFD,
+                    origin=st.sampled_from(_ORIGINS),
+                    declared=_fds,
+                    fd=st.sampled_from(sorted(fds, key=_fd_sort_key)),
+                ),
+                max_size=3,
+            )
+        )
+    return FDSet(fds, declared)
+
+
+_fd_sets = _fd_set()
 # Mostly real FD sets, occasionally the bottom sentinel, so the law arms that
 # touch bottom are exercised without swamping the normal cases.
 _values = st.one_of(_fd_sets, st.just(ALL_FDS))
-
-_REL = SourceRef(SourceKind.MODEL, "model.shop.payments")
 
 
 def _fact(value: FDSet) -> Fact[FDSet, SourceRef]:
@@ -84,6 +117,38 @@ def test_join_intersects_fds() -> None:
     assert FUNCTIONAL_DEPENDENCY_LATTICE.join(a, b) == FDSet.of(shared)
 
 
+def _instance(fd: FD, origin: SourceRef = _ORIGINS[0]) -> DeclaredFD:
+    return DeclaredFD(origin=origin, declared=fd, fd=fd)
+
+
+def test_meet_unions_declared_instances() -> None:
+    fd_a = FD(frozenset({"country"}), "currency")
+    fd_b = FD(frozenset({"country"}), "region")
+    a = FDSet(frozenset({fd_a}), frozenset({_instance(fd_a)}))
+    b = FDSet(frozenset({fd_b}), frozenset({_instance(fd_b)}))
+    assert FUNCTIONAL_DEPENDENCY_LATTICE.meet(a, b) == FDSet(
+        frozenset({fd_a, fd_b}), frozenset({_instance(fd_a), _instance(fd_b)})
+    )
+
+
+def test_join_keeps_only_shared_instances() -> None:
+    """The same dependency grounded at two different origins is two instances, and
+    a confluence keeps neither unless both sides carry the same one."""
+    fd = FD(frozenset({"country"}), "currency")
+    a = FDSet(frozenset({fd}), frozenset({_instance(fd, _ORIGINS[0])}))
+    b = FDSet(frozenset({fd}), frozenset({_instance(fd, _ORIGINS[1])}))
+    assert FUNCTIONAL_DEPENDENCY_LATTICE.join(a, b) == FDSet.of(fd)
+    assert FUNCTIONAL_DEPENDENCY_LATTICE.join(a, a) == a
+
+
+def test_an_instance_outside_the_fds_is_rejected() -> None:
+    """The invariant: a declared instance's current dependency is one of the
+    value's dependencies, so consumers reading ``fds`` alone never under-see."""
+    fd = FD(frozenset({"country"}), "currency")
+    with pytest.raises(ValueError, match="outside fds"):
+        FDSet(frozenset(), frozenset({_instance(fd)}))
+
+
 @given(st.lists(_fd_sets, max_size=6))
 def test_resolution_never_contradicts(values: list[FDSet]) -> None:
     """FD declarations only ever union, so a bucket of real FD sets resolves to
@@ -91,10 +156,12 @@ def test_resolution_never_contradicts(values: list[FDSet]) -> None:
     facts = tuple(_fact(v) for v in values)
     value, is_contradiction = resolve(FUNCTIONAL_DEPENDENCY_LATTICE, facts)
     assert not is_contradiction
-    expected: frozenset[FD] = frozenset()
+    expected_fds: frozenset[FD] = frozenset()
+    expected_declared: frozenset[DeclaredFD] = frozenset()
     for v in values:
-        expected = expected | v.fds
-    assert value == FDSet(expected)
+        expected_fds = expected_fds | v.fds
+        expected_declared = expected_declared | v.declared
+    assert value == FDSet(expected_fds, expected_declared)
 
 
 # --- entailment ----------------------------------------------------------------

--- a/tests/lineage/test_functional_dependency_lattice.py
+++ b/tests/lineage/test_functional_dependency_lattice.py
@@ -117,26 +117,12 @@ def test_join_intersects_fds() -> None:
     assert FUNCTIONAL_DEPENDENCY_LATTICE.join(a, b) == FDSet.of(shared)
 
 
-def _instance(fd: FD, origin: SourceRef = _ORIGINS[0]) -> DeclaredFD:
-    return DeclaredFD(origin=origin, declared=fd, fd=fd)
-
-
-def test_join_keeps_only_shared_instances() -> None:
-    """The same dependency grounded at two different origins is two instances, and
-    a confluence keeps neither unless both sides carry the same one."""
-    fd = FD(frozenset({"country"}), "currency")
-    a = FDSet(frozenset({fd}), frozenset({_instance(fd, _ORIGINS[0])}))
-    b = FDSet(frozenset({fd}), frozenset({_instance(fd, _ORIGINS[1])}))
-    assert FUNCTIONAL_DEPENDENCY_LATTICE.join(a, b) == FDSet.of(fd)
-    assert FUNCTIONAL_DEPENDENCY_LATTICE.join(a, a) == a
-
-
 def test_an_instance_outside_the_fds_is_rejected() -> None:
     """The invariant: a declared instance's current dependency is one of the
     value's dependencies, so consumers reading ``fds`` alone never under-see."""
     fd = FD(frozenset({"country"}), "currency")
     with pytest.raises(ValueError, match="outside fds"):
-        FDSet(frozenset(), frozenset({_instance(fd)}))
+        FDSet(frozenset(), frozenset({DeclaredFD(origin=_ORIGINS[0], declared=fd, fd=fd)}))
 
 
 @given(st.lists(_fd_sets, max_size=6))

--- a/tests/lineage/test_functional_dependency_lattice.py
+++ b/tests/lineage/test_functional_dependency_lattice.py
@@ -121,16 +121,6 @@ def _instance(fd: FD, origin: SourceRef = _ORIGINS[0]) -> DeclaredFD:
     return DeclaredFD(origin=origin, declared=fd, fd=fd)
 
 
-def test_meet_unions_declared_instances() -> None:
-    fd_a = FD(frozenset({"country"}), "currency")
-    fd_b = FD(frozenset({"country"}), "region")
-    a = FDSet(frozenset({fd_a}), frozenset({_instance(fd_a)}))
-    b = FDSet(frozenset({fd_b}), frozenset({_instance(fd_b)}))
-    assert FUNCTIONAL_DEPENDENCY_LATTICE.meet(a, b) == FDSet(
-        frozenset({fd_a, fd_b}), frozenset({_instance(fd_a), _instance(fd_b)})
-    )
-
-
 def test_join_keeps_only_shared_instances() -> None:
     """The same dependency grounded at two different origins is two instances, and
     a confluence keeps neither unless both sides carry the same one."""

--- a/tests/lineage/test_functional_dependency_lattice.py
+++ b/tests/lineage/test_functional_dependency_lattice.py
@@ -51,8 +51,14 @@ _ORIGINS = (
 )
 
 
-def _fd_sort_key(fd: FD) -> tuple[tuple[str, ...], str]:
-    return (tuple(sorted(fd.determinant)), fd.dependent)
+@st.composite
+def _declared_instance(draw: st.DrawFn) -> DeclaredFD:
+    """An instance with an arbitrary binding of the declared columns onto the
+    column universe, the shape a walk's renames produce."""
+    declared = draw(_fds)
+    cols = declared.determinant | {declared.dependent}
+    binding = frozenset((c, draw(st.sampled_from(_COLS))) for c in cols)
+    return DeclaredFD(origin=draw(st.sampled_from(_ORIGINS)), declared=declared, binding=binding)
 
 
 @st.composite
@@ -60,20 +66,8 @@ def _fd_set(draw: st.DrawFn) -> FDSet:
     """An FD set whose declared instances respect the value's invariant: each
     instance's current dependency is among ``fds``."""
     fds = draw(st.frozensets(_fds, max_size=4))
-    declared: frozenset[DeclaredFD] = frozenset()
-    if fds:
-        declared = draw(
-            st.frozensets(
-                st.builds(
-                    DeclaredFD,
-                    origin=st.sampled_from(_ORIGINS),
-                    declared=_fds,
-                    fd=st.sampled_from(sorted(fds, key=_fd_sort_key)),
-                ),
-                max_size=3,
-            )
-        )
-    return FDSet(fds, declared)
+    declared = draw(st.frozensets(_declared_instance(), max_size=3))
+    return FDSet(fds | frozenset(inst.fd for inst in declared), declared)
 
 
 _fd_sets = _fd_set()
@@ -122,7 +116,15 @@ def test_an_instance_outside_the_fds_is_rejected() -> None:
     value's dependencies, so consumers reading ``fds`` alone never under-see."""
     fd = FD(frozenset({"country"}), "currency")
     with pytest.raises(ValueError, match="outside fds"):
-        FDSet(frozenset(), frozenset({DeclaredFD(origin=_ORIGINS[0], declared=fd, fd=fd)}))
+        FDSet(frozenset(), frozenset({DeclaredFD.identity(_ORIGINS[0], fd)}))
+
+
+def test_a_binding_off_the_declared_columns_is_rejected() -> None:
+    """The instance invariant: the binding maps exactly the declared columns, so
+    the current dependency is always derivable."""
+    fd = FD(frozenset({"country"}), "currency")
+    with pytest.raises(ValueError, match="declared columns"):
+        DeclaredFD(origin=_ORIGINS[0], declared=fd, binding=frozenset({("country", "country")}))
 
 
 @given(st.lists(_fd_sets, max_size=6))

--- a/tests/lineage/test_functional_dependency_propagation.py
+++ b/tests/lineage/test_functional_dependency_propagation.py
@@ -536,36 +536,17 @@ def test_inner_join_carries_a_where_pin_on_either_side() -> None:
 # The union merge keeps exactly the declared instances every arm shares, whole,
 # after positional alignment: a union adds only cross pairs (one row per arm), an
 # arm-local witness leaves them uncovered, and one shared axiom covers them. The
-# rows enumerate the decision space: one carry per composition path the merge must
-# thread (operator, alignment, chain flattening, the dbt CTE-and-rename shell) and
-# one drop per soundness edge (derived witness, two worlds, an unknown arm, two
-# axioms of one world on the same columns, crossed columns, a star arm), plus the
-# other set operators, which claim nothing. The union PBT in
-# test_pbt_functional_dependency_soundness.py judges the same rule against
-# materialized data.
+# carry side is owned by the union PBT in
+# test_pbt_functional_dependency_soundness.py, whose anti-vacuity arm spans both
+# operators, both arm orders, and differing arm aliases; the rows here pin what
+# its generator cannot reach: the two structural carries (chain flattening, the
+# dbt CTE-and-rename shell), one drop per soundness edge (derived witness, two
+# worlds, an unknown arm, two axioms of one world on the same columns, crossed
+# columns, a star arm), and the other set operators, which claim nothing.
 
 _CC = _fd("currency", "country")
 
 _SET_OPERATIONS = [
-    pytest.param(
-        _declared(_CC),
-        "SELECT country, currency FROM payments UNION ALL SELECT country, currency FROM payments",
-        _carried(_inst(_CC)),
-        id="one-world-slices-carry",
-    ),
-    pytest.param(
-        _declared(_CC),
-        "SELECT country, currency FROM payments UNION SELECT country, currency FROM payments",
-        _carried(_inst(_CC)),
-        id="union-distinct-carries-alike",
-    ),
-    pytest.param(
-        _declared(_CC),
-        "SELECT country AS nation, currency AS curr FROM payments "
-        "UNION ALL SELECT country AS c1, currency AS c2 FROM payments",
-        _carried(_inst(_CC, as_fd=_fd("curr", "nation"))),
-        id="arms-align-by-position",
-    ),
     pytest.param(
         _declared(_CC),
         "SELECT country, currency FROM payments "
@@ -581,13 +562,6 @@ _SET_OPERATIONS = [
         "SELECT country AS nation, currency AS curr FROM unioned",
         _carried(_inst(_CC, as_fd=_fd("curr", "nation"))),
         id="dbt-shape-cte-then-rename",
-    ),
-    pytest.param(
-        _declared(_fd("region", "country"), _fd("currency", "region")),
-        "SELECT country, region, currency FROM payments "
-        "UNION ALL SELECT country, region, currency FROM payments",
-        _carried(_inst(_fd("region", "country")), _inst(_fd("currency", "region"))),
-        id="declared-chain-kept-whole",
     ),
     pytest.param(
         _declared(),

--- a/tests/lineage/test_functional_dependency_propagation.py
+++ b/tests/lineage/test_functional_dependency_propagation.py
@@ -9,7 +9,16 @@ drops what it cannot carry, a WHERE preserves them and pins filtered columns
 constant, a GROUP BY determines every other output from the group key, a key read
 from the uniqueness property determines the columns selected alongside it, a join
 carries its kept sides' dependencies plus an inner join's ON equalities, and a
-UNION proves nothing.
+UNION keeps exactly the declared dependencies every arm carries from one
+declaration while everything derived drops.
+
+The union rule rests on the pair-coverage argument: a dependency is universally
+quantified over row pairs, and a union adds exactly the cross pairs, one row from
+each arm. A derived dependency's witness is arm-local (each arm can pin a column
+to a different constant), so the cross pairs are uncovered and it dies. A declared
+dependency is an axiom about the declaring relation's world, so when every arm's
+pairs are that world's pairs, the cross pairs are covered too and the merge keeps
+it, with the same grounding.
 """
 
 from __future__ import annotations
@@ -20,13 +29,25 @@ import pytest
 
 from dblect.adapters import profile_for_adapter
 from dblect.lineage.builder import build_relation_graph
-from dblect.lineage.facts.model import Annotation, Declared, DeclaredSource, Fact
+from dblect.lineage.facts.model import (
+    BASE_WORLD,
+    Annotation,
+    CompileOrigin,
+    CompileValue,
+    Declared,
+    DeclaredSource,
+    Fact,
+    NativeConstraint,
+    Provenance,
+)
 from dblect.lineage.facts.registry import AnnotationStore, PropertyRegistry
 from dblect.lineage.graph import SourceKind, SourceRef
 from dblect.lineage.properties.functional_dependency import (
     FD,
     NO_FDS,
+    DeclaredFD,
     FDSet,
+    determines,
     functional_dependency_grounding,
     functional_dependency_property,
 )
@@ -66,6 +87,18 @@ def _fd(dependent: str, *determinant: str) -> FD:
     return FD(frozenset(determinant), dependent)
 
 
+def _inst(fd: FD, *, origin: SourceRef = _PAYMENTS, as_fd: FD | None = None) -> DeclaredFD:
+    """A declared dependency's instance: ``fd`` as declared at ``origin``, carried
+    under the current relation's names (``as_fd`` when a projection renamed it)."""
+    return DeclaredFD(origin=origin, declared=fd, fd=fd if as_fd is None else as_fd)
+
+
+def _carried(*instances: DeclaredFD, derived: tuple[FD, ...] = ()) -> FDSet:
+    """The value a relation holds when it carries these declared instances plus
+    any purely derived dependencies."""
+    return FDSet(frozenset(i.fd for i in instances) | frozenset(derived), frozenset(instances))
+
+
 def _fds(facts: _FdFacts, *nodes: Node, read_keys: bool = False) -> dict[str, FDSet]:
     """Build a manifest from the nodes, propagate the FD property (after uniqueness
     when ``read_keys`` is set, so the key-derived source is live), and return each
@@ -95,7 +128,7 @@ def test_passthrough_carries_the_declared_fd() -> None:
         _source(_PAYMENTS.unique_id),
         _node("model.shop.stg", "SELECT country, currency, amount FROM payments"),
     )
-    assert out["model.shop.stg"] == FDSet.of(_fd("currency", "country"))
+    assert out["model.shop.stg"] == _carried(_inst(_fd("currency", "country")))
 
 
 def test_projection_renames_both_sides() -> None:
@@ -104,7 +137,9 @@ def test_projection_renames_both_sides() -> None:
         _source(_PAYMENTS.unique_id),
         _node("model.shop.stg", "SELECT country AS nation, currency AS curr FROM payments"),
     )
-    assert out["model.shop.stg"] == FDSet.of(_fd("curr", "nation"))
+    assert out["model.shop.stg"] == _carried(
+        _inst(_fd("currency", "country"), as_fd=_fd("curr", "nation"))
+    )
 
 
 def test_dropping_a_dependency_column_drops_the_fd() -> None:
@@ -122,7 +157,7 @@ def test_star_carries_everything() -> None:
         _source(_PAYMENTS.unique_id),
         _node("model.shop.stg", "SELECT * FROM payments"),
     )
-    assert out["model.shop.stg"] == FDSet.of(_fd("currency", "country"))
+    assert out["model.shop.stg"] == _carried(_inst(_fd("currency", "country")))
 
 
 # --- WHERE ----------------------------------------------------------------------
@@ -136,7 +171,7 @@ def test_where_preserves_fds() -> None:
         _source(_PAYMENTS.unique_id),
         _node("model.shop.stg", "SELECT country, currency FROM payments WHERE amount > 0"),
     )
-    assert out["model.shop.stg"] == FDSet.of(_fd("currency", "country"))
+    assert out["model.shop.stg"] == _carried(_inst(_fd("currency", "country")))
 
 
 def test_where_equality_pins_a_column_constant() -> None:
@@ -216,9 +251,9 @@ def test_group_by_keeps_fds_among_the_group_columns() -> None:
             "GROUP BY country, currency",
         ),
     )
-    assert out["model.shop.by_cc"] == FDSet.of(
-        _fd("currency", "country"),
-        _fd("total", "country", "currency"),
+    assert out["model.shop.by_cc"] == _carried(
+        _inst(_fd("currency", "country")),
+        derived=(_fd("total", "country", "currency"),),
     )
 
 
@@ -250,22 +285,39 @@ def test_star_over_a_group_by_keeps_only_within_group_fds() -> None:
     assert out["model.shop.g"] == NO_FDS
 
 
-# --- shapes the walk does not model ----------------------------------------------
+# --- set operations: derived dependencies die, declared ones are judged below ----
 
 
-def test_union_all_proves_nothing() -> None:
-    """Two arms can each satisfy a dependency while their union violates it (the same
-    determinant value mapping to different dependents per arm)."""
+def test_union_still_proves_nothing_for_derived_dependencies() -> None:
+    """Each arm pins ``currency`` constant, yet the union holds two currencies: a
+    derived dependency's witness is arm-local, so no cross pair is covered and the
+    merge must claim nothing."""
+    out = _fds(
+        _declared(),
+        _source(_PAYMENTS.unique_id),
+        _node(
+            "model.shop.u",
+            "SELECT country, currency FROM payments WHERE currency = 'usd' "
+            "UNION ALL SELECT country, currency FROM payments WHERE currency = 'eur'",
+        ),
+    )
+    assert out["model.shop.u"] == NO_FDS
+
+
+@pytest.mark.parametrize("op", ["INTERSECT", "EXCEPT"])
+def test_intersect_and_except_claim_nothing(op: str) -> None:
+    """Both keep a subset of one arm's rows, which cannot break a dependency; the
+    walk stays silent about them all the same (carrying the covering arm is a
+    possible refinement, not the current contract)."""
     out = _fds(
         _declared(_fd("currency", "country")),
         _source(_PAYMENTS.unique_id),
         _node(
-            "model.shop.u",
-            "SELECT country, currency FROM payments "
-            "UNION ALL SELECT country, currency FROM payments",
+            "model.shop.s",
+            f"SELECT country, currency FROM payments {op} SELECT country, currency FROM payments",
         ),
     )
-    assert out["model.shop.u"] == NO_FDS
+    assert out["model.shop.s"] == NO_FDS
 
 
 # --- the key-derived source -------------------------------------------------------
@@ -331,7 +383,7 @@ def test_inner_join_carries_a_joined_relations_fd() -> None:
             "JOIN customers c ON p.customer_id = c.id",
         ),
     )
-    assert out["model.shop.m"] == FDSet.of(_fd("currency", "country"))
+    assert out["model.shop.m"] == _carried(_inst(_fd("currency", "country"), origin=_CUSTOMERS))
 
 
 def test_inner_join_carries_both_sides_fds() -> None:
@@ -350,7 +402,10 @@ def test_inner_join_carries_both_sides_fds() -> None:
             "JOIN customers c ON p.customer_id = c.id",
         ),
     )
-    assert out["model.shop.m"] == FDSet.of(_fd("amount", "ref"), _fd("currency", "country"))
+    assert out["model.shop.m"] == _carried(
+        _inst(_fd("amount", "ref")),
+        _inst(_fd("currency", "country"), origin=_CUSTOMERS),
+    )
 
 
 def test_inner_join_qualifies_under_a_name_collision() -> None:
@@ -368,7 +423,7 @@ def test_inner_join_qualifies_under_a_name_collision() -> None:
             "FROM payments p JOIN customers c ON p.customer_id = c.id",
         ),
     )
-    assert out["model.shop.m"] == FDSet.of(_fd("currency", "country"))
+    assert out["model.shop.m"] == _carried(_inst(_fd("currency", "country"), origin=_CUSTOMERS))
 
 
 def test_left_join_drops_the_optional_sides_fds() -> None:
@@ -401,7 +456,7 @@ def test_left_join_carries_the_kept_sides_fds() -> None:
             "LEFT JOIN customers c ON p.customer_id = c.id",
         ),
     )
-    assert out["model.shop.m"] == FDSet.of(_fd("amount", "ref"))
+    assert out["model.shop.m"] == _carried(_inst(_fd("amount", "ref")))
 
 
 def test_left_join_does_not_mint_the_on_equality() -> None:
@@ -438,7 +493,7 @@ def test_right_join_keeps_the_joined_in_side() -> None:
             "RIGHT JOIN customers c ON p.customer_id = c.id",
         ),
     )
-    assert out["model.shop.m"] == FDSet.of(_fd("currency", "country"))
+    assert out["model.shop.m"] == _carried(_inst(_fd("currency", "country"), origin=_CUSTOMERS))
 
 
 def test_full_join_proves_nothing() -> None:
@@ -474,7 +529,7 @@ def test_cross_join_carries_side_fds() -> None:
             "SELECT p.amount, c.country, c.currency FROM payments p CROSS JOIN customers c",
         ),
     )
-    assert out["model.shop.m"] == FDSet.of(_fd("currency", "country"))
+    assert out["model.shop.m"] == _carried(_inst(_fd("currency", "country"), origin=_CUSTOMERS))
 
 
 def test_a_later_outer_join_pads_an_earlier_inner_joins_equality() -> None:
@@ -494,7 +549,7 @@ def test_a_later_outer_join_pads_an_earlier_inner_joins_equality() -> None:
             "RIGHT JOIN extra e ON c.id = e.k",
         ),
     )
-    assert out["model.shop.m"] == FDSet.of(_fd("v", "g"))
+    assert out["model.shop.m"] == _carried(_inst(_fd("v", "g"), origin=extra))
 
 
 def test_inner_join_carries_a_where_pin_on_either_side() -> None:
@@ -510,3 +565,277 @@ def test_inner_join_carries_a_where_pin_on_either_side() -> None:
         ),
     )
     assert out["model.shop.m"] == FDSet.of(_fd("currency"))
+
+
+# --- declared dependencies across a union -----------------------------------------
+#
+# The union rule: a declared dependency is an axiom about the declaring relation's
+# world, so it survives a union exactly when every arm carries the same instance,
+# same grounding and same current columns. Anything less leaves a cross pair
+# uncovered, so mixed provenance, a second declaration, and a column swap all drop.
+
+
+def test_union_of_one_world_carries_the_declared_dependency() -> None:
+    """Both arms draw their pairs from the declared world, so every cross pair is
+    covered and the merge keeps the dependency with its grounding."""
+    out = _fds(
+        _declared(_fd("currency", "country")),
+        _source(_PAYMENTS.unique_id),
+        _node(
+            "model.shop.u",
+            "SELECT country, currency FROM payments "
+            "UNION ALL SELECT country, currency FROM payments",
+        ),
+    )
+    assert out["model.shop.u"] == _carried(_inst(_fd("currency", "country")))
+
+
+def test_union_of_filtered_slices_carries_the_declaration_and_drops_the_pin() -> None:
+    """The declared instance covers the merged rows; the arm-local equality pin
+    does not."""
+    out = _fds(
+        _declared(_fd("currency", "country")),
+        _source(_PAYMENTS.unique_id),
+        _node(
+            "model.shop.u",
+            "SELECT country, currency FROM payments WHERE country = 'us' "
+            "UNION ALL SELECT country, currency FROM payments WHERE country <> 'us'",
+        ),
+    )
+    assert out["model.shop.u"] == _carried(_inst(_fd("currency", "country")))
+
+
+def test_union_distinct_carries_like_union_all() -> None:
+    """UNION keeps a subset of UNION ALL's rows, so whatever survives the merge
+    survives the dedup too."""
+    out = _fds(
+        _declared(_fd("currency", "country")),
+        _source(_PAYMENTS.unique_id),
+        _node(
+            "model.shop.u",
+            "SELECT country, currency FROM payments UNION SELECT country, currency FROM payments",
+        ),
+    )
+    assert out["model.shop.u"] == _carried(_inst(_fd("currency", "country")))
+
+
+def test_union_arms_align_by_position() -> None:
+    """SQL lines arms up by position under the first arm's names; the instance
+    follows the alignment."""
+    out = _fds(
+        _declared(_fd("currency", "country")),
+        _source(_PAYMENTS.unique_id),
+        _node(
+            "model.shop.u",
+            "SELECT country AS nation, currency AS curr FROM payments "
+            "UNION ALL SELECT country AS c1, currency AS c2 FROM payments",
+        ),
+    )
+    assert out["model.shop.u"] == _carried(
+        _inst(_fd("currency", "country"), as_fd=_fd("curr", "nation"))
+    )
+
+
+def test_three_arm_union_carries_the_shared_declaration() -> None:
+    out = _fds(
+        _declared(_fd("currency", "country")),
+        _source(_PAYMENTS.unique_id),
+        _node(
+            "model.shop.u",
+            "SELECT country, currency FROM payments "
+            "UNION ALL SELECT country, currency FROM payments "
+            "UNION ALL SELECT country, currency FROM payments",
+        ),
+    )
+    assert out["model.shop.u"] == _carried(_inst(_fd("currency", "country")))
+
+
+def test_rename_after_a_union_carries_the_renamed_instance() -> None:
+    """The standard dbt shape: union in a CTE, projection on top."""
+    out = _fds(
+        _declared(_fd("currency", "country")),
+        _source(_PAYMENTS.unique_id),
+        _node(
+            "model.shop.u",
+            "WITH unioned AS (SELECT country, currency FROM payments "
+            "UNION ALL SELECT country, currency FROM payments) "
+            "SELECT country AS nation, currency AS curr FROM unioned",
+        ),
+    )
+    assert out["model.shop.u"] == _carried(
+        _inst(_fd("currency", "country"), as_fd=_fd("curr", "nation"))
+    )
+
+
+def test_star_passthrough_after_a_union_carries() -> None:
+    out = _fds(
+        _declared(_fd("currency", "country")),
+        _source(_PAYMENTS.unique_id),
+        _node(
+            "model.shop.u",
+            "WITH unioned AS (SELECT country, currency FROM payments "
+            "UNION ALL SELECT country, currency FROM payments) "
+            "SELECT * FROM unioned",
+        ),
+    )
+    assert out["model.shop.u"] == _carried(_inst(_fd("currency", "country")))
+
+
+def test_a_downstream_model_carries_the_union_survivor() -> None:
+    out = _fds(
+        _declared(_fd("currency", "country")),
+        _source(_PAYMENTS.unique_id),
+        _node(
+            "model.shop.u",
+            "SELECT country, currency FROM payments "
+            "UNION ALL SELECT country, currency FROM payments",
+        ),
+        _node("model.shop.d", "SELECT country, currency FROM u"),
+    )
+    assert out["model.shop.d"] == _carried(_inst(_fd("currency", "country")))
+
+
+def test_group_by_below_a_union_keeps_the_instance() -> None:
+    out = _fds(
+        _declared(_fd("currency", "country")),
+        _source(_PAYMENTS.unique_id),
+        _node(
+            "model.shop.u",
+            "WITH unioned AS (SELECT country, currency, amount FROM payments "
+            "UNION ALL SELECT country, currency, amount FROM payments) "
+            "SELECT country, currency, SUM(amount) AS total FROM unioned "
+            "GROUP BY country, currency",
+        ),
+    )
+    assert out["model.shop.u"] == _carried(
+        _inst(_fd("currency", "country")),
+        derived=(_fd("total", "country", "currency"),),
+    )
+
+
+def test_union_keeps_a_declared_chain_whole() -> None:
+    """Both links survive as instances, so the closure still entails the chain's
+    ends downstream of the union."""
+    out = _fds(
+        _declared(_fd("region", "country"), _fd("currency", "region")),
+        _source(_PAYMENTS.unique_id),
+        _node(
+            "model.shop.u",
+            "SELECT country, region, currency FROM payments "
+            "UNION ALL SELECT country, region, currency FROM payments",
+        ),
+    )
+    assert out["model.shop.u"] == _carried(
+        _inst(_fd("region", "country")), _inst(_fd("currency", "region"))
+    )
+    assert determines(out["model.shop.u"], frozenset({"country"}), "currency")
+
+
+def test_union_of_two_declared_worlds_drops_the_dependency() -> None:
+    """Each arm honours its own declaration, and a cross pair with one row from
+    each world is covered by neither: two order systems' id spaces may collide."""
+    out = _fds(
+        _declared_on(
+            {
+                _PAYMENTS: (_fd("currency", "country"),),
+                _CUSTOMERS: (_fd("currency", "country"),),
+            }
+        ),
+        _source(_PAYMENTS.unique_id),
+        _source(_CUSTOMERS.unique_id),
+        _node(
+            "model.shop.u",
+            "SELECT country, currency FROM payments "
+            "UNION ALL SELECT country, currency FROM customers",
+        ),
+    )
+    assert out["model.shop.u"] == NO_FDS
+
+
+def test_union_of_a_declared_and_an_unknown_arm_drops_the_dependency() -> None:
+    out = _fds(
+        _declared(_fd("currency", "country")),
+        _source(_PAYMENTS.unique_id),
+        _source(_CUSTOMERS.unique_id),
+        _node(
+            "model.shop.u",
+            "SELECT country, currency FROM payments "
+            "UNION ALL SELECT country, currency FROM customers",
+        ),
+    )
+    assert out["model.shop.u"] == NO_FDS
+
+
+def test_two_declarations_of_one_world_on_the_same_columns_drop() -> None:
+    """One relation declares ``a -> b`` and ``c -> d``; the arms rename both onto
+    the same output columns. The pairs come from different world mappings, so the
+    identity of the declaration, not just its origin, keys the merge."""
+    out = _fds(
+        _declared(_fd("b", "a"), _fd("d", "c")),
+        _source(_PAYMENTS.unique_id),
+        _node(
+            "model.shop.u",
+            "SELECT a AS m, b AS n FROM payments UNION ALL SELECT c AS m, d AS n FROM payments",
+        ),
+    )
+    assert out["model.shop.u"] == NO_FDS
+
+
+def test_union_with_swapped_columns_drops_the_instance() -> None:
+    """The second arm crosses the declared columns, so under the union's names its
+    instance runs the other way and no shared instance remains."""
+    out = _fds(
+        _declared(_fd("currency", "country")),
+        _source(_PAYMENTS.unique_id),
+        _node(
+            "model.shop.u",
+            "SELECT country, currency FROM payments "
+            "UNION ALL SELECT currency AS country, country AS currency FROM payments",
+        ),
+    )
+    assert out["model.shop.u"] == NO_FDS
+
+
+def test_union_arm_with_a_star_claims_nothing() -> None:
+    """A star arm leaves nothing to line up positionally, so the merge cannot
+    match instances across arms."""
+    out = _fds(
+        _declared(_fd("currency", "country")),
+        _source(_PAYMENTS.unique_id),
+        _node(
+            "model.shop.u",
+            "SELECT country, currency FROM payments UNION ALL SELECT * FROM payments",
+        ),
+    )
+    assert out["model.shop.u"] == NO_FDS
+
+
+# --- what grounds an axiom ---------------------------------------------------------
+#
+# Only a person's claim about the world mints a grounded instance. The provenance
+# space is closed, so each kind is decided explicitly: a declaration is the axiom,
+# a native constraint is enforced by the warehouse's write path (relation-scoped),
+# and a compile value is minted by the toolchain, not asserted about a world.
+
+
+def _grounded_value(provenance: Provenance) -> FDSet:
+    fact = Fact(scope=_PAYMENTS, value=FDSet.of(_fd("currency", "country")), provenance=provenance)
+    return functional_dependency_grounding({_PAYMENTS: (fact,)})(_PAYMENTS).value
+
+
+def test_declared_provenance_grounds_an_instance() -> None:
+    assert _grounded_value(Declared(DeclaredSource.USER_ASSERTED)) == _carried(
+        _inst(_fd("currency", "country"))
+    )
+
+
+def test_native_constraint_grounds_without_an_instance() -> None:
+    assert _grounded_value(NativeConstraint(enforced_on_write=True)) == FDSet.of(
+        _fd("currency", "country")
+    )
+
+
+def test_compile_value_grounds_without_an_instance() -> None:
+    assert _grounded_value(
+        CompileValue(origin=CompileOrigin.DBT_VAR, world=BASE_WORLD)
+    ) == FDSet.of(_fd("currency", "country"))

--- a/tests/lineage/test_functional_dependency_propagation.py
+++ b/tests/lineage/test_functional_dependency_propagation.py
@@ -86,10 +86,14 @@ def _fd(dependent: str, *determinant: str) -> FD:
     return FD(frozenset(determinant), dependent)
 
 
-def _inst(fd: FD, *, origin: SourceRef = _PAYMENTS, as_fd: FD | None = None) -> DeclaredFD:
-    """A declared dependency's instance: ``fd`` as declared at ``origin``, carried
-    under the current relation's names (``as_fd`` when a projection renamed it)."""
-    return DeclaredFD(origin=origin, declared=fd, fd=fd if as_fd is None else as_fd)
+def _inst(
+    fd: FD, *, origin: SourceRef = _PAYMENTS, renames: Mapping[str, str] | None = None
+) -> DeclaredFD:
+    """A declared dependency's instance: ``fd`` as declared at ``origin``, each
+    column bound to its current name (itself, unless ``renames`` maps it)."""
+    current = renames or {}
+    binding = frozenset((c, current.get(c, c)) for c in fd.determinant | {fd.dependent})
+    return DeclaredFD(origin=origin, declared=fd, binding=binding)
 
 
 def _carried(*instances: DeclaredFD, derived: tuple[FD, ...] = ()) -> FDSet:
@@ -137,7 +141,7 @@ def test_projection_renames_both_sides() -> None:
         _node("model.shop.stg", "SELECT country AS nation, currency AS curr FROM payments"),
     )
     assert out["model.shop.stg"] == _carried(
-        _inst(_fd("currency", "country"), as_fd=_fd("curr", "nation"))
+        _inst(_fd("currency", "country"), renames={"country": "nation", "currency": "curr"})
     )
 
 
@@ -538,11 +542,12 @@ def test_inner_join_carries_a_where_pin_on_either_side() -> None:
 # arm-local witness leaves them uncovered, and one shared axiom covers them. The
 # carry side is owned by the union PBT in
 # test_pbt_functional_dependency_soundness.py, whose anti-vacuity arm spans both
-# operators, both arm orders, and differing arm aliases; the rows here pin what
-# its generator cannot reach: the two structural carries (chain flattening, the
-# dbt CTE-and-rename shell), one drop per soundness edge (derived witness, two
-# worlds, an unknown arm, two axioms of one world on the same columns, crossed
-# columns, a star arm), and the other set operators, which claim nothing.
+# operators, arm orders, and arm aliases; the rows here pin the structural
+# carries (chain flattening, parenthesized arms, the dbt CTE-and-rename shell),
+# one drop per soundness edge (derived witness, two worlds, an unknown arm, two
+# axioms of one world on the same columns, crossed columns, crossed determinant
+# columns, a merge by name, a star arm), and the other set operators, which
+# claim nothing.
 
 _CC = _fd("currency", "country")
 
@@ -560,8 +565,15 @@ _SET_OPERATIONS = [
         "WITH unioned AS (SELECT country, currency FROM payments "
         "UNION ALL SELECT country, currency FROM payments) "
         "SELECT country AS nation, currency AS curr FROM unioned",
-        _carried(_inst(_CC, as_fd=_fd("curr", "nation"))),
+        _carried(_inst(_CC, renames={"country": "nation", "currency": "curr"})),
         id="dbt-shape-cte-then-rename",
+    ),
+    pytest.param(
+        _declared(_CC),
+        "(SELECT country, currency FROM payments) "
+        "UNION ALL (SELECT country, currency FROM payments)",
+        _carried(_inst(_CC)),
+        id="parenthesized-arms-carry",
     ),
     pytest.param(
         _declared(),
@@ -594,6 +606,19 @@ _SET_OPERATIONS = [
         "UNION ALL SELECT currency AS country, country AS currency FROM payments",
         NO_FDS,
         id="crossed-columns-drop",
+    ),
+    pytest.param(
+        _declared(_fd("c", "a", "b")),
+        "SELECT a, b, c FROM payments UNION ALL SELECT b AS a, a AS b, c FROM payments",
+        NO_FDS,
+        id="crossed-determinant-columns-drop",
+    ),
+    pytest.param(
+        _declared(_CC),
+        "SELECT country, currency FROM payments "
+        "UNION ALL BY NAME SELECT country, currency FROM payments",
+        NO_FDS,
+        id="by-name-merge-claims-nothing",
     ),
     pytest.param(
         _declared(_CC),

--- a/tests/lineage/test_functional_dependency_propagation.py
+++ b/tests/lineage/test_functional_dependency_propagation.py
@@ -47,7 +47,6 @@ from dblect.lineage.properties.functional_dependency import (
     NO_FDS,
     DeclaredFD,
     FDSet,
-    determines,
     functional_dependency_grounding,
     functional_dependency_property,
 )
@@ -283,41 +282,6 @@ def test_star_over_a_group_by_keeps_only_within_group_fds() -> None:
         _node("model.shop.g", "SELECT * FROM payments GROUP BY country"),
     )
     assert out["model.shop.g"] == NO_FDS
-
-
-# --- set operations: derived dependencies die, declared ones are judged below ----
-
-
-def test_union_still_proves_nothing_for_derived_dependencies() -> None:
-    """Each arm pins ``currency`` constant, yet the union holds two currencies: a
-    derived dependency's witness is arm-local, so no cross pair is covered and the
-    merge must claim nothing."""
-    out = _fds(
-        _declared(),
-        _source(_PAYMENTS.unique_id),
-        _node(
-            "model.shop.u",
-            "SELECT country, currency FROM payments WHERE currency = 'usd' "
-            "UNION ALL SELECT country, currency FROM payments WHERE currency = 'eur'",
-        ),
-    )
-    assert out["model.shop.u"] == NO_FDS
-
-
-@pytest.mark.parametrize("op", ["INTERSECT", "EXCEPT"])
-def test_intersect_and_except_claim_nothing(op: str) -> None:
-    """Both keep a subset of one arm's rows, which cannot break a dependency; the
-    walk stays silent about them all the same (carrying the covering arm is a
-    possible refinement, not the current contract)."""
-    out = _fds(
-        _declared(_fd("currency", "country")),
-        _source(_PAYMENTS.unique_id),
-        _node(
-            "model.shop.s",
-            f"SELECT country, currency FROM payments {op} SELECT country, currency FROM payments",
-        ),
-    )
-    assert out["model.shop.s"] == NO_FDS
 
 
 # --- the key-derived source -------------------------------------------------------
@@ -567,275 +531,143 @@ def test_inner_join_carries_a_where_pin_on_either_side() -> None:
     assert out["model.shop.m"] == FDSet.of(_fd("currency"))
 
 
-# --- declared dependencies across a union -----------------------------------------
+# --- set operations ---------------------------------------------------------------
 #
-# The union rule: a declared dependency is an axiom about the declaring relation's
-# world, so it survives a union exactly when every arm carries the same instance,
-# same grounding and same current columns. Anything less leaves a cross pair
-# uncovered, so mixed provenance, a second declaration, and a column swap all drop.
+# The union merge keeps exactly the declared instances every arm shares, whole,
+# after positional alignment: a union adds only cross pairs (one row per arm), an
+# arm-local witness leaves them uncovered, and one shared axiom covers them. The
+# rows enumerate the decision space: one carry per composition path the merge must
+# thread (operator, alignment, chain flattening, the dbt CTE-and-rename shell) and
+# one drop per soundness edge (derived witness, two worlds, an unknown arm, two
+# axioms of one world on the same columns, crossed columns, a star arm), plus the
+# other set operators, which claim nothing. The union PBT in
+# test_pbt_functional_dependency_soundness.py judges the same rule against
+# materialized data.
 
+_CC = _fd("currency", "country")
 
-def test_union_of_one_world_carries_the_declared_dependency() -> None:
-    """Both arms draw their pairs from the declared world, so every cross pair is
-    covered and the merge keeps the dependency with its grounding."""
-    out = _fds(
-        _declared(_fd("currency", "country")),
-        _source(_PAYMENTS.unique_id),
-        _node(
-            "model.shop.u",
-            "SELECT country, currency FROM payments "
-            "UNION ALL SELECT country, currency FROM payments",
-        ),
-    )
-    assert out["model.shop.u"] == _carried(_inst(_fd("currency", "country")))
-
-
-def test_union_of_filtered_slices_carries_the_declaration_and_drops_the_pin() -> None:
-    """The declared instance covers the merged rows; the arm-local equality pin
-    does not."""
-    out = _fds(
-        _declared(_fd("currency", "country")),
-        _source(_PAYMENTS.unique_id),
-        _node(
-            "model.shop.u",
-            "SELECT country, currency FROM payments WHERE country = 'us' "
-            "UNION ALL SELECT country, currency FROM payments WHERE country <> 'us'",
-        ),
-    )
-    assert out["model.shop.u"] == _carried(_inst(_fd("currency", "country")))
-
-
-def test_union_distinct_carries_like_union_all() -> None:
-    """UNION keeps a subset of UNION ALL's rows, so whatever survives the merge
-    survives the dedup too."""
-    out = _fds(
-        _declared(_fd("currency", "country")),
-        _source(_PAYMENTS.unique_id),
-        _node(
-            "model.shop.u",
-            "SELECT country, currency FROM payments UNION SELECT country, currency FROM payments",
-        ),
-    )
-    assert out["model.shop.u"] == _carried(_inst(_fd("currency", "country")))
-
-
-def test_union_arms_align_by_position() -> None:
-    """SQL lines arms up by position under the first arm's names; the instance
-    follows the alignment."""
-    out = _fds(
-        _declared(_fd("currency", "country")),
-        _source(_PAYMENTS.unique_id),
-        _node(
-            "model.shop.u",
-            "SELECT country AS nation, currency AS curr FROM payments "
-            "UNION ALL SELECT country AS c1, currency AS c2 FROM payments",
-        ),
-    )
-    assert out["model.shop.u"] == _carried(
-        _inst(_fd("currency", "country"), as_fd=_fd("curr", "nation"))
-    )
-
-
-def test_three_arm_union_carries_the_shared_declaration() -> None:
-    out = _fds(
-        _declared(_fd("currency", "country")),
-        _source(_PAYMENTS.unique_id),
-        _node(
-            "model.shop.u",
-            "SELECT country, currency FROM payments "
-            "UNION ALL SELECT country, currency FROM payments "
-            "UNION ALL SELECT country, currency FROM payments",
-        ),
-    )
-    assert out["model.shop.u"] == _carried(_inst(_fd("currency", "country")))
-
-
-def test_rename_after_a_union_carries_the_renamed_instance() -> None:
-    """The standard dbt shape: union in a CTE, projection on top."""
-    out = _fds(
-        _declared(_fd("currency", "country")),
-        _source(_PAYMENTS.unique_id),
-        _node(
-            "model.shop.u",
-            "WITH unioned AS (SELECT country, currency FROM payments "
-            "UNION ALL SELECT country, currency FROM payments) "
-            "SELECT country AS nation, currency AS curr FROM unioned",
-        ),
-    )
-    assert out["model.shop.u"] == _carried(
-        _inst(_fd("currency", "country"), as_fd=_fd("curr", "nation"))
-    )
-
-
-def test_star_passthrough_after_a_union_carries() -> None:
-    out = _fds(
-        _declared(_fd("currency", "country")),
-        _source(_PAYMENTS.unique_id),
-        _node(
-            "model.shop.u",
-            "WITH unioned AS (SELECT country, currency FROM payments "
-            "UNION ALL SELECT country, currency FROM payments) "
-            "SELECT * FROM unioned",
-        ),
-    )
-    assert out["model.shop.u"] == _carried(_inst(_fd("currency", "country")))
-
-
-def test_a_downstream_model_carries_the_union_survivor() -> None:
-    out = _fds(
-        _declared(_fd("currency", "country")),
-        _source(_PAYMENTS.unique_id),
-        _node(
-            "model.shop.u",
-            "SELECT country, currency FROM payments "
-            "UNION ALL SELECT country, currency FROM payments",
-        ),
-        _node("model.shop.d", "SELECT country, currency FROM u"),
-    )
-    assert out["model.shop.d"] == _carried(_inst(_fd("currency", "country")))
-
-
-def test_group_by_below_a_union_keeps_the_instance() -> None:
-    out = _fds(
-        _declared(_fd("currency", "country")),
-        _source(_PAYMENTS.unique_id),
-        _node(
-            "model.shop.u",
-            "WITH unioned AS (SELECT country, currency, amount FROM payments "
-            "UNION ALL SELECT country, currency, amount FROM payments) "
-            "SELECT country, currency, SUM(amount) AS total FROM unioned "
-            "GROUP BY country, currency",
-        ),
-    )
-    assert out["model.shop.u"] == _carried(
-        _inst(_fd("currency", "country")),
-        derived=(_fd("total", "country", "currency"),),
-    )
-
-
-def test_union_keeps_a_declared_chain_whole() -> None:
-    """Both links survive as instances, so the closure still entails the chain's
-    ends downstream of the union."""
-    out = _fds(
+_SET_OPERATIONS = [
+    pytest.param(
+        _declared(_CC),
+        "SELECT country, currency FROM payments UNION ALL SELECT country, currency FROM payments",
+        _carried(_inst(_CC)),
+        id="one-world-slices-carry",
+    ),
+    pytest.param(
+        _declared(_CC),
+        "SELECT country, currency FROM payments UNION SELECT country, currency FROM payments",
+        _carried(_inst(_CC)),
+        id="union-distinct-carries-alike",
+    ),
+    pytest.param(
+        _declared(_CC),
+        "SELECT country AS nation, currency AS curr FROM payments "
+        "UNION ALL SELECT country AS c1, currency AS c2 FROM payments",
+        _carried(_inst(_CC, as_fd=_fd("curr", "nation"))),
+        id="arms-align-by-position",
+    ),
+    pytest.param(
+        _declared(_CC),
+        "SELECT country, currency FROM payments "
+        "UNION ALL SELECT country, currency FROM payments "
+        "UNION ALL SELECT country, currency FROM payments",
+        _carried(_inst(_CC)),
+        id="chained-arms-flatten",
+    ),
+    pytest.param(
+        _declared(_CC),
+        "WITH unioned AS (SELECT country, currency FROM payments "
+        "UNION ALL SELECT country, currency FROM payments) "
+        "SELECT country AS nation, currency AS curr FROM unioned",
+        _carried(_inst(_CC, as_fd=_fd("curr", "nation"))),
+        id="dbt-shape-cte-then-rename",
+    ),
+    pytest.param(
         _declared(_fd("region", "country"), _fd("currency", "region")),
-        _source(_PAYMENTS.unique_id),
-        _node(
-            "model.shop.u",
-            "SELECT country, region, currency FROM payments "
-            "UNION ALL SELECT country, region, currency FROM payments",
-        ),
-    )
-    assert out["model.shop.u"] == _carried(
-        _inst(_fd("region", "country")), _inst(_fd("currency", "region"))
-    )
-    assert determines(out["model.shop.u"], frozenset({"country"}), "currency")
-
-
-def test_union_of_two_declared_worlds_drops_the_dependency() -> None:
-    """Each arm honours its own declaration, and a cross pair with one row from
-    each world is covered by neither: two order systems' id spaces may collide."""
-    out = _fds(
-        _declared_on(
-            {
-                _PAYMENTS: (_fd("currency", "country"),),
-                _CUSTOMERS: (_fd("currency", "country"),),
-            }
-        ),
-        _source(_PAYMENTS.unique_id),
-        _source(_CUSTOMERS.unique_id),
-        _node(
-            "model.shop.u",
-            "SELECT country, currency FROM payments "
-            "UNION ALL SELECT country, currency FROM customers",
-        ),
-    )
-    assert out["model.shop.u"] == NO_FDS
-
-
-def test_union_of_a_declared_and_an_unknown_arm_drops_the_dependency() -> None:
-    out = _fds(
-        _declared(_fd("currency", "country")),
-        _source(_PAYMENTS.unique_id),
-        _source(_CUSTOMERS.unique_id),
-        _node(
-            "model.shop.u",
-            "SELECT country, currency FROM payments "
-            "UNION ALL SELECT country, currency FROM customers",
-        ),
-    )
-    assert out["model.shop.u"] == NO_FDS
-
-
-def test_two_declarations_of_one_world_on_the_same_columns_drop() -> None:
-    """One relation declares ``a -> b`` and ``c -> d``; the arms rename both onto
-    the same output columns. The pairs come from different world mappings, so the
-    identity of the declaration, not just its origin, keys the merge."""
-    out = _fds(
+        "SELECT country, region, currency FROM payments "
+        "UNION ALL SELECT country, region, currency FROM payments",
+        _carried(_inst(_fd("region", "country")), _inst(_fd("currency", "region"))),
+        id="declared-chain-kept-whole",
+    ),
+    pytest.param(
+        _declared(),
+        "SELECT country, currency FROM payments WHERE currency = 'usd' "
+        "UNION ALL SELECT country, currency FROM payments WHERE currency = 'eur'",
+        NO_FDS,
+        id="derived-witness-dies",
+    ),
+    pytest.param(
+        _declared_on({_PAYMENTS: (_CC,), _CUSTOMERS: (_CC,)}),
+        "SELECT country, currency FROM payments UNION ALL SELECT country, currency FROM customers",
+        NO_FDS,
+        id="two-declared-worlds-drop",
+    ),
+    pytest.param(
+        _declared(_CC),
+        "SELECT country, currency FROM payments UNION ALL SELECT country, currency FROM customers",
+        NO_FDS,
+        id="declared-meets-unknown-arm-drops",
+    ),
+    pytest.param(
         _declared(_fd("b", "a"), _fd("d", "c")),
-        _source(_PAYMENTS.unique_id),
-        _node(
-            "model.shop.u",
-            "SELECT a AS m, b AS n FROM payments UNION ALL SELECT c AS m, d AS n FROM payments",
-        ),
-    )
-    assert out["model.shop.u"] == NO_FDS
+        "SELECT a AS m, b AS n FROM payments UNION ALL SELECT c AS m, d AS n FROM payments",
+        NO_FDS,
+        id="two-axioms-of-one-world-on-the-same-columns-drop",
+    ),
+    pytest.param(
+        _declared(_CC),
+        "SELECT country, currency FROM payments "
+        "UNION ALL SELECT currency AS country, country AS currency FROM payments",
+        NO_FDS,
+        id="crossed-columns-drop",
+    ),
+    pytest.param(
+        _declared(_CC),
+        "SELECT country, currency FROM payments UNION ALL SELECT * FROM payments",
+        NO_FDS,
+        id="star-arm-leaves-nothing-to-align",
+    ),
+    pytest.param(
+        _declared(_CC),
+        "SELECT country, currency FROM payments INTERSECT SELECT country, currency FROM payments",
+        NO_FDS,
+        id="intersect-claims-nothing",
+    ),
+    pytest.param(
+        _declared(_CC),
+        "SELECT country, currency FROM payments EXCEPT SELECT country, currency FROM payments",
+        NO_FDS,
+        id="except-claims-nothing",
+    ),
+]
 
 
-def test_union_with_swapped_columns_drops_the_instance() -> None:
-    """The second arm crosses the declared columns, so under the union's names its
-    instance runs the other way and no shared instance remains."""
+@pytest.mark.parametrize(("facts", "sql", "expected"), _SET_OPERATIONS)
+def test_set_operation_merges(facts: _FdFacts, sql: str, expected: FDSet) -> None:
     out = _fds(
-        _declared(_fd("currency", "country")),
+        facts,
         _source(_PAYMENTS.unique_id),
-        _node(
-            "model.shop.u",
-            "SELECT country, currency FROM payments "
-            "UNION ALL SELECT currency AS country, country AS currency FROM payments",
+        _source(_CUSTOMERS.unique_id),
+        _node("model.shop.u", sql),
+    )
+    assert out["model.shop.u"] == expected
+
+
+# Only a person's claim about the world mints a grounded instance; the closed
+# provenance space is decided per kind (a native constraint holds by the
+# warehouse's write path, a compile value is minted by the toolchain).
+@pytest.mark.parametrize(
+    ("provenance", "expected"),
+    [
+        pytest.param(Declared(DeclaredSource.USER_ASSERTED), _carried(_inst(_CC)), id="declared"),
+        pytest.param(NativeConstraint(enforced_on_write=True), FDSet.of(_CC), id="native"),
+        pytest.param(
+            CompileValue(origin=CompileOrigin.DBT_VAR, world=BASE_WORLD),
+            FDSet.of(_CC),
+            id="compile-value",
         ),
-    )
-    assert out["model.shop.u"] == NO_FDS
-
-
-def test_union_arm_with_a_star_claims_nothing() -> None:
-    """A star arm leaves nothing to line up positionally, so the merge cannot
-    match instances across arms."""
-    out = _fds(
-        _declared(_fd("currency", "country")),
-        _source(_PAYMENTS.unique_id),
-        _node(
-            "model.shop.u",
-            "SELECT country, currency FROM payments UNION ALL SELECT * FROM payments",
-        ),
-    )
-    assert out["model.shop.u"] == NO_FDS
-
-
-# --- what grounds an axiom ---------------------------------------------------------
-#
-# Only a person's claim about the world mints a grounded instance. The provenance
-# space is closed, so each kind is decided explicitly: a declaration is the axiom,
-# a native constraint is enforced by the warehouse's write path (relation-scoped),
-# and a compile value is minted by the toolchain, not asserted about a world.
-
-
-def _grounded_value(provenance: Provenance) -> FDSet:
-    fact = Fact(scope=_PAYMENTS, value=FDSet.of(_fd("currency", "country")), provenance=provenance)
-    return functional_dependency_grounding({_PAYMENTS: (fact,)})(_PAYMENTS).value
-
-
-def test_declared_provenance_grounds_an_instance() -> None:
-    assert _grounded_value(Declared(DeclaredSource.USER_ASSERTED)) == _carried(
-        _inst(_fd("currency", "country"))
-    )
-
-
-def test_native_constraint_grounds_without_an_instance() -> None:
-    assert _grounded_value(NativeConstraint(enforced_on_write=True)) == FDSet.of(
-        _fd("currency", "country")
-    )
-
-
-def test_compile_value_grounds_without_an_instance() -> None:
-    assert _grounded_value(
-        CompileValue(origin=CompileOrigin.DBT_VAR, world=BASE_WORLD)
-    ) == FDSet.of(_fd("currency", "country"))
+    ],
+)
+def test_only_a_declaration_grounds_an_instance(provenance: Provenance, expected: FDSet) -> None:
+    fact = Fact(scope=_PAYMENTS, value=FDSet.of(_CC), provenance=provenance)
+    assert functional_dependency_grounding({_PAYMENTS: (fact,)})(_PAYMENTS).value == expected

--- a/tests/lineage/test_pbt_functional_dependency_soundness.py
+++ b/tests/lineage/test_pbt_functional_dependency_soundness.py
@@ -7,14 +7,14 @@ group key determining every other output of a GROUP BY.
 The soundness obligation is uniform: every claimed ``X -> y`` must hold on the
 materialized result, meaning no two result rows agree on ``X`` and differ on ``y``.
 
-So this test generates a small scenario (a base table whose data satisfies the
+So each test generates a small scenario (base tables whose data satisfies the
 declared dependency when one is declared, and a model built from a random
-projection/rename, an optional equality filter, and an optional GROUP BY), asks
-the analyzer for the model's FD set, materializes everything in duckdb, and checks
-each claimed dependency against the rows. Over-claims anywhere in the walk (a
-rename that blurs columns, a filter wrongly treated as pinning, a group key minted
-from the wrong columns) surface as a concrete two-row counterexample, with no walk
-rule restated in the test.
+projection/rename plus the shape under test), asks the analyzer for the model's FD
+set, materializes everything in duckdb, and checks each claimed dependency against
+the rows. Over-claims anywhere in the walk (a rename that blurs columns, a filter
+wrongly treated as pinning, a union merge that forgets which declared column feeds
+which output) surface as a concrete two-row counterexample, with no walk rule
+restated in the test.
 """
 
 from __future__ import annotations
@@ -37,13 +37,90 @@ from dblect.lineage.properties.functional_dependency import (
     functional_dependency_property,
 )
 from dblect.lineage.property import propagate
-from dblect.manifest import Manifest, Node
+from tests._manifest_builders import manifest as _manifest
 from tests._manifest_builders import node as _node
 from tests._manifest_builders import source as _source
 from tests.lineage._group_spelling import GroupSpelling
 
-_SRC = SourceRef(SourceKind.SOURCE, "source.test.raw.t")
 _MODEL = SourceRef(SourceKind.MODEL, "model.test.m")
+
+# A table to materialize: its column DDL and its rows.
+_Table = tuple[str, tuple[tuple[int, ...], ...]]
+
+
+def _declared_fact(scope: SourceRef, *fds: FD) -> Fact[FDSet, SourceRef]:
+    return Fact(
+        scope=scope, value=FDSet.of(*fds), provenance=Declared(DeclaredSource.USER_ASSERTED)
+    )
+
+
+def _claimed_fds(
+    sql: str,
+    sources: Mapping[SourceRef, str],
+    facts: Mapping[SourceRef, tuple[Fact[FDSet, SourceRef], ...]],
+) -> FDSet:
+    """The model's FD set over ``sql``, exactly as the relation property derives it."""
+    tables = [_source(ref.unique_id, name=name) for ref, name in sources.items()]
+    m = _manifest(*tables, _node(_MODEL.unique_id, sql, name="m"))
+    prop = functional_dependency_property(functional_dependency_grounding(facts))
+    return propagate(build_relation_graph(m).graph, prop)[_MODEL].value
+
+
+def _materialize(
+    con: duckdb.DuckDBPyConnection, sql: str, tables: Mapping[str, _Table]
+) -> tuple[tuple[str, ...], list[tuple[object, ...]]]:
+    """Create ``tables``, run ``sql``, and return the result's lowercased column
+    names and rows."""
+    try:
+        for name, (columns, rows) in tables.items():
+            con.execute(f"CREATE OR REPLACE TABLE {name} ({columns})")
+            if rows:
+                marks = ", ".join("?" for _ in rows[0])
+                con.executemany(f"INSERT INTO {name} VALUES ({marks})", [list(r) for r in rows])
+        cursor = con.execute(sql)
+        description = cursor.description
+        assert description is not None
+        names = tuple(str(d[0]).lower() for d in description)
+        return names, [tuple(r) for r in cursor.fetchall()]
+    finally:
+        for name in tables:
+            con.execute(f"DROP TABLE IF EXISTS {name}")
+
+
+def _fd_holds(
+    fd: FD, names: tuple[str, ...], rows: list[tuple[object, ...]]
+) -> tuple[object, ...] | None:
+    """``None`` when the dependency holds; otherwise a witness determinant value
+    whose rows disagree on the dependent."""
+    index = {name: i for i, name in enumerate(names)}
+    seen: dict[tuple[object, ...], object] = {}
+    for row in rows:
+        key = tuple(row[index[col]] for col in sorted(fd.determinant))
+        dep = row[index[fd.dependent]]
+        if key in seen and seen[key] != dep:
+            return key
+        seen[key] = dep
+    return None
+
+
+def _assert_claims_hold(
+    claimed: FDSet, names: tuple[str, ...], rows: list[tuple[object, ...]], sql: str
+) -> None:
+    """Every claimed dependency judged against the materialized rows."""
+    for fd in claimed.fds:
+        assert {fd.dependent, *fd.determinant} <= set(names), (
+            f"claimed FD names a column the result lacks: {fd} vs {names} for sql={sql!r}"
+        )
+        witness = _fd_holds(fd, names, rows)
+        assert witness is None, (
+            f"claimed FD {sorted(fd.determinant)} -> {fd.dependent} violated at "
+            f"determinant value {witness} for sql={sql!r} rows={rows}"
+        )
+
+
+# --- projection, filter, and GROUP BY over one table -------------------------------
+
+_SRC = SourceRef(SourceKind.SOURCE, "source.test.raw.t")
 _COLS = ("g", "x", "y")
 
 
@@ -115,73 +192,22 @@ def _model_sql(s: Scenario) -> str:
     return sql
 
 
-def _claimed(s: Scenario) -> FDSet:
-    """The model's FD set, exactly as the relation property derives it."""
-    nodes = {
-        _SRC.unique_id: _source(_SRC.unique_id, name="t"),
-        _MODEL.unique_id: _node(_MODEL.unique_id, _model_sql(s), name="m"),
-    }
-    manifest = Manifest(schema_version="v12", adapter_type="duckdb", nodes=nodes)
-    value = FDSet.of(FD(frozenset({"g"}), "x")) if s.declared else FDSet(frozenset())
-    fact = Fact(scope=_SRC, value=value, provenance=Declared(DeclaredSource.USER_ASSERTED))
-    prop = functional_dependency_property(functional_dependency_grounding({_SRC: (fact,)}))
-    anns = propagate(build_relation_graph(manifest).graph, prop)
-    return anns[_MODEL].value
-
-
-def _materialize(
-    con: duckdb.DuckDBPyConnection, s: Scenario
-) -> tuple[tuple[str, ...], list[tuple[object, ...]]]:
-    try:
-        con.execute("CREATE OR REPLACE TABLE t (g INTEGER, x INTEGER, y INTEGER)")
-        if s.rows:
-            con.executemany("INSERT INTO t VALUES (?, ?, ?)", [list(r) for r in s.rows])
-        cursor = con.execute(_model_sql(s))
-        description = cursor.description
-        assert description is not None
-        names = tuple(str(d[0]).lower() for d in description)
-        return names, [tuple(r) for r in cursor.fetchall()]
-    finally:
-        con.execute("DROP TABLE IF EXISTS t")
-
-
-def _fd_holds(
-    fd: FD, names: tuple[str, ...], rows: list[tuple[object, ...]]
-) -> tuple[object, ...] | None:
-    """``None`` when the dependency holds; otherwise a witness determinant value
-    whose rows disagree on the dependent."""
-    index = {name: i for i, name in enumerate(names)}
-    seen: dict[tuple[object, ...], object] = {}
-    for row in rows:
-        key = tuple(row[index[col]] for col in sorted(fd.determinant))
-        dep = row[index[fd.dependent]]
-        if key in seen and seen[key] != dep:
-            return key
-        seen[key] = dep
-    return None
-
-
 @given(s=_scenario())
 @settings(max_examples=300, deadline=None, suppress_health_check=[HealthCheck.too_slow])
 def test_every_claimed_fd_holds_on_the_data(
     oracle_con: duckdb.DuckDBPyConnection, s: Scenario
 ) -> None:
-    claimed = _claimed(s)
+    fds = (FD(frozenset({"g"}), "x"),) if s.declared else ()
+    claimed = _claimed_fds(_model_sql(s), {_SRC: "t"}, {_SRC: (_declared_fact(_SRC, *fds),)})
     assert not claimed.is_bottom
     if s.group_cols:
         # Anti-vacuity: a GROUP BY always yields at least the group-key dependency,
         # so a walk that silently claims nothing cannot pass on silence alone.
         assert claimed.fds
-    names, rows = _materialize(oracle_con, s)
-    for fd in claimed.fds:
-        assert {fd.dependent, *fd.determinant} <= set(names), (
-            f"claimed FD names a column the result lacks: {fd} vs {names} for sql={_model_sql(s)!r}"
-        )
-        witness = _fd_holds(fd, names, rows)
-        assert witness is None, (
-            f"claimed FD {sorted(fd.determinant)} -> {fd.dependent} violated at "
-            f"determinant value {witness} for sql={_model_sql(s)!r} rows={rows}"
-        )
+    names, rows = _materialize(
+        oracle_con, _model_sql(s), {"t": ("g INTEGER, x INTEGER, y INTEGER", s.rows)}
+    )
+    _assert_claims_hold(claimed, names, rows, _model_sql(s))
 
 
 # --- dependency through a join (C4) ----------------------------------------------
@@ -196,7 +222,6 @@ def test_every_claimed_fd_holds_on_the_data(
 
 _PAY = SourceRef(SourceKind.SOURCE, "source.test.raw.pay")
 _DIM = SourceRef(SourceKind.SOURCE, "source.test.raw.dim")
-_JOIN_MODEL = SourceRef(SourceKind.MODEL, "model.test.j")
 _QCOLS: tuple[tuple[str, str], ...] = (("p", "k"), ("p", "a"), ("d", "k"), ("d", "g"), ("d", "v"))
 _JOIN_KINDS: Mapping[str, str] = {
     "inner": "JOIN dim d ON p.k = d.k",
@@ -250,66 +275,16 @@ def _join_sql(s: JoinScenario) -> str:
     return f"SELECT {cols} FROM pay p {_JOIN_KINDS[s.side]}"
 
 
-def _source_node(ref: SourceRef, name: str) -> Node:
-    return _source(ref.unique_id, name=name)
-
-
-def _join_claimed(s: JoinScenario) -> FDSet:
-    """The join model's FD set, exactly as the relation property derives it, with
-    ``k -> a`` declared on ``pay`` and ``g -> v`` on ``dim``."""
-    nodes = {
-        _PAY.unique_id: _source_node(_PAY, "pay"),
-        _DIM.unique_id: _source_node(_DIM, "dim"),
-        _JOIN_MODEL.unique_id: _node(_JOIN_MODEL.unique_id, _join_sql(s), name="j"),
-    }
-    manifest = Manifest(schema_version="v12", adapter_type="duckdb", nodes=nodes)
-    facts = {
-        _PAY: (
-            Fact(
-                scope=_PAY,
-                value=FDSet.of(FD(frozenset({"k"}), "a")),
-                provenance=Declared(DeclaredSource.USER_ASSERTED),
-            ),
-        ),
-        _DIM: (
-            Fact(
-                scope=_DIM,
-                value=FDSet.of(FD(frozenset({"g"}), "v")),
-                provenance=Declared(DeclaredSource.USER_ASSERTED),
-            ),
-        ),
-    }
-    prop = functional_dependency_property(functional_dependency_grounding(facts))
-    anns = propagate(build_relation_graph(manifest).graph, prop)
-    return anns[_JOIN_MODEL].value
-
-
-def _join_materialize(
-    con: duckdb.DuckDBPyConnection, s: JoinScenario
-) -> tuple[tuple[str, ...], list[tuple[object, ...]]]:
-    try:
-        con.execute("CREATE OR REPLACE TABLE pay (k INTEGER, a INTEGER)")
-        con.execute("CREATE OR REPLACE TABLE dim (k INTEGER, g INTEGER, v INTEGER)")
-        if s.rows_pay:
-            con.executemany("INSERT INTO pay VALUES (?, ?)", [list(r) for r in s.rows_pay])
-        if s.rows_dim:
-            con.executemany("INSERT INTO dim VALUES (?, ?, ?)", [list(r) for r in s.rows_dim])
-        cursor = con.execute(_join_sql(s))
-        description = cursor.description
-        assert description is not None
-        names = tuple(str(d[0]).lower() for d in description)
-        return names, [tuple(r) for r in cursor.fetchall()]
-    finally:
-        con.execute("DROP TABLE IF EXISTS pay")
-        con.execute("DROP TABLE IF EXISTS dim")
-
-
 @given(s=_join_scenario())
 @settings(max_examples=300, deadline=None, suppress_health_check=[HealthCheck.too_slow])
 def test_every_claimed_join_fd_holds_on_the_data(
     oracle_con: duckdb.DuckDBPyConnection, s: JoinScenario
 ) -> None:
-    claimed = _join_claimed(s)
+    facts = {
+        _PAY: (_declared_fact(_PAY, FD(frozenset({"k"}), "a")),),
+        _DIM: (_declared_fact(_DIM, FD(frozenset({"g"}), "v")),),
+    }
+    claimed = _claimed_fds(_join_sql(s), {_PAY: "pay", _DIM: "dim"}, facts)
     assert not claimed.is_bottom
     selected = dict(s.projection)
     declared = {"p": (("p", "k"), ("p", "a")), "d": (("d", "g"), ("d", "v"))}
@@ -325,119 +300,83 @@ def test_every_claimed_join_fd_holds_on_the_data(
             # The padded side's drop is the contract: NULL padding can break the
             # dependency, so the walk must stay silent about it.
             assert out_fd not in claimed.fds, f"padded-side FD claimed for sql={_join_sql(s)!r}"
-    names, rows = _join_materialize(oracle_con, s)
-    for fd in claimed.fds:
-        assert {fd.dependent, *fd.determinant} <= set(names), (
-            f"claimed FD names a column the result lacks: {fd} vs {names} for sql={_join_sql(s)!r}"
-        )
-        witness = _fd_holds(fd, names, rows)
-        assert witness is None, (
-            f"claimed FD {sorted(fd.determinant)} -> {fd.dependent} violated at "
-            f"determinant value {witness} for sql={_join_sql(s)!r} rows={rows}"
-        )
+    names, rows = _materialize(
+        oracle_con,
+        _join_sql(s),
+        {
+            "pay": ("k INTEGER, a INTEGER", s.rows_pay),
+            "dim": ("k INTEGER, g INTEGER, v INTEGER", s.rows_dim),
+        },
+    )
+    _assert_claims_hold(claimed, names, rows, _join_sql(s))
 
 
 # --- declared dependencies across a union ------------------------------------------
 #
-# Two base tables each honour ``g -> x`` in their own data, under their own mapping.
-# The walk may keep the dependency across a union only when every arm's pairs come
-# from one declared world; two worlds' mappings disagree, and the materialized union
-# is the judge. The anti-vacuity arm pins the flip side: when both arms are slices
-# of the one declared relation, projected identically, silence is a failure.
+# Two base tables each honour ``{g, h} -> x`` in their own data, under their own
+# mapping. The walk may keep the dependency across a union only when every arm's
+# pairs come from one declared world under one column binding. Each way the merge
+# can go wrong is in the generated space: two worlds' mappings disagree, arms
+# permuting the determinant columns run the axiom two different ways, and a BY
+# NAME merge lines the arms up by alias rather than position. The materialized
+# union judges all of it. The anti-vacuity arm pins the flip side: when both arms
+# are slices of the one declared relation, projected identically and merged
+# positionally, silence is a failure.
 
 _T1 = SourceRef(SourceKind.SOURCE, "source.test.raw.t1")
 _T2 = SourceRef(SourceKind.SOURCE, "source.test.raw.t2")
-_U_MODEL = SourceRef(SourceKind.MODEL, "model.test.u")
-_ARM_ORDERS: tuple[tuple[str, str], ...] = (("g", "x"), ("x", "g"))
+_GH_X = FD(frozenset({"g", "h"}), "x")
 
 
 @dataclass(frozen=True)
 class UnionScenario:
     same_world: bool  # arm two reads t1 (the declaring relation) rather than t2
-    declare_t2: bool  # t2 carries its own ``g -> x`` declaration
-    rows_t1: tuple[tuple[int, int], ...]  # (g, x), x a function of g
-    rows_t2: tuple[tuple[int, int], ...]  # (g, x), x a function of g, independent mapping
-    arm1_cols: tuple[str, str]  # projection order of the first arm
-    arm2_cols: tuple[str, str]  # projection order of the second arm (may swap)
-    arm2_names: tuple[str, str]  # the second arm's aliases (alignment is positional)
+    declare_t2: bool  # t2 carries its own ``{g, h} -> x`` declaration
+    rows_t1: tuple[tuple[int, int, int], ...]  # (g, h, x), x a function of (g, h)
+    rows_t2: tuple[tuple[int, int, int], ...]  # same shape, independent mapping
+    arm1_cols: tuple[str, ...]  # first arm's projection order over (g, h, x)
+    arm2_cols: tuple[str, ...]  # second arm's projection order (may permute)
+    arm2_names: tuple[str, ...]  # second arm's aliases (a positional merge ignores them)
     distinct: bool  # UNION rather than UNION ALL
+    by_name: bool  # merge BY NAME rather than positionally
 
 
 @st.composite
 def _union_scenario(draw: st.DrawFn) -> UnionScenario:
-    def rows(mapping: Mapping[int, int]) -> tuple[tuple[int, int], ...]:
-        out: list[tuple[int, int]] = []
+    def rows(mapping: Mapping[tuple[int, int], int]) -> tuple[tuple[int, int, int], ...]:
+        out: list[tuple[int, int, int]] = []
         for _ in range(draw(st.integers(min_value=0, max_value=6))):
-            g = draw(st.integers(min_value=0, max_value=2))
-            out.append((g, mapping[g]))
+            g = draw(st.integers(min_value=0, max_value=1))
+            h = draw(st.integers(min_value=0, max_value=1))
+            out.append((g, h, mapping[(g, h)]))
         return tuple(out)
 
-    map1 = {g: draw(st.integers(min_value=0, max_value=2)) for g in range(3)}
-    map2 = {g: draw(st.integers(min_value=0, max_value=2)) for g in range(3)}
+    def mapping() -> dict[tuple[int, int], int]:
+        return {(g, h): draw(st.integers(min_value=0, max_value=2)) for g in (0, 1) for h in (0, 1)}
+
+    map1, map2 = mapping(), mapping()
+    perm = st.permutations(("g", "h", "x"))
     return UnionScenario(
         same_world=draw(st.booleans()),
         declare_t2=draw(st.booleans()),
         rows_t1=rows(map1),
         rows_t2=rows(map2),
-        arm1_cols=draw(st.sampled_from(_ARM_ORDERS)),
-        arm2_cols=draw(st.sampled_from(_ARM_ORDERS)),
-        arm2_names=draw(st.sampled_from((("o0", "o1"), ("p0", "p1")))),
+        arm1_cols=tuple(draw(perm)),
+        arm2_cols=tuple(draw(perm)),
+        arm2_names=tuple(draw(st.one_of(perm, st.just(("p0", "p1", "p2"))))),
         distinct=draw(st.booleans()),
+        by_name=draw(st.booleans()),
     )
 
 
 def _union_sql(s: UnionScenario) -> str:
-    arm1 = f"SELECT {s.arm1_cols[0]} AS o0, {s.arm1_cols[1]} AS o1 FROM t1"
+    arm1 = ", ".join(f"{col} AS o{i}" for i, col in enumerate(s.arm1_cols))
+    arm2 = ", ".join(
+        f"{col} AS {name}" for col, name in zip(s.arm2_cols, s.arm2_names, strict=True)
+    )
     arm2_table = "t1" if s.same_world else "t2"
-    arm2 = (
-        f"SELECT {s.arm2_cols[0]} AS {s.arm2_names[0]}, "
-        f"{s.arm2_cols[1]} AS {s.arm2_names[1]} FROM {arm2_table}"
-    )
-    op = "UNION" if s.distinct else "UNION ALL"
-    return f"{arm1} {op} {arm2}"
-
-
-def _g_to_x_fact(scope: SourceRef) -> Fact[FDSet, SourceRef]:
-    return Fact(
-        scope=scope,
-        value=FDSet.of(FD(frozenset({"g"}), "x")),
-        provenance=Declared(DeclaredSource.USER_ASSERTED),
-    )
-
-
-def _union_claimed(s: UnionScenario) -> FDSet:
-    nodes = {
-        _T1.unique_id: _source(_T1.unique_id, name="t1"),
-        _T2.unique_id: _source(_T2.unique_id, name="t2"),
-        _U_MODEL.unique_id: _node(_U_MODEL.unique_id, _union_sql(s), name="u"),
-    }
-    manifest = Manifest(schema_version="v12", adapter_type="duckdb", nodes=nodes)
-    facts = {_T1: (_g_to_x_fact(_T1),)}
-    if s.declare_t2:
-        facts[_T2] = (_g_to_x_fact(_T2),)
-    prop = functional_dependency_property(functional_dependency_grounding(facts))
-    anns = propagate(build_relation_graph(manifest).graph, prop)
-    return anns[_U_MODEL].value
-
-
-def _union_materialize(
-    con: duckdb.DuckDBPyConnection, s: UnionScenario
-) -> tuple[tuple[str, ...], list[tuple[object, ...]]]:
-    try:
-        con.execute("CREATE OR REPLACE TABLE t1 (g INTEGER, x INTEGER)")
-        con.execute("CREATE OR REPLACE TABLE t2 (g INTEGER, x INTEGER)")
-        if s.rows_t1:
-            con.executemany("INSERT INTO t1 VALUES (?, ?)", [list(r) for r in s.rows_t1])
-        if s.rows_t2:
-            con.executemany("INSERT INTO t2 VALUES (?, ?)", [list(r) for r in s.rows_t2])
-        cursor = con.execute(_union_sql(s))
-        description = cursor.description
-        assert description is not None
-        names = tuple(str(d[0]).lower() for d in description)
-        return names, [tuple(r) for r in cursor.fetchall()]
-    finally:
-        con.execute("DROP TABLE IF EXISTS t1")
-        con.execute("DROP TABLE IF EXISTS t2")
+    op = ("UNION" if s.distinct else "UNION ALL") + (" BY NAME" if s.by_name else "")
+    return f"SELECT {arm1} FROM t1 {op} SELECT {arm2} FROM {arm2_table}"
 
 
 @given(s=_union_scenario())
@@ -445,22 +384,20 @@ def _union_materialize(
 def test_every_claimed_union_fd_holds_on_the_data(
     oracle_con: duckdb.DuckDBPyConnection, s: UnionScenario
 ) -> None:
-    claimed = _union_claimed(s)
+    facts = {_T1: (_declared_fact(_T1, _GH_X),)}
+    if s.declare_t2:
+        facts[_T2] = (_declared_fact(_T2, _GH_X),)
+    claimed = _claimed_fds(_union_sql(s), {_T1: "t1", _T2: "t2"}, facts)
     assert not claimed.is_bottom
-    if s.same_world and s.arm1_cols == s.arm2_cols:
+    if s.same_world and s.arm1_cols == s.arm2_cols and not s.by_name:
         # Anti-vacuity: both arms are the declared relation projected identically,
         # so the merge must keep the declared dependency (silence cannot pass).
         out = {col: f"o{i}" for i, col in enumerate(s.arm1_cols)}
-        assert determines(claimed, frozenset({out["g"]}), out["x"]), (
+        assert determines(claimed, frozenset({out["g"], out["h"]}), out["x"]), (
             f"same-world union dropped the declared FD for sql={_union_sql(s)!r}"
         )
-    names, rows = _union_materialize(oracle_con, s)
-    for fd in claimed.fds:
-        assert {fd.dependent, *fd.determinant} <= set(names), (
-            f"claimed FD names a column the result lacks: {fd} vs {names} for sql={_union_sql(s)!r}"
-        )
-        witness = _fd_holds(fd, names, rows)
-        assert witness is None, (
-            f"claimed FD {sorted(fd.determinant)} -> {fd.dependent} violated at "
-            f"determinant value {witness} for sql={_union_sql(s)!r} rows={rows}"
-        )
+    ddl = "g INTEGER, h INTEGER, x INTEGER"
+    names, rows = _materialize(
+        oracle_con, _union_sql(s), {"t1": (ddl, s.rows_t1), "t2": (ddl, s.rows_t2)}
+    )
+    _assert_claims_hold(claimed, names, rows, _union_sql(s))

--- a/tests/lineage/test_pbt_functional_dependency_soundness.py
+++ b/tests/lineage/test_pbt_functional_dependency_soundness.py
@@ -1,8 +1,9 @@
 """Empirical soundness PBT for the functional-dependency property: the data judges.
 
 The FD walk claims dependencies on a model's output from three sources: a declared
-dependency carried through the relational algebra, a constancy minted by an
-equality filter, and the group key determining every other output of a GROUP BY.
+dependency carried through the relational algebra (a union of arms drawn from the
+declaring relation included), a constancy minted by an equality filter, and the
+group key determining every other output of a GROUP BY.
 The soundness obligation is uniform: every claimed ``X -> y`` must hold on the
 materialized result, meaning no two result rows agree on ``X`` and differ on ``y``.
 
@@ -31,6 +32,7 @@ from dblect.lineage.graph import SourceKind, SourceRef
 from dblect.lineage.properties.functional_dependency import (
     FD,
     FDSet,
+    determines,
     functional_dependency_grounding,
     functional_dependency_property,
 )
@@ -332,4 +334,133 @@ def test_every_claimed_join_fd_holds_on_the_data(
         assert witness is None, (
             f"claimed FD {sorted(fd.determinant)} -> {fd.dependent} violated at "
             f"determinant value {witness} for sql={_join_sql(s)!r} rows={rows}"
+        )
+
+
+# --- declared dependencies across a union ------------------------------------------
+#
+# Two base tables each honour ``g -> x`` in their own data, under their own mapping.
+# The walk may keep the dependency across a union only when every arm's pairs come
+# from one declared world; two worlds' mappings disagree, and the materialized union
+# is the judge. The anti-vacuity arm pins the flip side: when both arms are slices
+# of the one declared relation, projected identically, silence is a failure.
+
+_T1 = SourceRef(SourceKind.SOURCE, "source.test.raw.t1")
+_T2 = SourceRef(SourceKind.SOURCE, "source.test.raw.t2")
+_U_MODEL = SourceRef(SourceKind.MODEL, "model.test.u")
+_ARM_ORDERS: tuple[tuple[str, str], ...] = (("g", "x"), ("x", "g"))
+
+
+@dataclass(frozen=True)
+class UnionScenario:
+    same_world: bool  # arm two reads t1 (the declaring relation) rather than t2
+    declare_t2: bool  # t2 carries its own ``g -> x`` declaration
+    rows_t1: tuple[tuple[int, int], ...]  # (g, x), x a function of g
+    rows_t2: tuple[tuple[int, int], ...]  # (g, x), x a function of g, independent mapping
+    arm1_cols: tuple[str, str]  # projection order of the first arm
+    arm2_cols: tuple[str, str]  # projection order of the second arm (may swap)
+    arm2_names: tuple[str, str]  # the second arm's aliases (alignment is positional)
+    distinct: bool  # UNION rather than UNION ALL
+
+
+@st.composite
+def _union_scenario(draw: st.DrawFn) -> UnionScenario:
+    def rows(mapping: Mapping[int, int]) -> tuple[tuple[int, int], ...]:
+        out: list[tuple[int, int]] = []
+        for _ in range(draw(st.integers(min_value=0, max_value=6))):
+            g = draw(st.integers(min_value=0, max_value=2))
+            out.append((g, mapping[g]))
+        return tuple(out)
+
+    map1 = {g: draw(st.integers(min_value=0, max_value=2)) for g in range(3)}
+    map2 = {g: draw(st.integers(min_value=0, max_value=2)) for g in range(3)}
+    return UnionScenario(
+        same_world=draw(st.booleans()),
+        declare_t2=draw(st.booleans()),
+        rows_t1=rows(map1),
+        rows_t2=rows(map2),
+        arm1_cols=draw(st.sampled_from(_ARM_ORDERS)),
+        arm2_cols=draw(st.sampled_from(_ARM_ORDERS)),
+        arm2_names=draw(st.sampled_from((("o0", "o1"), ("p0", "p1")))),
+        distinct=draw(st.booleans()),
+    )
+
+
+def _union_sql(s: UnionScenario) -> str:
+    arm1 = f"SELECT {s.arm1_cols[0]} AS o0, {s.arm1_cols[1]} AS o1 FROM t1"
+    arm2_table = "t1" if s.same_world else "t2"
+    arm2 = (
+        f"SELECT {s.arm2_cols[0]} AS {s.arm2_names[0]}, "
+        f"{s.arm2_cols[1]} AS {s.arm2_names[1]} FROM {arm2_table}"
+    )
+    op = "UNION" if s.distinct else "UNION ALL"
+    return f"{arm1} {op} {arm2}"
+
+
+def _g_to_x_fact(scope: SourceRef) -> Fact[FDSet, SourceRef]:
+    return Fact(
+        scope=scope,
+        value=FDSet.of(FD(frozenset({"g"}), "x")),
+        provenance=Declared(DeclaredSource.USER_ASSERTED),
+    )
+
+
+def _union_claimed(s: UnionScenario) -> FDSet:
+    nodes = {
+        _T1.unique_id: _source(_T1.unique_id, name="t1"),
+        _T2.unique_id: _source(_T2.unique_id, name="t2"),
+        _U_MODEL.unique_id: _node(_U_MODEL.unique_id, _union_sql(s), name="u"),
+    }
+    manifest = Manifest(schema_version="v12", adapter_type="duckdb", nodes=nodes)
+    facts = {_T1: (_g_to_x_fact(_T1),)}
+    if s.declare_t2:
+        facts[_T2] = (_g_to_x_fact(_T2),)
+    prop = functional_dependency_property(functional_dependency_grounding(facts))
+    anns = propagate(build_relation_graph(manifest).graph, prop)
+    return anns[_U_MODEL].value
+
+
+def _union_materialize(
+    con: duckdb.DuckDBPyConnection, s: UnionScenario
+) -> tuple[tuple[str, ...], list[tuple[object, ...]]]:
+    try:
+        con.execute("CREATE OR REPLACE TABLE t1 (g INTEGER, x INTEGER)")
+        con.execute("CREATE OR REPLACE TABLE t2 (g INTEGER, x INTEGER)")
+        if s.rows_t1:
+            con.executemany("INSERT INTO t1 VALUES (?, ?)", [list(r) for r in s.rows_t1])
+        if s.rows_t2:
+            con.executemany("INSERT INTO t2 VALUES (?, ?)", [list(r) for r in s.rows_t2])
+        cursor = con.execute(_union_sql(s))
+        description = cursor.description
+        assert description is not None
+        names = tuple(str(d[0]).lower() for d in description)
+        return names, [tuple(r) for r in cursor.fetchall()]
+    finally:
+        con.execute("DROP TABLE IF EXISTS t1")
+        con.execute("DROP TABLE IF EXISTS t2")
+
+
+@given(s=_union_scenario())
+@settings(max_examples=300, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+def test_every_claimed_union_fd_holds_on_the_data(
+    oracle_con: duckdb.DuckDBPyConnection, s: UnionScenario
+) -> None:
+    claimed = _union_claimed(s)
+    assert not claimed.is_bottom
+    if s.same_world and s.arm1_cols == s.arm2_cols:
+        # Anti-vacuity: both arms are the declared relation projected identically,
+        # so the merge must keep the declared dependency (silence cannot pass).
+        out = {col: f"o{i}" for i, col in enumerate(s.arm1_cols)}
+        assert determines(claimed, frozenset({out["g"]}), out["x"]), (
+            f"same-world union dropped the declared FD for sql={_union_sql(s)!r}"
+        )
+    names, rows = _union_materialize(oracle_con, s)
+    for fd in claimed.fds:
+        assert {fd.dependent, *fd.determinant} <= set(names), (
+            f"claimed FD names a column the result lacks: {fd} vs {names} for sql={_union_sql(s)!r}"
+        )
+        witness = _fd_holds(fd, names, rows)
+        assert witness is None, (
+            f"claimed FD {sorted(fd.determinant)} -> {fd.dependent} violated at "
+            f"determinant value {witness} for sql={_union_sql(s)!r} rows={rows}"
         )

--- a/uv.lock
+++ b/uv.lock
@@ -498,7 +498,7 @@ requires-dist = [
     { name = "duckdb", specifier = ">=1.0" },
     { name = "jinja2", specifier = ">=3.1" },
     { name = "pyyaml", specifier = ">=6.0" },
-    { name = "sqlglot", specifier = ">=25.0" },
+    { name = "sqlglot", specifier = ">=30.0" },
     { name = "typer", specifier = ">=0.12" },
 ]
 provides-extras = ["dbt-core"]


### PR DESCRIPTION
Replaces #234, which proposed `DEPENDENCY_NOT_ESTABLISHED`, the dependency twin of #230's grain check. That transfer turns out to be unsound: the case it fired on is a case the walk should be proving. What lands instead is a lineage change that makes the union merge agree with what a declaration means, and no emitter. This PR is standalone on `main`, not stacked on #230.

## What a declared dependency means

`a determines b` is an axiom about the world, asserting determinism of the entity: `order_id determines user_id` because one order cannot belong to two users. It is quantified over every pair of rows that describe the world, not over the rows of one relation. Users declare it precisely because SQL structure cannot derive it, and dblect consumes it on trust (to prove a `GROUP BY order_id` that selects `user_id` well typed, to fold join keys covered by a chain).

Along the way, `zip -> city` retires as the running example. It is false in the world (ZIP codes cross city lines), and its falseness is what made a union warning look plausible. `order_id -> user_id` is the honest canonical example.

## Why UNION treats derived and declared dependencies differently

A dependency is universally quantified over row pairs, and what a union adds is exactly the cross pairs, one row from each arm. Survival at the merge depends on whether the dependency's witness covers those cross pairs.

- **Derived dependencies are relation-local and genuinely die.** One arm has `WHERE currency = 'usd'` and carries the constant dependency `{} -> currency`; the other has `WHERE currency = 'eur'` and carries the same syntactic dependency. Both arms carry it and the union violates it. Key-derived and GROUP BY-derived dependencies fail the same way. The walk's drop for these stays.
- **Declared dependencies survive when the arms share the axiom.** When every arm's `(order_id, user_id)` pairs are the declared world's pairs, which is what it means for each arm's instance to trace to the same grounding declaration, every cross pair is covered too and the merge carries the dependency. The merged data can only violate it if the axiom is false in the data, a data-quality failure the declaration asserts away and one no SQL structure can create.

This is also why #230 stands while its dependency analogue does not transfer. Uniqueness is not a pair property over a world: a union of a relation with itself breaks uniqueness while no data is wrong anywhere, so "arms each unique on k, merge maybe not" is a real structural hazard. That same union breaks no dependency.

## The change

Each declared dependency now travels as a grounded instance, `DeclaredFD(origin, declared, fd)`: the relation it was declared about, the dependency in that relation's names, and the dependency under the current relation's output names, renamed as the walk climbs. `FDSet` carries these instances beside the plain set (every instance's current dependency is also in `fds`, enforced at construction, so consumers reading `fds` alone are unchanged). Grounding lifts instances from `Declared`-provenance facts only, decided explicitly across the closed provenance space: a native constraint holds by the warehouse's write path and a compile value is minted by the toolchain, so neither claims a world.

The union merge keeps exactly the instances every arm shares, whole, once arms are lined up by position under the first arm's names as SQL merges them. All three fields key the match: origin alone is not enough (one relation can declare `a -> b` and `c -> d`, and arms can rename both onto the same output columns), and the axiom alone is not either (an arm can cross the declared columns, running the instance the other way). Mixed provenance drops too: declared in one arm and derived in the other, or the same syntactic dependency grounded in two different declarations (two order systems whose id spaces may collide are exactly where the axiom's coverage ends). Instances ride the same renames and cuts as plain dependencies everywhere else (projections, WHERE, GROUP BY within the key, a join's kept sides), so the two can never drift.

This closes a real false negative: downstream of a union over `us_orders` and `ca_orders`, `GROUP BY order_id` selecting `user_id` was unprovable even though the axiom guarantees it.

## No emitter

`DEPENDENCY_NOT_ESTABLISHED` is dropped, not narrowed. Its central fire case, a union whose every arm carries the declared dependency, is the case this change proves quiet. Structural SQL can neither establish nor refute an axiom; the honest check for a declaration is a data test at the declaring model (no determinant value maps to two dependent values). That is a small separate feature if we want it, and #202's "FD violation" half should be re-scoped the same way.

## Tests

Written before the implementation, then verified to bite by breaking the code four ways and confirming a test fails for each: witnessing on some arm instead of every arm, matching instances without their current columns (the swapped-columns case fails), keeping derived dependencies across the merge (the two-worlds cases and the data-judge PBT fail), and lifting every provenance into instances (the native-constraint and compile-value cases fail).

- The merge rule is one decision, so its deterministic tests are one parametrized table, and the carry side is owned by the PBT: its anti-vacuity arm spans both operators, both arm orders, and differing arm aliases, and it reds on a dead merge rule. The table pins what the generator cannot reach: two structural carries (chain flattening, the dbt CTE-and-rename shell), a drop row per soundness edge (derived witness, two declared worlds, an unknown arm, two axioms of one world on the same columns, crossed columns, a star arm), one row per set operator, and a provenance row per kind. Carry machinery around the merge (renames, stars, GROUP BY cuts, cross-model flow) is pinned by the existing non-union tests, which instances now flow through, and by the construction invariant.
- Lattice laws over instance-carrying values, plus the construction invariant (an instance outside `fds` is rejected); mutating `join` to keep unshared instances fails the laws themselves, so no named test restates that rule.
- A data-as-judge PBT alongside the existing ones: two base tables with independently drawn `g -> x` mappings, arms drawn from one world or two, every claimed dependency checked against the materialized union, with an anti-vacuity arm (same world, same projection: the merge must keep the dependency, silence cannot pass).

## Not in this PR

- The aggregate coherence guard does not yet discharge through an intermediate model or a union, because the companion column's ref stays bound to its source relation; that is the cross-relation companion rebinding follow-up (#76), and the FD value it will read below unions is now correct.
- INTERSECT and EXCEPT could carry their covering arm (a subset cannot break a dependency); they stay silent, recorded in the walk as a possible refinement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAE4C5m7unT2uPjd1XthjN
