### PR TITLE
test(lineage): key-derivation oracle extensions and FD-closure xfail specs

### DIFF
--- a/tests/lineage/test_functional_dependency_propagation.py
+++ b/tests/lineage/test_functional_dependency_propagation.py
@@ -47,6 +47,7 @@ from dblect.lineage.properties.functional_dependency import (
     NO_FDS,
     DeclaredFD,
     FDSet,
+    determines,
     functional_dependency_grounding,
     functional_dependency_property,
 )
@@ -670,3 +671,49 @@ def test_set_operation_merges(facts: _FdFacts, sql: str, expected: FDSet) -> Non
 def test_only_a_declaration_grounds_an_instance(provenance: Provenance, expected: FDSet) -> None:
     fact = Fact(scope=_PAYMENTS, value=FDSet.of(_CC), provenance=provenance)
     assert functional_dependency_grounding({_PAYMENTS: (fact,)})(_PAYMENTS).value == expected
+
+
+# --- shapes the FD-closure key engine will newly derive (not yet from this walk) ----
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="keys from the FD closure: the walk does not track the self-join-to-group-max idiom",
+)
+def test_join_back_to_a_grouped_subquery_determines_line_number() -> None:
+    """``m.line_number`` is the per-order max, single-valued per ``order_id`` by
+    construction, and every surviving ``l`` row equals it, so ``order_id`` determines
+    ``line_number`` at the output. The walk does not follow the self-join-to-max idiom."""
+    out = _fds(
+        _declared(),
+        _source("source.shop.raw.lines"),
+        _node(
+            "model.shop.m",
+            "SELECT l.order_id, l.line_number, l.amount FROM lines l "
+            "JOIN (SELECT order_id, MAX(line_number) AS line_number "
+            "FROM lines GROUP BY 1) m "
+            "ON l.order_id = m.order_id AND l.line_number = m.line_number",
+        ),
+    )
+    assert determines(out["model.shop.m"], frozenset({"order_id"}), "line_number")
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="keys from the FD closure: the group-by rule does not yet reach through a join",
+)
+def test_group_by_over_a_join_determines_the_aggregate() -> None:
+    """The group key determines every other output regardless of whether the grouped
+    relation is a base table or a join; the walk's group-by rule does not yet reach
+    through a join in the FROM."""
+    out = _fds(
+        _declared(),
+        _source("source.shop.raw.orders"),
+        _source("source.shop.raw.lines"),
+        _node(
+            "model.shop.m",
+            "SELECT o.order_id, SUM(l.amount) AS total FROM orders o "
+            "JOIN lines l ON o.order_id = l.order_id GROUP BY o.order_id",
+        ),
+    )
+    assert determines(out["model.shop.m"], frozenset({"order_id"}), "total")

--- a/tests/lineage/test_pbt_uniqueness_soundness.py
+++ b/tests/lineage/test_pbt_uniqueness_soundness.py
@@ -39,7 +39,7 @@ later). Multi-model chains are the next extension.
 from __future__ import annotations
 
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 import duckdb
 from hypothesis import HealthCheck, given, settings
@@ -114,6 +114,22 @@ def _unique_test(source_name: str, *, column: str, where: str | None = None) -> 
     )
 
 
+def _unique_combination_test(source_name: str, *, columns: tuple[str, str]) -> Node:
+    target = f"source.test.raw.{source_name}"
+    suffix = "_".join(columns)
+    return _node(
+        f"test.test.{source_name}_{suffix}_unique_combo",
+        kind=ResourceType.OTHER,
+        name=f"{source_name}_{suffix}_unique_combo",
+        depends_on=frozenset({target}),
+        test_metadata=DbtTestMetadata(
+            name="dbt_utils.unique_combination_of_columns",
+            kwargs={"combination_of_columns": list(columns)},
+        ),
+        attached_node=target,
+    )
+
+
 def _model_node(sql: str, *, depends_on: frozenset[str]) -> Node:
     return _node(_MODEL_UID, sql, raw=sql, name="m", depends_on=depends_on)
 
@@ -126,6 +142,9 @@ class SourceSpec:
     name: str
     key_col: str  # declared unique, generated distinct + non-null
     plain_cols: tuple[str, ...]
+    # When set, the source declares unique_combination_of_columns(key_col, composite_with)
+    # instead of unique(key_col); rows are then distinct on that pair alone.
+    composite_with: str | None = None
 
     @property
     def columns(self) -> tuple[str, ...]:
@@ -134,12 +153,18 @@ class SourceSpec:
 
 @dataclass(frozen=True)
 class ModelSpec:
-    shape: str  # filter | inner_join | left_join | group_by | distinct | qualify | anti/semi shapes
+    shape: str  # filter | inner_join | left_join | group_by | distinct | qualify
+    # | anti/semi shapes | join_grouped
     select_cols: tuple[str, ...]
     left_join_col: str | None = None
     right_join_col: str | None = None
+    # An inner join may project the joined-in side's own join column, aliased under
+    # the probe's usual output name, instead of the probe's column: the shape where
+    # the current walk loses the key.
+    project_other_side: bool = False
     filter_col: str | None = None
     filter_threshold: int | None = None
+    filter_op: str = ">="
     group_cols: tuple[str, ...] | None = None
     group_spelling: GroupSpelling | None = None
     partition_cols: tuple[str, ...] | None = None
@@ -156,25 +181,57 @@ _S0 = SourceSpec(name="s0", key_col="k0", plain_cols=("a0", "b0"))
 _S1 = SourceSpec(name="s1", key_col="k1", plain_cols=("a1", "b1"))
 _KEY_DOMAIN = 64
 _PLAIN_DOMAIN = 4
+_COMPOSITE_DOMAIN = 4  # small enough that each column repeats while the pair stays unique
 
 
 @st.composite
 def _rows(draw: st.DrawFn, source: SourceSpec) -> tuple[tuple[int, ...], ...]:
-    """Rows for a source: the key column is distinct non-null (so ``unique`` is a true
-    key), every other column a small-domain int (to force join matches and duplicates)."""
+    """Rows for a source. With no composite key, the key column is distinct non-null
+    (so ``unique`` is a true key), every other column a small-domain int (to force
+    join matches and duplicates). With a composite key, the (key_col, composite_with)
+    pair is distinct as a tuple while each of the two columns is free to repeat alone,
+    so ``unique_combination_of_columns`` is a true key but neither column is by itself."""
     n = draw(st.integers(min_value=0, max_value=8))
-    keys = draw(
+    if source.composite_with is None:
+        keys = draw(
+            st.lists(
+                st.integers(min_value=0, max_value=_KEY_DOMAIN - 1),
+                min_size=n,
+                max_size=n,
+                unique=True,
+            )
+        )
+        rows: list[tuple[int, ...]] = []
+        for key in keys:
+            plain = tuple(
+                draw(st.integers(min_value=0, max_value=_PLAIN_DOMAIN - 1))
+                for _ in source.plain_cols
+            )
+            rows.append((key, *plain))
+        return tuple(rows)
+
+    extra_index = source.plain_cols.index(source.composite_with)
+    pairs = draw(
         st.lists(
-            st.integers(min_value=0, max_value=_KEY_DOMAIN - 1), min_size=n, max_size=n, unique=True
+            st.tuples(
+                st.integers(min_value=0, max_value=_COMPOSITE_DOMAIN - 1),
+                st.integers(min_value=0, max_value=_COMPOSITE_DOMAIN - 1),
+            ),
+            min_size=n,
+            max_size=n,
+            unique=True,
         )
     )
-    rows: list[tuple[int, ...]] = []
-    for key in keys:
+    composite_rows: list[tuple[int, ...]] = []
+    for key, extra in pairs:
         plain = tuple(
-            draw(st.integers(min_value=0, max_value=_PLAIN_DOMAIN - 1)) for _ in source.plain_cols
+            extra
+            if i == extra_index
+            else draw(st.integers(min_value=0, max_value=_PLAIN_DOMAIN - 1))
+            for i in range(len(source.plain_cols))
         )
-        rows.append((key, *plain))
-    return tuple(rows)
+        composite_rows.append((key, *plain))
+    return tuple(composite_rows)
 
 
 def _column_subset(draw: st.DrawFn) -> tuple[str, ...]:
@@ -198,6 +255,7 @@ def _scenario(draw: st.DrawFn) -> Scenario:
                 "anti_join",
                 "semi_join",
                 "left_is_null",
+                "join_grouped",
             )
         )
     )
@@ -206,7 +264,23 @@ def _scenario(draw: st.DrawFn) -> Scenario:
     is_join = shape in ("inner_join", "left_join")
     sources = (_S0, _S1) if is_join or shape in anti_shapes else (_S0,)
 
-    if shape in anti_shapes:
+    # s0 always participates, so it carries the choice of a composite declared key
+    # (unique_combination_of_columns over k0 and a second column) instead of a plain
+    # unique(k0); the pair is distinct while either column alone is free to repeat.
+    if draw(st.booleans()):
+        second = draw(st.sampled_from(_S0.plain_cols))
+        sources = tuple(
+            replace(src, composite_with=second) if src.name == _S0.name else src for src in sources
+        )
+
+    if shape == "join_grouped":
+        # A self-join back to s0 grouped by one column with MAX() of another; the
+        # walk derives no coarse key here, so the oracle must still see none promoted.
+        gcol, other = draw(
+            st.lists(st.sampled_from(_S0.columns), min_size=2, max_size=2, unique=True)
+        )
+        model = ModelSpec(shape=shape, select_cols=_S0.columns, group_cols=(gcol, other))
+    elif shape in anti_shapes:
         # An anti/semi filter preserves s0's declared key {k0}; the oracle proves it over rows.
         model = ModelSpec(
             shape=shape,
@@ -223,11 +297,15 @@ def _scenario(draw: st.DrawFn) -> Scenario:
         )
         model = ModelSpec(shape=shape, select_cols=_S0.columns, partition_cols=part)
     elif is_join:
+        # An inner join may project s1's own join column, aliased as ``k0``, instead of
+        # s0's: the ON equates them, so the oracle must still see no unsound key.
+        project_other_side = shape == "inner_join" and draw(st.booleans())
         model = ModelSpec(
             shape=shape,
             select_cols=("k0", "a1"),
-            left_join_col=draw(st.sampled_from(_S0.columns)),
+            left_join_col="k0" if project_other_side else draw(st.sampled_from(_S0.columns)),
             right_join_col=draw(st.sampled_from(_S1.columns)),
+            project_other_side=project_other_side,
         )
     elif shape == "filter":
         model = ModelSpec(
@@ -235,6 +313,7 @@ def _scenario(draw: st.DrawFn) -> Scenario:
             select_cols=("k0", "a0"),
             filter_col=draw(st.sampled_from(_S0.columns)),
             filter_threshold=draw(st.integers(min_value=0, max_value=_PLAIN_DOMAIN)),
+            filter_op=draw(st.sampled_from((">=", "="))),
         )
     elif shape == "group_by":
         spelling = draw(st.sampled_from(tuple(GroupSpelling)))
@@ -267,9 +346,19 @@ def _scenario(draw: st.DrawFn) -> Scenario:
 def _scenario_sql(m: ModelSpec) -> str:
     if m.shape in ("inner_join", "left_join"):
         join = "INNER JOIN" if m.shape == "inner_join" else "LEFT JOIN"
+        first = f"s1.{m.right_join_col} AS k0" if m.project_other_side else "s0.k0 AS k0"
         return (
-            f"SELECT s0.k0 AS k0, s1.a1 AS a1 "
+            f"SELECT {first}, s1.a1 AS a1 "
             f"FROM s0 {join} s1 ON s0.{m.left_join_col} = s1.{m.right_join_col}"
+        )
+    if m.shape == "join_grouped":
+        assert m.group_cols is not None
+        gcol, other = m.group_cols
+        cols = ", ".join(f"l.{c} AS {c}" for c in m.select_cols)
+        return (
+            f"SELECT {cols} FROM s0 l JOIN "
+            f"(SELECT {gcol}, MAX({other}) AS {other} FROM s0 GROUP BY {gcol}) m "
+            f"ON l.{gcol} = m.{gcol} AND l.{other} = m.{other}"
         )
     if m.shape in ("anti_join", "semi_join", "left_is_null"):
         base = "SELECT s0.k0 AS k0, s0.a0 AS a0 FROM s0"
@@ -281,7 +370,7 @@ def _scenario_sql(m: ModelSpec) -> str:
         # left_is_null: the IS NULL sits on s1's join-key column, the recognised anti-join idiom.
         return f"{base} LEFT JOIN s1 {on} WHERE s1.{m.right_join_col} IS NULL"
     if m.shape == "filter":
-        return f"SELECT k0, a0 FROM s0 WHERE {m.filter_col} >= {m.filter_threshold}"
+        return f"SELECT k0, a0 FROM s0 WHERE {m.filter_col} {m.filter_op} {m.filter_threshold}"
     if m.shape == "qualify":
         assert m.partition_cols is not None
         cols = ", ".join(m.select_cols)
@@ -311,7 +400,12 @@ def _scenario_manifest(s: Scenario) -> Manifest:
     nodes: list[Node] = []
     for src in s.sources:
         nodes.append(_source_node(src.name))
-        nodes.append(_unique_test(src.name, column=src.key_col))
+        if src.composite_with is not None:
+            nodes.append(
+                _unique_combination_test(src.name, columns=(src.key_col, src.composite_with))
+            )
+        else:
+            nodes.append(_unique_test(src.name, column=src.key_col))
     nodes.append(
         _model_node(
             _scenario_sql(s.model),

--- a/tests/lineage/test_uniqueness_propagation.py
+++ b/tests/lineage/test_uniqueness_propagation.py
@@ -50,6 +50,19 @@ def _unique(uid: str, *, column: str, target: str) -> Node:
     )
 
 
+def _unique_combination(uid: str, *, columns: tuple[str, ...], target: str) -> Node:
+    return _node(
+        uid,
+        kind=ResourceType.OTHER,
+        depends_on=frozenset({target}),
+        test_metadata=DbtTestMetadata(
+            name="dbt_utils.unique_combination_of_columns",
+            kwargs={"combination_of_columns": list(columns)},
+        ),
+        attached_node=target,
+    )
+
+
 def _key(*cols: str) -> Key:
     return frozenset(cols)
 
@@ -447,3 +460,81 @@ def test_declared_model_key_unions_with_sql_derived_key() -> None:
     assert keys["model.shop.d"] == CandidateKeySet.of(
         _key("customer_id"), _key("customer_id", "region")
     )
+
+
+# --- shapes the FD-closure key engine will newly derive (not yet from this walk) ----
+#
+# `lines` is keyed on the composite pair (order_id, line_number), never on order_id
+# alone: a fact table where an order spans many lines. Each shape below has a real key
+# that a walk over the FD closure can justify but this structural walk cannot yet see.
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="keys from the FD closure: the walk cannot tie a projected column to "
+    "another relation's key through an ON equality",
+)
+def test_fan_out_join_derives_the_pair_key_through_the_other_alias() -> None:
+    """The ON equates ``o.order_id`` with ``l.order_id``, and the output projects
+    ``o.order_id`` rather than ``l.order_id``, so this walk cannot tie the projected
+    column to ``lines``' declared pair key even though the values agree row for row."""
+    orders = _source("source.shop.raw.orders")
+    lines = _source("source.shop.raw.lines")
+    keys = _keys(
+        orders,
+        lines,
+        _unique("test.shop.o", column="order_id", target=orders.unique_id),
+        _unique_combination(
+            "test.shop.l", columns=("order_id", "line_number"), target=lines.unique_id
+        ),
+        _node(
+            "model.shop.m",
+            "SELECT o.order_id, l.line_number FROM orders o "
+            "JOIN lines l ON o.order_id = l.order_id",
+        ),
+    )
+    assert keys["model.shop.m"] == CandidateKeySet.of(_key("order_id", "line_number"))
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="keys from the FD closure: the walk does not track the self-join-to-group-max idiom",
+)
+def test_join_back_to_a_grouped_subquery_derives_the_group_key() -> None:
+    """Self-joining to the per-order max line number keeps one row per order, so
+    ``order_id`` alone is a key, not just the declared pair: the walk would need
+    ``order_id -> line_number`` at the output to shrink the pair key to it."""
+    lines = _source("source.shop.raw.lines")
+    keys = _keys(
+        lines,
+        _unique_combination(
+            "test.shop.l", columns=("order_id", "line_number"), target=lines.unique_id
+        ),
+        _node(
+            "model.shop.m",
+            "SELECT l.order_id, l.line_number, l.amount FROM lines l "
+            "JOIN (SELECT order_id, MAX(line_number) AS line_number "
+            "FROM lines GROUP BY 1) m "
+            "ON l.order_id = m.order_id AND l.line_number = m.line_number",
+        ),
+    )
+    assert keys["model.shop.m"] == CandidateKeySet.of(_key("order_id"))
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="keys from the FD closure: the walk does not collapse a composite key "
+    "when a filter pins one of its columns constant",
+)
+def test_constant_filter_collapses_the_pair_key_to_the_remaining_column() -> None:
+    """Pinning ``line_number`` constant makes the declared pair key redundant in its
+    second column, so ``order_id`` alone is a key of the filtered output."""
+    lines = _source("source.shop.raw.lines")
+    keys = _keys(
+        lines,
+        _unique_combination(
+            "test.shop.l", columns=("order_id", "line_number"), target=lines.unique_id
+        ),
+        _node("model.shop.m", "SELECT order_id, line_number FROM lines WHERE line_number = 1"),
+    )
+    assert keys["model.shop.m"] == CandidateKeySet.of(_key("order_id"))

--- a/tests/lineage/test_uniqueness_propagation.py
+++ b/tests/lineage/test_uniqueness_propagation.py
@@ -493,7 +493,7 @@ def test_fan_out_join_derives_the_pair_key_through_the_other_alias() -> None:
             "JOIN lines l ON o.order_id = l.order_id",
         ),
     )
-    assert keys["model.shop.m"] == CandidateKeySet.of(_key("order_id", "line_number"))
+    assert _key("order_id", "line_number") in keys["model.shop.m"].keys
 
 
 @pytest.mark.xfail(
@@ -518,7 +518,7 @@ def test_join_back_to_a_grouped_subquery_derives_the_group_key() -> None:
             "ON l.order_id = m.order_id AND l.line_number = m.line_number",
         ),
     )
-    assert keys["model.shop.m"] == CandidateKeySet.of(_key("order_id"))
+    assert _key("order_id") in keys["model.shop.m"].keys
 
 
 @pytest.mark.xfail(
@@ -537,4 +537,4 @@ def test_constant_filter_collapses_the_pair_key_to_the_remaining_column() -> Non
         ),
         _node("model.shop.m", "SELECT order_id, line_number FROM lines WHERE line_number = 1"),
     )
-    assert keys["model.shop.m"] == CandidateKeySet.of(_key("order_id"))
+    assert _key("order_id") in keys["model.shop.m"].keys


### PR DESCRIPTION
## What

Tests only, no source changes. Prepares for replacing the hand-written key walk
(`_RelationWalk` in `uniqueness.py`) and FD walk (`_FdWalk` in
`functional_dependency.py`) with one engine that derives keys from the
functional-dependency closure.

Part A extends the uniqueness soundness PBT's `_scenario` grammar with four
shapes from issue #64: a composite source key
(`unique_combination_of_columns`), an inner join projecting the other side's
join column, a self-join back to a grouped derived table, and a constant
equality filter. All four pass on `main` as it stands; the oracle only checks
that whatever key gets promoted is genuinely unique over the materialized rows.

Part B adds five `xfail(strict=True)` example tests, three in
`test_uniqueness_propagation.py` and two in
`test_functional_dependency_propagation.py`, pinning shapes where the current
structural walk misses a key or dependency that the FD closure can justify:
projecting a joined relation's key through an equality, deriving a key from a
self-join-to-group-max idiom, collapsing a composite key when a filter pins
one column constant, and a GROUP BY over a join. Each will flip green once the
new engine lands.

## Why

Before the engine exists, we want (a) the data oracle to already cover the
query shapes it will newly handle, so unsoundness surfaces against real rows
from day one, and (b) tests pinning the current gaps so the engine's
completeness gain is visible and checked.

## Test-bite evidence

- Part A: ran the extended `_scenario` PBT (300 examples, 4 different seeds)
  and it passes on `main` unchanged, confirming every new shape is sound
  today. Spot-checked with direct probes that the new shapes produce
  non-vacuous promoted keys (not just always-empty), and confirmed
  `_assert_keys_sound` rejects an injected bogus key for the new
  `join_grouped` shape.
- Part B: ran all five new tests without the `xfail` marker first. Each failed
  on `main` for the stated reason (a missing or coarser key/FD, no crash):
  - fan-out join: promoted `frozenset()` instead of `{order_id, line_number}`
  - join back to grouped subquery (uniqueness): promoted the coarse pair key
    instead of `{order_id}`
  - constant filter: same coarse-pair-not-collapsed failure
  - join back to grouped subquery (FD): empty `FDSet` instead of
    `order_id -> line_number`
  - GROUP BY over a join: empty `FDSet` instead of `order_id -> total`

## Gate

`ruff check`, `ruff format --check`, `pyright`, and `pytest -q` all green:
1604 passed, 5 xfailed.

## Left out

Nothing dropped from scope. One thing worth flagging: the composite-key draw
in Part A applies only to `s0` (the source every shape shares), not `s1`,
since that alone reaches every new shape and keeps the grammar's field count
minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GHc6Tr7N4pffySTGeJZnEw